### PR TITLE
Add mysqlsh wrapper

### DIFF
--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -27,7 +27,8 @@ class MySQL:
     def mysqlsh_bin(self) -> str:
         """Determine binary path for MySQL Shell.
 
-        :returns: Path to binary mysqlsh
+        Returns:
+            Path to binary mysqlsh
         """
         # Allow for various versions of the mysql-shell snap
         # When we get the alias use /snap/bin/mysqlsh
@@ -42,7 +43,8 @@ class MySQL:
     def mysqlsh_common_dir(self) -> str:
         """Determine snap common dir for mysqlsh.
 
-        :returns: Path to common dir
+        Returns:
+            Path to common dir
         """
         return "/root/snap/mysql-shell/common"
 
@@ -69,11 +71,13 @@ class MySQL:
     def run_mysqlsh_script(self, script: str) -> AnyStr:
         """Execute a MySQL shell script.
 
-        :param script: Mysqlsh script
-        :raises subprocess.CalledProcessError: Raises CalledProcessError if the
-                                               script gets a non-zero return
-                                               code.
-        :returns: subprocess output
+        Raises CalledProcessError if the script gets a non-zero return code.
+
+        Args:
+            script: Mysqlsh script string
+
+        Returns:
+            Byte string subprocess output
         """
         if not os.path.exists(self.mysqlsh_common_dir):
             # Pre-execute mysqlsh to create self.mysqlsh_common_dir

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -40,7 +40,7 @@ class MySQL:
 
     @property
     def mysqlsh_common_dir(self):
-        """Determine snap common dir for mysqlsh
+        """Determine snap common dir for mysqlsh.
 
         :returns: Path to common dir
         :rtype: str
@@ -68,7 +68,7 @@ class MySQL:
         pass
 
     def run_mysqlsh_script(self, script, mode="python"):
-        """Execute a MySQL shell script
+        """Execute a MySQL shell script.
 
         :param script: Mysqlsh script
         :type script: str
@@ -87,7 +87,6 @@ class MySQL:
             # ambiguous error message. This will only ever execute once.
             cmd = [self.mysqlsh_bin, "--help"]
             subprocess.check_call(cmd, stderr=subprocess.PIPE)
-
 
         # Use the self.mysqlsh_common_dir dir for the confined
         # mysql-shell snap.

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -8,6 +8,7 @@ import logging
 import os
 import subprocess
 import tempfile
+from typing import AnyStr
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +24,10 @@ class MySQL:
         pass
 
     @property
-    def mysqlsh_bin(self):
+    def mysqlsh_bin(self) -> str:
         """Determine binary path for MySQL Shell.
 
         :returns: Path to binary mysqlsh
-        :rtype: str
         """
         # Allow for various versions of the mysql-shell snap
         # When we get the alias use /snap/bin/mysqlsh
@@ -39,11 +39,10 @@ class MySQL:
         return "/snap/bin/mysql-shell"
 
     @property
-    def mysqlsh_common_dir(self):
+    def mysqlsh_common_dir(self) -> str:
         """Determine snap common dir for mysqlsh.
 
         :returns: Path to common dir
-        :rtype: str
         """
         return "/root/snap/mysql-shell/common"
 
@@ -67,19 +66,14 @@ class MySQL:
         """Add an instance to the InnoDB cluster."""
         pass
 
-    def run_mysqlsh_script(self, script, mode="python"):
+    def run_mysqlsh_script(self, script: str) -> AnyStr:
         """Execute a MySQL shell script.
 
         :param script: Mysqlsh script
-        :type script: str
-        :param mode: Script type (python, or sql)
-        :type mode: str
-        :side effect: Calls subprocess.check_output
         :raises subprocess.CalledProcessError: Raises CalledProcessError if the
                                                script gets a non-zero return
                                                code.
         :returns: subprocess output
-        :rtype: UTF-8 byte string
         """
         if not os.path.exists(self.mysqlsh_common_dir):
             # Pre-execute mysqlsh to create self.mysqlsh_common_dir
@@ -90,13 +84,11 @@ class MySQL:
 
         # Use the self.mysqlsh_common_dir dir for the confined
         # mysql-shell snap.
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", dir=self.mysqlsh_common_dir
-        ) as _file:
+        with tempfile.NamedTemporaryFile(mode="w", dir=self.mysqlsh_common_dir) as _file:
             _file.write(script)
             _file.flush()
 
             # Specify python as this is not the default in the deb version
             # of the mysql-shell snap
-            cmd = [self.mysqlsh_bin, "--no-wizard", f"--{mode}", "-f", _file.name]
+            cmd = [self.mysqlsh_bin, "--no-wizard", "--python", "-f", _file.name]
             return subprocess.check_output(cmd, stderr=subprocess.PIPE)


### PR DESCRIPTION
# Issue
Necessity to have common function to wrap mysqlsh calls

# Solution
Inherited working code from reactive machine charm (openstack team).

# Context
MySQL setup/configuration calls are execute using mysql-shell cli.
There's still no tests, since we need it to work at the same time on different parts of the code.

# Release Notes
* Imported code from [openstack machine charm](https://github.com/openstack/charm-mysql-innodb-cluster/blob/d8d1dc0527046cc3dd41f4394575f14e9675f230/src/lib/charm/openstack/mysql_innodb_cluster.py#L1672)
* refactor to add type hints
* refactor to current standard docstrings
