### PR TITLE
Refactor MySQL users creations + implement cluster creation and addition of instances to cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,5 +36,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          lxd-channel: 4.24/stable # patch until https://bugs.launchpad.net/juju/+bug/1968849 is resolved
       - name: Run integration tests
         run: tox -e integration

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,13 +61,13 @@ class MySQLOperatorCharm(CharmBase):
             # TODO: replace stubbed arguments once mechanisms to generate them exist
             # Mechanisms = generating user/pass and storing+retrieving them from peer databag.
             self._mysql_helpers = MySQL(
-                "clusteradminpassword",
-                "clusteradmin",
-                "test_cluster",
                 "127.0.0.1",
+                "test_cluster",
                 "password",
-                "serverconfigpassword",
                 "serverconfig",
+                "serverconfigpassword",
+                "clusteradmin",
+                "clusteradminpassword",
             )
 
         return self._mysql_helpers

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,9 +21,6 @@ class MySQLOperatorCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        # Please do not reference this variable directly. Instead use _get_mysql_helpers().
-        self._mysql_helpers = None
-
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.start, self._on_start)
 
@@ -54,23 +51,19 @@ class MySQLOperatorCharm(CharmBase):
     #  Helpers
     # =======================
 
-    @property
-    def _mysql(self):
+    def _get_mysql_helpers(self):
         """Returns an instance of the MySQL object from mysqlsh_helpers."""
-        if not self._mysql_helpers:
-            # TODO: replace stubbed arguments once mechanisms to generate them exist
-            # Mechanisms = generating user/pass and storing+retrieving them from peer databag.
-            self._mysql_helpers = MySQL(
-                "127.0.0.1",
-                "test_cluster",
-                "password",
-                "serverconfig",
-                "serverconfigpassword",
-                "clusteradmin",
-                "clusteradminpassword",
-            )
-
-        return self._mysql_helpers
+        # TODO: replace stubbed arguments once mechanisms to generate them exist
+        # Mechanisms = generating user/pass and storing+retrieving them from peer databag.
+        return MySQL(
+            "127.0.0.1",
+            "test_cluster",
+            "password",
+            "serverconfig",
+            "serverconfigpassword",
+            "clusteradmin",
+            "clusteradminpassword",
+        )
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,8 +32,8 @@ class MySQLOperatorCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        # initialized in _on_install()
-        self.mysql_helpers = None
+        # Please do not reference this variable directly. Instead use _get_mysql_helpers().
+        self._mysql_helpers = None
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.start, self._on_start)
@@ -83,17 +83,8 @@ class MySQLOperatorCharm(CharmBase):
 
         # Update the mysql configuration - from templates/mysqld.cnf
         try:
-            # TODO: replace stubbed arguments once mechanisms to generate them exist
-            self.mysql_helpers = MySQL(
-                "clusteradminpassword",
-                "clusteradmin",
-                "test_cluster",
-                "127.0.0.1",
-                "password",
-                "serverconfigpassword",
-                "serverconfig",
-            )
-            self.mysql_helpers.update_mysql_configuration()
+            mysql_helpers = self._get_mysql_helpers()
+            mysql_helpers.update_mysql_configuration()
         except (MySQLInitializationError, MySQLUpdateConfigurationError):
             self.unit.status = BlockedStatus("Failed to update the mysql configuration")
             return
@@ -106,6 +97,27 @@ class MySQLOperatorCharm(CharmBase):
     def _on_start(self, _) -> None:
         """Ensure that required software is running."""
         pass
+
+    # =======================
+    #  Helpers
+    # =======================
+
+    def _get_mysql_helpers(self):
+        """Returns an instance of the MySQL object from mysqlsh_helpers."""
+        if not self._mysql_helpers:
+            # TODO: replace stubbed arguments once mechanisms to generate them exist
+            # Mechanisms = generating user/pass and storing+retrieving them from peer databag.
+            self._mysql_helpers = MySQL(
+                "clusteradminpassword",
+                "clusteradmin",
+                "test_cluster",
+                "127.0.0.1",
+                "password",
+                "serverconfigpassword",
+                "serverconfig",
+            )
+
+        return self._mysql_helpers
 
 
 if __name__ == "__main__":

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -7,19 +7,24 @@
 import json
 import logging
 import os
+import pathlib
 import shutil
 import subprocess
 import tempfile
 
+from charms.operator_libs_linux.v0 import apt
+from charms.operator_libs_linux.v1 import snap
 from tenacity import retry, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
 
 
-class MySQLInitializationError(Exception):
-    """Exception raised when initializing MySQL helper class."""
-
-    pass
+# TODO: determine if version locking is needed for both mysql-shell and mysql-server
+MYSQL_SHELL_SNAP_NAME = "mysql-shell"
+MYSQL_APT_PACKAGE_NAME = "mysql-server-8.0"
+MYSQL_SHELL_COMMON_DIRECTORY = "/root/snap/mysql-shell/common"
+MYSQLD_SOCK_FILE = "/var/run/mysqld/mysqld.sock"
+MYSQLD_CONFIG_DIRECTORY = "/etc/mysql/mysql.conf.d"
 
 
 class MySQLConfigureMySQLUsersError(Exception):
@@ -40,14 +45,14 @@ class MySQLCreateClusterError(Exception):
     pass
 
 
-class MySQLUpdateConfigurationError(Exception):
-    """Exception raised when there is an issue updating the MySQL configuration."""
+class MySQLAddInstanceToClusterError(Exception):
+    """Exception raised when there is an issue add an instance to the MySQL InnoDB cluster."""
 
     pass
 
 
-class MySQLAddInstanceToClusterError(Exception):
-    """Exception raised when there is an issue add an instance to the MySQL InnoDB cluster."""
+class MySQLServiceNotRunningError(Exception):
+    """Exception raised when the MySQL service is not running."""
 
     pass
 
