### PR TITLE
FIX #20 - Empty password string causes error while deploying

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ options:
     description: Port used by MySQL
   admin-password:
     type: string
-    default: ''
+    default: 'Password'
     descriptions: Password used by root user to setup cluster
 #  preferred-storage-engine:
 #    default: InnoDB


### PR DESCRIPTION
See #20 
