### PR TITLE
Dpe 144 user creation methods

### DIFF
--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -76,9 +76,9 @@ class MySQL:
         revokes certain privileges from the 'root' user.
         """
         _script = (
-            f'shell.connect("orchestrator:{self.root_password}@localhost")',
-            f"dba.session.run_sql(\"CREATE USER '{self.cluster_admin_user}'@'localhost' IDENTIFIED BY '{self.cluster_admin_password}' ;\")",
-            f"dba.session.run_sql(\"GRANT ALL ON *.* TO '{self.cluster_admin_user}'@'localhost' WITH GRANT OPTION ;\")",
+            f'shell.connect("root:{self.root_password}@localhost")',
+            f"dba.session.run_sql(\"CREATE USER '{self.cluster_admin_user}'@'%' IDENTIFIED BY '{self.cluster_admin_password}' ;\")",
+            f"dba.session.run_sql(\"GRANT ALL ON *.* TO '{self.cluster_admin_user}'@'%' WITH GRANT OPTION ;\")",
             'dba.session.run_sql("REVOKE SYSTEM_USER ON *.* FROM root ;")',
         )
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import ops.testing
+
+# Since ops>=1.4 this enables better connection tracking.
+# See: More at https://juju.is/docs/sdk/testing#heading--simulate-can-connect
+ops.testing.SIMULATE_CAN_CONNECT = True

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -8,37 +8,58 @@ from unittest.mock import patch
 from mysqlsh_helpers import MySQL, MySQLCreateUserError
 
 
-class TestMySQLHelpers(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    # def test_mysqlsh_bin(self):
-
-    @patch("mysqlsh_helpers.MySQL.run_mysqlsh_script")
-    def test_configure_mysql_users(self, _run_mysqlsh_script):
+class TestMySQL(unittest.TestCase):
+    @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
+    def test_configure_mysql_users(self, _run_mysqlcli_script):
         """Test failed to configuring the MySQL users."""
-        _run_mysqlsh_script.return_value = b""
-        _expected_script = "\n".join(
+        _run_mysqlcli_script.return_value = b""
+        _expected_script = " ".join(
             (
-                'shell.connect("root:test@localhost")',
-                "dba.session.run_sql(\"CREATE USER 'test'@'%' IDENTIFIED BY 'test' ;\")",
-                "dba.session.run_sql(\"GRANT ALL ON *.* TO 'test'@'%' WITH GRANT OPTION ;\")",
-                'dba.session.run_sql("REVOKE SYSTEM_USER ON *.* FROM root ;")',
+                "SET @@SESSION.SQL_LOG_BIN=0;",
+                "CREATE USER 'cadmin'@'10.1.1.1' IDENTIFIED BY 'test';",
+                "GRANT ALL ON *.* TO 'cadmin'@'10.1.1.1' WITH GRANT OPTION;",
+                "CREATE USER 'root'@'%' IDENTIFIED BY 'test';",
+                "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
+                "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
+                "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'test';",
+                "REVOKE SYSTEM_USER ON *.* FROM root@'%';",
+                "REVOKE SYSTEM_USER ON *.* FROM root@localhost;",
+                "FLUSH PRIVILEGES;",
             )
         )
 
-        _m = MySQL("test", "test", "test")
+        _m = MySQL("test", "cadmin", "test", "10.1.1.1")
 
         self.assertEqual(_m.configure_mysql_users(), "")
-        _run_mysqlsh_script.assert_called_once_with(_expected_script)
+        _run_mysqlcli_script.assert_called_once_with(_expected_script)
 
-    @patch("mysqlsh_helpers.MySQL.run_mysqlsh_script")
-    def test_configure_mysql_users_fail(self, _run_mysqlsh_script):
+    @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
+    def test_configure_mysql_users_fail(self, _run_mysqlcli_script):
         """Test failed to configuring the MySQL users."""
-        _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(
+        _run_mysqlcli_script.side_effect = subprocess.CalledProcessError(
             cmd="mysqlsh", returncode=127
         )
 
-        _m = MySQL("test", "test", "test")
+        _m = MySQL("test", "test", "test", "10.1.1.1")
         with self.assertRaises(MySQLCreateUserError):
             _m.configure_mysql_users()
+
+    @patch("os.path.exists")
+    def test_mysqlsh_bin(self, _exists):
+        """Test the mysqlsh_bin property."""
+        _exists.return_value = True
+        _m = MySQL("test", "test", "test", "10.0.1.1")
+
+        self.assertEqual(_m.mysqlsh_bin, "/usr/bin/mysqlsh")
+
+        _exists.return_value = False
+        self.assertEqual(_m.mysqlsh_bin, "/snap/bin/mysql-shell")
+
+    @patch("os.path.exists")
+    def test_mysqlsh_common_dir(self, _exists):
+        """Test the mysqlsh_common_dir property."""
+        _exists.return_value = True
+        _m = MySQL("test", "test", "test", "11.1.1.1")
+        self.assertEqual(_m.mysqlsh_common_dir, "/root/snap/mysql-shell/common")
+        _exists.return_value = False
+        self.assertEqual(_m.mysqlsh_common_dir, "/tmp")

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -1,0 +1,44 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from mysqlsh_helpers import MySQL, MySQLCreateUserError
+
+
+class TestMySQLHelpers(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    # def test_mysqlsh_bin(self):
+
+    @patch("mysqlsh_helpers.MySQL.run_mysqlsh_script")
+    def test_configure_mysql_users(self, _run_mysqlsh_script):
+        """Test failed to configuring the MySQL users."""
+        _run_mysqlsh_script.return_value = b""
+        _expected_script = "\n".join(
+            (
+                'shell.connect("root:test@localhost")',
+                "dba.session.run_sql(\"CREATE USER 'test'@'%' IDENTIFIED BY 'test' ;\")",
+                "dba.session.run_sql(\"GRANT ALL ON *.* TO 'test'@'%' WITH GRANT OPTION ;\")",
+                'dba.session.run_sql("REVOKE SYSTEM_USER ON *.* FROM root ;")',
+            )
+        )
+
+        _m = MySQL("test", "test", "test")
+
+        self.assertEqual(_m.configure_mysql_users(), "")
+        _run_mysqlsh_script.assert_called_once_with(_expected_script)
+
+    @patch("mysqlsh_helpers.MySQL.run_mysqlsh_script")
+    def test_configure_mysql_users_fail(self, _run_mysqlsh_script):
+        """Test failed to configuring the MySQL users."""
+        _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(
+            cmd="mysqlsh", returncode=127
+        )
+
+        _m = MySQL("test", "test", "test")
+        with self.assertRaises(MySQLCreateUserError):
+            _m.configure_mysql_users()


### PR DESCRIPTION
# Issue

Jira link is (DPE-144](https://warthogs.atlassian.net/browse/DPE-144).

For mysql, we need to create a "clusteradmin" user with full privileges but that can be run only from the instance, playing the role of the "operator".


# Solution
<!-- A summary of the solution addressing the above issue -->


# Context

For mysql, we need to create a `clusteradmin` user with full privileges but that can be run only from the instance, playing the role of the "operator".
We also need to create the general `root` user for external access (i.e. mysql-router, other apps). This user must not have the privilege to allow it change other users passwords, hence protecting access lost for the cluster.
Additionally, we must set password for all of these users.



# Testing
<!-- What steps need to be taken to test this PR? -->


# Release Notes
<!-- A digestable summary of the change in this PR -->