@@ -71,8 +76,6 @@ class MySQL:
     ):
         """Initialize the MySQL class.
 
-        Raises MySQLInitializationError if the was an error initializing the helper class.
-
         Args:
             cluster_admin_password: password for the cluster admin user
             cluster_admin_user: user name for the cluster admin user
@@ -90,16 +93,8 @@ class MySQL:
         self.server_config_password = server_config_password
         self.server_config_user = server_config_user
 
-        try:
-            self._ensure_mysqlsh_common_dir()
-        except subprocess.CalledProcessError as e:
-            logger.exception(
-                f"Failed to ensure mysqlsh common dir for: {self.instance_address}", exc_info=e
-            )
-            raise MySQLInitializationError(e.stderr)
-
-    @property
-    def _mysqlsh_bin(self) -> str:
+    @staticmethod
+    def _get_mysqlsh_bin() -> str:
         """Determine binary path for MySQL Shell.
 
         Returns:
@@ -116,30 +111,56 @@ class MySQL:
         # Default to the full path version
         return "/snap/bin/mysql-shell"
 
-    @property
-    def _mysqlsh_common_dir(self) -> str:
-        """Determine snap common dir for mysqlsh.
+    @staticmethod
+    def install_and_configure_mysql_dependencies() -> None:
+        """Install and configure MySQL dependencies.
 
-        Raises MySQLUpdateConfigurationError if there was an issue configuring the mysql service.
-
-        Returns:
-            Path to common dir
+        Raises
+            subprocess.CalledProcessError: if issue updating apt or creating mysqlsh common dir
+            apt.PackageNotFoundError, apt.PackageError: if issue install mysql server
+            snap.SnapNotFOundError, snap.SnapError: if issue installing mysql shell snap
         """
-        return "/root/snap/mysql-shell/common"
-
-    def update_mysql_configuration(self):
-        """Add a configuration file for mysqld and restart the mysql service."""
         try:
-            # target file starts with 'z-' so it has priority over the default config file
-            shutil.copyfile("templates/mysqld.cnf", "/etc/mysql/mysql.conf.d/z-custom-mysqld.cnf")
-
-            restart_mysql_command = ["systemctl", "restart", "mysql"]
-            subprocess.check_output(restart_mysql_command, stderr=subprocess.PIPE)
-        except Exception as e:
-            logger.exception(
-                f"Failed to update mysql config for: {self.instance_address}", exc_info=e
+            # create the mysqld config directory if it does not exist
+            logger.debug("Copying custom mysqld config")
+            pathlib.Path(MYSQLD_CONFIG_DIRECTORY).mkdir(mode=0o755, parents=True, exist_ok=True)
+            # target file has prefix 'z-' to ensure priority over the default mysqld config file
+            shutil.copyfile(
+                "templates/mysqld.cnf", f"{MYSQLD_CONFIG_DIRECTORY}/z-custom-mysqld.cnf"
             )
-            raise MySQLUpdateConfigurationError(e.stderr)
+
+            # install mysql server
+            logger.debug("Updating apt")
+            apt.update()
+            logger.debug("Installing mysql server")
+            apt.add_package(MYSQL_APT_PACKAGE_NAME)
+
+            # install mysql shell if not already installed
+            logger.debug("Retrieving snap cache")
+            cache = snap.SnapCache()
+            mysql_shell = cache[MYSQL_SHELL_SNAP_NAME]
+
+            if not mysql_shell.present:
+                logger.debug("Installing mysql shell snap")
+                mysql_shell.ensure(snap.SnapState.Latest, channel="stable")
+
+            # ensure creation of mysql shell common directory by running 'mysqlsh --help'
+            if not os.path.exists(MYSQL_SHELL_COMMON_DIRECTORY):
+                logger.debug("Creating mysql shell common directory")
+                mysqlsh_help_command = [MySQL._get_mysqlsh_bin(), "--help"]
+                subprocess.check_call(mysqlsh_help_command, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            logger.exception("Failed to execute subprocess command", exc_info=e)
+            raise
+        except (apt.PackageNotFoundError, apt.PackageError) as e:
+            logger.exception("Failed to install apt packages", exc_info=e)
+            raise
+        except (snap.SnapNotFoundError, snap.SnapError) as e:
+            logger.exception("Failed to install snaps", exc_info=e)
+            raise
+        except Exception as e:
+            logger.exception("Encountered an unexpected exception", exc_info=e)
+            raise
 
     def configure_mysql_users(self):
         """Configure the MySQL users for the instance.
@@ -164,25 +185,38 @@ class MySQL:
             "CONNECTION_ADMIN",
         )
 
-        commands = (
+        # commands  to create 'root'@'%' user
+        create_root_user_commands = (
             "SET @@SESSION.SQL_LOG_BIN=0;",
             f"CREATE USER 'root'@'%' IDENTIFIED BY '{self.root_password}';",
             "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
+        )
+
+        # commands to be run from mysql client with root user and password set above
+        configure_users_commands = (
+            "SET @@SESSION.SQL_LOG_BIN=0;",
             f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}';",
             f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION;",
             "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
-            f"ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '{self.root_password}';",
+            f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}';",
             f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@'%';",
             f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@localhost;",
             "FLUSH PRIVILEGES;",
         )
 
         try:
-            logger.debug("Configuring MySQL users=")
-            self._run_mysqlcli_script(" ".join(commands))
+            logger.debug("Configuring MySQL users")
+            self._run_mysqlcli_script(" ".join(create_root_user_commands))
+            # run configure users commands with newly created root user
+            self._run_mysqlcli_script(
+                " ".join(configure_users_commands), password=self.root_password
+            )
         except subprocess.CalledProcessError as e:
-            logger.exception(f"Failed to configure users for: {self.instance_address}", exc_info=e)
-            raise MySQLConfigureMySQLUsersError(e.stdout)
+            logger.exception(
+                f"Failed to configure users for: {self.instance_address} with error {e.stderr}",
+                exc_info=e,
+            )
+            raise MySQLConfigureMySQLUsersError(e.stderr)
 
     def configure_instance(self) -> None:
         """Configure the instance to be used in an InnoDB cluster.
@@ -206,8 +240,11 @@ class MySQL:
 
             logger.debug("Waiting until MySQL is restarted")
             self._wait_until_mysql_connection()
-        except subprocess.CalledProcessError as e:
-            logger.exception(f"Failed to configure instance: {self.instance_address}", exc_info=e)
+        except (subprocess.CalledProcessError, MySQLServiceNotRunningError) as e:
+            logger.exception(
+                f"Failed to configure instance: {self.instance_address} with error {e.stderr}",
+                exc_info=e,
+            )
             raise MySQLConfigureInstanceError(e.stderr)
 
     def create_cluster(self) -> None:
@@ -225,7 +262,8 @@ class MySQL:
             self._run_mysqlsh_script("\n".join(commands))
         except subprocess.CalledProcessError as e:
             logger.exception(
-                f"Failed to create cluster on instance: {self.instance_address}", exc_info=e
+                f"Failed to create cluster on instance: {self.instance_address} with error {e.stderr}",
+                exc_info=e,
             )
             raise MySQLCreateClusterError(e.stderr)
 
@@ -254,7 +292,7 @@ class MySQL:
             self._run_mysqlsh_script("\n".join(commands))
         except subprocess.CalledProcessError as e:
             logger.exception(
-                f"Failed to add instance {instance_address} to cluster {self.cluster_name}",
+                f"Failed to add instance {instance_address} to cluster {self.cluster_name} with error {e.stderr}",
                 exc_info=e,
             )
             raise MySQLAddInstanceToClusterError(e.stderr)
@@ -265,22 +303,8 @@ class MySQL:
 
         Retry every 5 seconds for 30 seconds if there is an issue obtaining a connection.
         """
-        commands = (
-            f"my_shell = shell.connect('root:{self.root_password}@{self.instance_address}')",
-        )
-
-        self._run_mysqlsh_script("\n".join(commands))
-
-    def _ensure_mysqlsh_common_dir(self) -> None:
-        """Ensure that the mysql-shell common directory exists.
-
-        Creates the directory by running 'mysqlsh --help' if it doesn't exist.
-        """
-        if not os.path.exists(self._mysqlsh_common_dir):
-            # Execute mysqlsh to create self.mysqlsh_common_dir
-            # This will only ever execute once
-            cmd = [self._mysqlsh_bin, "--help"]
-            subprocess.check_call(cmd, stderr=subprocess.PIPE)
+        if not os.path.exists(MYSQLD_SOCK_FILE):
+            raise MySQLServiceNotRunningError()
 
     def _run_mysqlsh_script(self, script: str) -> None:
         """Execute a MySQL shell script.
@@ -293,19 +317,17 @@ class MySQL:
         Returns:
             Byte string subprocess output
         """
-        self._ensure_mysqlsh_common_dir()
-
-        # Use the self.mysqlsh_common_dir dir for the confined mysql-shell snap.
-        with tempfile.NamedTemporaryFile(mode="w", dir=self._mysqlsh_common_dir) as _file:
+        # Use the self.mysqlsh_common_dir for the confined mysql-shell snap.
+        with tempfile.NamedTemporaryFile(mode="w", dir=MYSQL_SHELL_COMMON_DIRECTORY) as _file:
             _file.write(script)
             _file.flush()
 
             # Specify python as this is not the default in the deb version
             # of the mysql-shell snap
-            cmd = [self._mysqlsh_bin, "--no-wizard", "--python", "-f", _file.name]
-            subprocess.check_output(cmd, stderr=subprocess.PIPE)
+            command = [MySQL._get_mysqlsh_bin(), "--no-wizard", "--python", "-f", _file.name]
+            subprocess.check_output(command, stderr=subprocess.PIPE)
 
-    def _run_mysqlcli_script(self, script: str) -> None:
+    def _run_mysqlcli_script(self, script: str, password=None) -> None:
         """Execute a MySQL CLI script.
 
         Execute SQL script as instance root user.
@@ -317,7 +339,7 @@ class MySQL:
         Returns:
             Byte string subprocess output
         """
-        cmd = [
+        command = [
             "mysql",
             "-u",
             "root",
@@ -327,4 +349,7 @@ class MySQL:
             script,
         ]
 
-        subprocess.check_output(cmd, stderr=subprocess.PIPE)
+        if password:
+            command.append(f"--password={password}")
+
+        subprocess.check_output(command, stderr=subprocess.PIPE)

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -4,6 +4,7 @@
 
 """Helper class to manage the MySQL InnoDB cluster lifecycle with MySQL Shell."""
 
+import json
 import logging
 import os
 import subprocess
@@ -14,14 +15,20 @@ from tenacity import retry, stop_after_delay, wait_fixed
 logger = logging.getLogger(__name__)
 
 
-class MySQLInstanceConfigureError(Exception):
+class MySQLConfigureMySQLUsersError(Exception):
+    """Exception raised when creating a user fails."""
+
+    pass
+
+
+class MySQLConfigureInstanceError(Exception):
     """Exception raised when there is an issue configuring a MySQL instance."""
 
     pass
 
 
-class MySQLConfigureMySQLUsersError(Exception):
-    """Exception raised when creating a user fails."""
+class MySQLCreateClusterError(Exception):
+    """Exception raised when there is an issue creating an InnoDB cluster."""
 
     pass
 
@@ -35,26 +42,37 @@ class MySQL:
 
     def __init__(
         self,
-        root_password: str,
-        cluster_admin_user: str,
         cluster_admin_password: str,
+        cluster_admin_user: str,
+        cluster_name: str,
         instance_address: str,
+        root_password: str,
+        server_config_password: str,
+        server_config_user: str,
     ):
         """Initialize the MySQL class.
 
         Args:
-            root_password: password for the 'root' user
-            cluster_admin_user: user name for the cluster admin user
             cluster_admin_password: password for the cluster admin user
+            cluster_admin_user: user name for the cluster admin user
+            cluster_name: cluster name
             instance_address: address of the targeted instance
+            root_password: password for the 'root' user
+            server_config_password: password for the server config user
+            server_config_user: user name for the server config user
         """
-        self.root_password = root_password
-        self.cluster_admin_user = cluster_admin_user
         self.cluster_admin_password = cluster_admin_password
+        self.cluster_admin_user = cluster_admin_user
+        self.cluster_name = cluster_name
         self.instance_address = instance_address
+        self.root_password = root_password
+        self.server_config_password = server_config_password
+        self.server_config_user = server_config_user
+
+        self._ensure_mysqlsh_common_dir()
 
     @property
-    def mysqlsh_bin(self) -> str:
+    def _mysqlsh_bin(self) -> str:
         """Determine binary path for MySQL Shell.
 
         Returns:
@@ -62,57 +80,64 @@ class MySQL:
         """
         # Allow for various versions of the mysql-shell snap
         # When we get the alias use /snap/bin/mysqlsh
-        _paths = ("/usr/bin/mysqlsh", "/snap/bin/mysqlsh", "/snap/bin/mysql-shell.mysqlsh")
+        paths = ("/usr/bin/mysqlsh", "/snap/bin/mysqlsh", "/snap/bin/mysql-shell.mysqlsh")
 
-        for path in _paths:
+        for path in paths:
             if os.path.exists(path):
                 return path
+
         # Default to the full path version
         return "/snap/bin/mysql-shell"
 
     @property
-    def mysqlsh_common_dir(self) -> str:
+    def _mysqlsh_common_dir(self) -> str:
         """Determine snap common dir for mysqlsh.
 
         Returns:
             Path to common dir
         """
-        if os.path.exists("/root/snap/mysql-shell/common"):
-            return "/root/snap/mysql-shell/common"
-        return "/tmp"
+        return "/root/snap/mysql-shell/common"
 
     def configure_mysql_users(self):
         """Configure the MySQL users for the instance.
 
-        Creates base `root@%` and `clusteradmin@instance_address` user with the
+        Creates base `root@%` and `<server_config>@%` users with the
         appropriate privileges, and reconfigure `root@localhost` user password.
+
         Raises MySQLConfigureMySQLUsersError if the user creation fails.
         """
-        _script = (
+        privileges_to_revoke = ("SYSTEM_USER", "SYSTEM_VARIABLES_ADMIN", "SUPER")
+
+        commands = (
             "SET @@SESSION.SQL_LOG_BIN=0;",
-            f"CREATE USER '{self.cluster_admin_user}'@'{self.instance_address}' IDENTIFIED BY '{self.cluster_admin_password}';",
-            f"GRANT ALL ON *.* TO '{self.cluster_admin_user}'@'{self.instance_address}' WITH GRANT OPTION;",
             f"CREATE USER 'root'@'%' IDENTIFIED BY '{self.root_password}';",
             "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
+            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}';",
+            f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION;",
             "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
             f"ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '{self.root_password}';",
-            "REVOKE SYSTEM_USER ON *.* FROM root@'%';",
-            "REVOKE SYSTEM_USER ON *.* FROM root@localhost;",
+            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@'%';",
+            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@localhost;",
             "FLUSH PRIVILEGES;",
         )
 
         try:
-            self._run_mysqlcli_script(" ".join(_script))
+            logger.debug("Configuring MySQL users=")
+            self._run_mysqlcli_script(" ".join(commands))
         except subprocess.CalledProcessError as e:
             logger.exception(f"Failed to configure users for: {self.instance_address}", exc_info=e)
             raise MySQLConfigureMySQLUsersError(e.stdout)
 
     def configure_instance(self) -> None:
         """Configure the instance to be used in an InnoDB cluster."""
+        options = {
+            "clusterAdmin": self.cluster_admin_user,
+            "clusterAdminPassword": self.cluster_admin_password,
+            "restart": "true",
+        }
+
         commands = (
-            f"dba.configure_instance('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            f"my_shell = shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            'my_shell.run_sql("RESTART;");',
+            f"dba.configure_instance('{self.server_config_user}:{self.server_config_password}@{self.instance_address}', {json.dumps(options)})",
         )
 
         try:
@@ -123,14 +148,27 @@ class MySQL:
             self._wait_until_mysql_connection()
         except subprocess.CalledProcessError as e:
             logger.exception(f"Failed to configure instance: {self.instance_address}", exc_info=e)
-            raise MySQLInstanceConfigureError(e.stderr)
+            raise MySQLConfigureInstanceError(e.stderr)
 
     def create_cluster(self) -> None:
         """Create an InnoDB cluster with Group Replication enabled."""
-        pass
+        commands = (
+            f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
+            f"dba.create_cluster('{self.cluster_name}')",
+        )
+
+        try:
+            logger.debug("Creating a MySQL InnoDB cluster")
+            self._run_mysqlsh_script("\n".join(commands))
+        except subprocess.CalledProcessError as e:
+            logger.exception(
+                f"Failed to create cluster on instance: {self.instance_address}", exc_info=e
+            )
+            raise MySQLCreateClusterError(e.stderr)
 
     def add_instance_to_cluster(self) -> None:
         """Add an instance to the InnoDB cluster."""
+        # TODO: implement logic to add the instance to a cluster
         pass
 
     @retry(reraise=True, stop=stop_after_delay(30), wait=wait_fixed(5))
@@ -140,10 +178,21 @@ class MySQL:
         Retry every 5 seconds for 30 seconds if there is an issue obtaining a connection.
         """
         commands = (
-            f"my_shell = shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"my_shell = shell.connect('root:{self.root_password}@{self.instance_address}')",
         )
 
         self._run_mysqlsh_script("\n".join(commands))
+
+    def _ensure_mysqlsh_common_dir(self) -> None:
+        """Ensure that the mysql-shell common directory exists.
+
+        Creates the directory by running 'mysqlsh --help' if it doesn't exist.
+        """
+        if not os.path.exists(self._mysqlsh_common_dir):
+            # Execute mysqlsh to create self.mysqlsh_common_dir
+            # This will only ever execute once
+            cmd = [self._mysqlsh_bin, "--help"]
+            subprocess.check_call(cmd, stderr=subprocess.PIPE)
 
     def _run_mysqlsh_script(self, script: str) -> None:
         """Execute a MySQL shell script.
@@ -156,22 +205,16 @@ class MySQL:
         Returns:
             Byte string subprocess output
         """
-        if not os.path.exists(self.mysqlsh_common_dir):
-            # Pre-execute mysqlsh to create self.mysqlsh_common_dir
-            # If we don't do this the real execution will fail with an
-            # ambiguous error message. This will only ever execute once.
-            cmd = [self.mysqlsh_bin, "--help"]
-            subprocess.check_call(cmd, stderr=subprocess.PIPE)
+        self._ensure_mysqlsh_common_dir()
 
-        # Use the self.mysqlsh_common_dir dir for the confined
-        # mysql-shell snap.
-        with tempfile.NamedTemporaryFile(mode="w", dir=self.mysqlsh_common_dir) as _file:
+        # Use the self.mysqlsh_common_dir dir for the confined mysql-shell snap.
+        with tempfile.NamedTemporaryFile(mode="w", dir=self._mysqlsh_common_dir) as _file:
             _file.write(script)
             _file.flush()
 
             # Specify python as this is not the default in the deb version
             # of the mysql-shell snap
-            cmd = [self.mysqlsh_bin, "--no-wizard", "--python", "-f", _file.name]
+            cmd = [self._mysqlsh_bin, "--no-wizard", "--python", "-f", _file.name]
             subprocess.check_output(cmd, stderr=subprocess.PIPE)
 
     def _run_mysqlcli_script(self, script: str) -> None:
@@ -195,4 +238,5 @@ class MySQL:
             "-e",
             script,
         ]
+
         subprocess.check_output(cmd, stderr=subprocess.PIPE)

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -187,14 +187,12 @@ class MySQL:
 
         # commands  to create 'root'@'%' user
         create_root_user_commands = (
-            "SET @@SESSION.SQL_LOG_BIN=0;",
             f"CREATE USER 'root'@'%' IDENTIFIED BY '{self.root_password}';",
             "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
         )
 
         # commands to be run from mysql client with root user and password set above
         configure_users_commands = (
-            "SET @@SESSION.SQL_LOG_BIN=0;",
             f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}';",
             f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION;",
             "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -66,32 +66,32 @@ class MySQL:
 
     def __init__(
         self,
-        cluster_admin_password: str,
-        cluster_admin_user: str,
-        cluster_name: str,
         instance_address: str,
+        cluster_name: str,
         root_password: str,
-        server_config_password: str,
         server_config_user: str,
+        server_config_password: str,
+        cluster_admin_user: str,
+        cluster_admin_password: str,
     ):
         """Initialize the MySQL class.
 
         Args:
-            cluster_admin_password: password for the cluster admin user
-            cluster_admin_user: user name for the cluster admin user
-            cluster_name: cluster name
             instance_address: address of the targeted instance
+            cluster_name: cluster name
             root_password: password for the 'root' user
-            server_config_password: password for the server config user
             server_config_user: user name for the server config user
+            server_config_password: password for the server config user
+            cluster_admin_user: user name for the cluster admin user
+            cluster_admin_password: password for the cluster admin user
         """
-        self.cluster_admin_password = cluster_admin_password
-        self.cluster_admin_user = cluster_admin_user
-        self.cluster_name = cluster_name
         self.instance_address = instance_address
+        self.cluster_name = cluster_name
         self.root_password = root_password
-        self.server_config_password = server_config_password
         self.server_config_user = server_config_user
+        self.server_config_password = server_config_password
+        self.cluster_admin_user = cluster_admin_user
+        self.cluster_admin_password = cluster_admin_password
 
     @staticmethod
     def _get_mysqlsh_bin() -> str:

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -278,7 +278,6 @@ class MySQL:
         """
         options = {
             "password": self.cluster_admin_password,
-            "recoveryMethod": "auto",
         }
 
         connect_commands = (

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -94,7 +94,7 @@ class MySQL:
         self.cluster_admin_password = cluster_admin_password
 
     @staticmethod
-    def _get_mysqlsh_bin() -> str:
+    def get_mysqlsh_bin() -> str:
         """Determine binary path for MySQL Shell.
 
         Returns:
@@ -147,7 +147,7 @@ class MySQL:
             # ensure creation of mysql shell common directory by running 'mysqlsh --help'
             if not os.path.exists(MYSQL_SHELL_COMMON_DIRECTORY):
                 logger.debug("Creating mysql shell common directory")
-                mysqlsh_help_command = [MySQL._get_mysqlsh_bin(), "--help"]
+                mysqlsh_help_command = [MySQL.get_mysqlsh_bin(), "--help"]
                 subprocess.check_call(mysqlsh_help_command, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError as e:
             logger.exception("Failed to execute subprocess command", exc_info=e)
@@ -324,7 +324,7 @@ class MySQL:
 
             # Specify python as this is not the default in the deb version
             # of the mysql-shell snap
-            command = [MySQL._get_mysqlsh_bin(), "--no-wizard", "--python", "-f", _file.name]
+            command = [MySQL.get_mysqlsh_bin(), "--no-wizard", "--python", "-f", _file.name]
             subprocess.check_output(command, stderr=subprocess.PIPE)
 
     def _run_mysqlcli_script(self, script: str, password=None) -> None:

--- a/templates/mysqld.cnf
+++ b/templates/mysqld.cnf
@@ -1,3 +1,3 @@
 [mysqld]
-bind-address		= 0.0.0.0
-mysqlx-bind-address = 0.0.0.0
+bind-address            = 0.0.0.0
+mysqlx-bind-address     = 0.0.0.0

--- a/templates/mysqld.cnf
+++ b/templates/mysqld.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+bind-address		= 0.0.0.0
+mysqlx-bind-address = 0.0.0.0

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,17 +1,13 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import subprocess
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from charms.operator_libs_linux.v0 import apt
-from charms.operator_libs_linux.v1 import snap
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 from charm import MySQLOperatorCharm
-from mysqlsh_helpers import MySQLInitializationError, MySQLUpdateConfigurationError
 
 
 class TestCharm(unittest.TestCase):
@@ -21,161 +17,16 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
         self.charm = self.harness.charm
 
-    @patch("charms.operator_libs_linux.v0.apt.update")
-    @patch("charms.operator_libs_linux.v0.apt.add_package")
-    @patch("charms.operator_libs_linux.v1.snap.SnapCache")
-    @patch("mysqlsh_helpers.MySQL._ensure_mysqlsh_common_dir")
-    @patch("mysqlsh_helpers.MySQL.update_mysql_configuration")
-    def test_on_install(
-        self,
-        _update_mysql_configuration,
-        _ensure_mysqlsh_common_dir,
-        _snap_cache,
-        _apt_add_package,
-        _apt_update,
-    ):
-        """Test the successful installation of packages."""
-        mock_cache = MagicMock()
-        _snap_cache.return_value = mock_cache
-
-        mock_mysql_shell = MagicMock()
-        mock_cache.__getitem__.return_value = mock_mysql_shell
-
-        mock_mysql_shell.present = False
-
-        mock_ensure = MagicMock()
-        mock_mysql_shell.ensure = mock_ensure
-
+    @patch("mysqlsh_helpers.MySQL.install_and_configure_mysql_dependencies")
+    def test_on_install(self, _install_and_configure_mysql_dependencies):
         self.charm.on.install.emit()
 
-        _apt_update.assert_called_once()
-        _apt_add_package.assert_called_once_with("mysql-server-8.0")
+        self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
 
-        mock_ensure.assert_called_once_with(snap.SnapState.Latest, channel="stable")
-
-        _update_mysql_configuration.assert_called_once()
-
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
-
-    @patch("charms.operator_libs_linux.v0.apt.update")
-    def test_on_install_apt_update_error(self, _apt_update):
-        """Test an issue with apt.update."""
-        _apt_update.side_effect = subprocess.CalledProcessError(cmd="apt update", returncode=127)
-
+    @patch(
+        "mysqlsh_helpers.MySQL.install_and_configure_mysql_dependencies", side_effect=Exception()
+    )
+    def test_on_install_exception(self, _install_and_configure_mysql_dependencies):
         self.charm.on.install.emit()
 
-        _apt_update.assert_called_once()
-        self.assertEqual(self.harness.model.unit.status, BlockedStatus("Failed to update apt"))
-
-    @patch("charms.operator_libs_linux.v0.apt.update")
-    @patch("charms.operator_libs_linux.v0.apt.add_package")
-    def test_on_install_apt_add_package_error(self, _apt_add_package, _apt_update):
-        """Test an issue with apt.add_package."""
-        # Test PackageNotFoundError
-        _apt_add_package.side_effect = apt.PackageNotFoundError
-
-        self.charm.on.install.emit()
-
-        _apt_update.assert_called_once()
-        _apt_add_package.assert_called_once_with("mysql-server-8.0")
-
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Failed to install 'mysql-server-8.0'")
-        )
-
-        # Reset the mocks
-        _apt_update.reset_mock()
-        _apt_add_package.reset_mock()
-
-        # Test PackageError
-        _apt_add_package.side_effect = apt.PackageError
-
-        self.charm.on.install.emit()
-
-        _apt_update.assert_called_once()
-        _apt_add_package.assert_called_once_with("mysql-server-8.0")
-
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Failed to install 'mysql-server-8.0'")
-        )
-
-    @patch("charms.operator_libs_linux.v0.apt.update")
-    @patch("charms.operator_libs_linux.v0.apt.add_package")
-    @patch("charms.operator_libs_linux.v1.snap.SnapCache")
-    def test_on_install_snap_error(self, _snap_cache, _apt_add_package, _apt_update):
-        """Test an issue with snap installations."""
-        # Test SnapNotFoundError
-        _snap_cache.side_effect = snap.SnapNotFoundError
-
-        self.charm.on.install.emit()
-
-        _apt_update.assert_called_once()
-        _apt_add_package.assert_called_once_with("mysql-server-8.0")
-
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Failed to install 'mysql-shell'")
-        )
-
-        # Reset the mocks
-        _apt_update.reset_mock()
-        _apt_add_package.reset_mock()
-        _snap_cache.reset_mock()
-
-        # Test SnapError
-        _snap_cache.side_effect = snap.SnapError
-
-        self.charm.on.install.emit()
-
-        _apt_update.assert_called_once()
-        _apt_add_package.assert_called_once_with("mysql-server-8.0")
-
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Failed to install 'mysql-shell'")
-        )
-
-    @patch("charms.operator_libs_linux.v0.apt.update")
-    @patch("charms.operator_libs_linux.v0.apt.add_package")
-    @patch("charms.operator_libs_linux.v1.snap.SnapCache")
-    @patch("mysqlsh_helpers.MySQL._ensure_mysqlsh_common_dir")
-    @patch("mysqlsh_helpers.MySQL.update_mysql_configuration")
-    def test_on_install_update_mysql_configuration_error(
-        self,
-        _update_mysql_configuration,
-        _ensure_mysqlsh_common_dir,
-        _snap_cache,
-        _apt_add_package,
-        _apt_update,
-    ):
-        """Test an issue with snap installations."""
-        # Test MySQLInitializationError
-        _update_mysql_configuration.side_effect = MySQLInitializationError
-
-        self.charm.on.install.emit()
-
-        _apt_update.assert_called_once()
-        _apt_add_package.assert_called_once_with("mysql-server-8.0")
-        _snap_cache.assert_called_once()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Failed to update the mysql configuration"),
-        )
-
-        # Reset the mocks
-        _apt_update.reset_mock()
-        _apt_add_package.reset_mock()
-        _snap_cache.reset_mock()
-
-        # Test MySQLUpdateConfigurationError
-        _update_mysql_configuration.side_effect = MySQLUpdateConfigurationError
-
-        self.charm.on.install.emit()
-
-        _apt_update.assert_called_once()
-        _apt_add_package.assert_called_once_with("mysql-server-8.0")
-        _snap_cache.assert_called_once()
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Failed to update the mysql configuration"),
-        )
+        self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -17,13 +17,13 @@ from mysqlsh_helpers import (
 class TestMySQL(unittest.TestCase):
     def setUp(self):
         self.mysql = MySQL(
-            "clusteradminpassword",
-            "clusteradmin",
-            "test_cluster",
             "127.0.0.1",
+            "test_cluster",
             "password",
-            "serverconfigpassword",
             "serverconfig",
+            "serverconfigpassword",
+            "clusteradmin",
+            "clusteradminpassword",
         )
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -80,10 +80,10 @@ class TestMySQL(unittest.TestCase):
     def test_mysqlsh_bin(self, _exists):
         """Test the mysqlsh_bin property."""
         _exists.return_value = True
-        self.assertEqual(MySQL._get_mysqlsh_bin(), "/usr/bin/mysqlsh")
+        self.assertEqual(MySQL.get_mysqlsh_bin(), "/usr/bin/mysqlsh")
 
         _exists.return_value = False
-        self.assertEqual(MySQL._get_mysqlsh_bin(), "/snap/bin/mysql-shell")
+        self.assertEqual(MySQL.get_mysqlsh_bin(), "/snap/bin/mysql-shell")
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
     @patch("mysqlsh_helpers.MySQL._wait_until_mysql_connection")

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -7,44 +7,46 @@ from unittest.mock import patch
 
 from mysqlsh_helpers import (
     MySQL,
+    MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
-    MySQLInstanceConfigureError,
+    MySQLCreateClusterError,
 )
 
 
 class TestMySQL(unittest.TestCase):
     def setUp(self):
-        root_password = "password"
-        cluster_admin_user = "clusteradmin"
-        cluster_admin_password = "innodb"
-        instance_address = "127.0.0.1"
-
-        self.mysql = MySQL(
-            root_password, cluster_admin_user, cluster_admin_password, instance_address
-        )
+        with patch("mysqlsh_helpers.MySQL._ensure_mysqlsh_common_dir"):
+            self.mysql = MySQL(
+                "clusteradminpassword",
+                "clusteradmin",
+                "test_cluster",
+                "127.0.0.1",
+                "password",
+                "serverconfigpassword",
+                "serverconfig",
+            )
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
     def test_configure_mysql_users(self, _run_mysqlcli_script):
         """Test failed to configuring the MySQL users."""
         _run_mysqlcli_script.return_value = b""
+
         _expected_script = " ".join(
             (
                 "SET @@SESSION.SQL_LOG_BIN=0;",
-                "CREATE USER 'cadmin'@'10.1.1.1' IDENTIFIED BY 'test';",
-                "GRANT ALL ON *.* TO 'cadmin'@'10.1.1.1' WITH GRANT OPTION;",
-                "CREATE USER 'root'@'%' IDENTIFIED BY 'test';",
+                "CREATE USER 'root'@'%' IDENTIFIED BY 'password';",
                 "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
+                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';",
+                "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;",
                 "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
-                "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'test';",
-                "REVOKE SYSTEM_USER ON *.* FROM root@'%';",
-                "REVOKE SYSTEM_USER ON *.* FROM root@localhost;",
+                "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';",
+                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER ON *.* FROM root@'%';",
+                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER ON *.* FROM root@localhost;",
                 "FLUSH PRIVILEGES;",
             )
         )
 
-        _m = MySQL("test", "cadmin", "test", "10.1.1.1")
-
-        _m.configure_mysql_users()
+        self.mysql.configure_mysql_users()
         _run_mysqlcli_script.assert_called_once_with(_expected_script)
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
@@ -54,38 +56,24 @@ class TestMySQL(unittest.TestCase):
             cmd="mysqlsh", returncode=127
         )
 
-        _m = MySQL("test", "test", "test", "10.1.1.1")
         with self.assertRaises(MySQLConfigureMySQLUsersError):
-            _m.configure_mysql_users()
+            self.mysql.configure_mysql_users()
 
     @patch("os.path.exists")
     def test_mysqlsh_bin(self, _exists):
         """Test the mysqlsh_bin property."""
         _exists.return_value = True
-        _m = MySQL("test", "test", "test", "10.0.1.1")
-
-        self.assertEqual(_m.mysqlsh_bin, "/usr/bin/mysqlsh")
+        self.assertEqual(self.mysql._mysqlsh_bin, "/usr/bin/mysqlsh")
 
         _exists.return_value = False
-        self.assertEqual(_m.mysqlsh_bin, "/snap/bin/mysql-shell")
-
-    @patch("os.path.exists")
-    def test_mysqlsh_common_dir(self, _exists):
-        """Test the mysqlsh_common_dir property."""
-        _exists.return_value = True
-        _m = MySQL("test", "test", "test", "11.1.1.1")
-        self.assertEqual(_m.mysqlsh_common_dir, "/root/snap/mysql-shell/common")
-        _exists.return_value = False
-        self.assertEqual(_m.mysqlsh_common_dir, "/tmp")
+        self.assertEqual(self.mysql._mysqlsh_bin, "/snap/bin/mysql-shell")
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
     @patch("mysqlsh_helpers.MySQL._wait_until_mysql_connection")
     def test_configure_instance(self, _wait_until_mysql_connection, _run_mysqlsh_script):
         """Test a successful execution of configure_instance."""
         configure_instance_commands = (
-            "dba.configure_instance('clusteradmin:innodb@127.0.0.1')",
-            "my_shell = shell.connect('clusteradmin:innodb@127.0.0.1')",
-            'my_shell.run_sql("RESTART;");',
+            'dba.configure_instance(\'serverconfig:serverconfigpassword@127.0.0.1\', {"clusterAdmin": "clusteradmin", "clusterAdminPassword": "clusteradminpassword", "restart": "true"})',
         )
 
         self.mysql.configure_instance()
@@ -98,11 +86,11 @@ class TestMySQL(unittest.TestCase):
     def test_configure_instance_exceptions(
         self, _wait_until_mysql_connection, _run_mysqlsh_script
     ):
-        """Test exceptions raised by methods called in configure_instance."""
+        """Test exceptions raise while running configure_instance."""
         # Test an issue with _run_mysqlsh_script
         _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(cmd="mock", returncode=127)
 
-        with self.assertRaises(MySQLInstanceConfigureError):
+        with self.assertRaises(MySQLConfigureInstanceError):
             self.mysql.configure_instance()
 
         _wait_until_mysql_connection.assert_not_called()
@@ -116,7 +104,27 @@ class TestMySQL(unittest.TestCase):
             cmd="mock", returncode=127
         )
 
-        with self.assertRaises(MySQLInstanceConfigureError):
+        with self.assertRaises(MySQLConfigureInstanceError):
             self.mysql.configure_instance()
 
         _run_mysqlsh_script.assert_called_once()
+
+    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
+    def test_create_cluster(self, _run_mysqlsh_script):
+        """Test a successful execution of create_cluster."""
+        create_cluster_commands = (
+            "shell.connect('serverconfig:serverconfigpassword@127.0.0.1')",
+            "dba.create_cluster('test_cluster')",
+        )
+
+        self.mysql.create_cluster()
+
+        _run_mysqlsh_script.assert_called_once_with("\n".join(create_cluster_commands))
+
+    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
+    def test_create_cluster_exceptions(self, _run_mysqlsh_script):
+        """Test exceptions raised while running create_cluster."""
+        _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(cmd="mock", returncode=127)
+
+        with self.assertRaises(MySQLCreateClusterError):
+            self.mysql.create_cluster()

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -33,7 +33,6 @@ class TestMySQL(unittest.TestCase):
 
         _expected_create_root_user_commands = " ".join(
             (
-                "SET @@SESSION.SQL_LOG_BIN=0;",
                 "CREATE USER 'root'@'%' IDENTIFIED BY 'password';",
                 "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
             )
@@ -41,7 +40,6 @@ class TestMySQL(unittest.TestCase):
 
         _expected_configure_user_commands = " ".join(
             (
-                "SET @@SESSION.SQL_LOG_BIN=0;",
                 "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';",
                 "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;",
                 "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -152,7 +152,7 @@ class TestMySQL(unittest.TestCase):
         add_instance_to_cluster_commands = (
             "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
             "cluster = dba.get_cluster('test_cluster')",
-            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "recoveryMethod": "clone"})',
+            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "recoveryMethod": "auto"})',
         )
 
         self.mysql.add_instance_to_cluster("127.0.0.2")


### PR DESCRIPTION
[Jira ticket 1](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&selectedIssue=DPE-144) and [Jira ticket 2](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&selectedIssue=DPE-145)

# Issue
1. We are not creating our users for mysql correctly. Additionally, we are only revoking a subset of the required priveleges for the `root` user
2. MySQL is binding to `127.0.0.1` upon installation of `mysql-server-8.0`. However, InnoDB requires cluster instances to be bound to `0.0.0.0`
3. We have not yet implemented the helper method to create a cluster
4. We have not yet implemented the helper method to add an instance to the cluster

# Solution
1. MySQL installation creates `root@localhost`. We additionally create `root@%` and `serverconfig@%` manually. We then create `clusteradmin@%` while configuring the instance for InnoDB (by calling `dba.configure_instance()` within a `mysqlsh` context). Additionally, we will revoke all system user related privileges from `root@localhost` and `root@%`.
See [this link](https://docs.oracle.com/cd/E17952_01/mysql-shell-8.0-en/innodb-cluster-user-accounts.html) for more information on InnoDB users. Also see [this link](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super) for more information on system user related privileges.

2. Add a mysql configuration template file (`templates/mysqld.cnf`) which defines values for `bind-address` and `mysqlx-bind-address` set to `0.0.0.0`. Copy over these files to the mysql configuration directory (with prefix `z-` so the file has the highest priority) and restart mysql via systemctl during the `on_install` hook.

3. Implement the helper method to create a cluster
4. Implement the helper method to add an instance to a cluster


# Testing
To test, I did the following:
1. Run `charmcraft pack` and deploy a unit using lxd. SSH into the lxd container and ensure that MySQL is running and confirm using the `mysql` client that the bind address values are set to `0.0.0.0`
```
shayan@wellington:~/code/mysql-operator (fix/refactor_user_creation) $ lxc exec juju-30620b-21 bash 
root@juju-30620b-21:~# systemctl status mysql
● mysql.service - MySQL Community Server
     Loaded: loaded (/lib/systemd/system/mysql.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2022-04-07 20:11:51 UTC; 35s ago
    Process: 5816 ExecStartPre=/usr/share/mysql/mysql-systemd-start pre (code=exited, status=0/SUCCESS)
   Main PID: 5824 (mysqld)
     Status: "Server is operational"
      Tasks: 38 (limit: 18730)
     Memory: 357.9M
     CGroup: /system.slice/mysql.service
             └─5824 /usr/sbin/mysqld

Apr 07 20:11:50 juju-30620b-21 systemd[1]: Starting MySQL Community Server...
Apr 07 20:11:51 juju-30620b-21 systemd[1]: Started MySQL Community Server.
root@juju-30620b-21:~# mysql

mysql> show variables like '%addr%';
+---------------------+---------+
| Variable_name       | Value   |
+---------------------+---------+
| admin_address       |         |
| bind_address        | 0.0.0.0 |
| mysqlx_bind_address | 0.0.0.0 |
+---------------------+---------+
3 rows in set (0.00 sec)
```

2. I launched 2 units with juju using lxd. Then SSH into both units, navigate to the juju source code directory, instantiate an instance of `MySQL` helper class and run the `configure_mysql_users` and `configure_instance` on both lxd containers. Then, on one container run `create_cluster()` and `add_instance_to_cluster()` methods.

# Release Notes
- Implement the helper functions to configure mysql, create the appropriate mysql users, configure the instance, create a cluster and add instances to the cluster.

