### PR TITLE
Modify on_start to create a cluster on the leader unit + minor bugfixes

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@
 # See LICENSE file for licensing details.
 
 options:
-  cluster_name:
+  cluster-name:
     description: "Optional - Name of the MySQL InnoDB cluster"
     type: "string"

--- a/src/charm.py
+++ b/src/charm.py
@@ -111,6 +111,8 @@ class MySQLOperatorCharm(CharmBase):
 
         # Create the cluster on the juju leader unit
         if not self.unit.is_leader():
+            # TODO: change to WaitingStatus, and move to ActiveStatus in the update-status
+            # event handler after the instance has been added to the cluster
             self.unit.status = ActiveStatus()
             return
 

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -320,7 +320,7 @@ class MySQL:
         if not os.path.exists(MYSQLD_SOCK_FILE):
             raise MySQLServiceNotRunningError()
 
-    def _run_mysqlsh_script(self, script: str) -> str:
+    def _run_mysqlsh_script(self, script: str) -> None:
         """Execute a MySQL shell script.
 
         Raises CalledProcessError if the script gets a non-zero return code.
@@ -339,7 +339,7 @@ class MySQL:
             # Specify python as this is not the default in the deb version
             # of the mysql-shell snap
             command = [MySQL.get_mysqlsh_bin(), "--no-wizard", "--python", "-f", _file.name]
-            return subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")
+            subprocess.check_output(command, stderr=subprocess.PIPE)
 
     def _run_mysqlcli_script(self, script: str, password=None) -> None:
         """Execute a MySQL CLI script.

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -129,10 +129,11 @@ class TestMySQL(unittest.TestCase):
         """Test a successful execution of create_cluster."""
         create_cluster_commands = (
             "shell.connect('serverconfig:serverconfigpassword@127.0.0.1')",
-            "dba.create_cluster('test_cluster')",
+            "cluster = dba.create_cluster('test_cluster')",
+            "cluster.set_instance_option('127.0.0.1', 'label', 'mysql-0')",
         )
 
-        self.mysql.create_cluster()
+        self.mysql.create_cluster("mysql-0")
 
         _run_mysqlsh_script.assert_called_once_with("\n".join(create_cluster_commands))
 
@@ -142,7 +143,7 @@ class TestMySQL(unittest.TestCase):
         _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(cmd="mock", returncode=127)
 
         with self.assertRaises(MySQLCreateClusterError):
-            self.mysql.create_cluster()
+            self.mysql.create_cluster("mysql-0")
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
     def test_add_instance_to_cluster(self, _run_mysqlsh_script):
@@ -150,10 +151,10 @@ class TestMySQL(unittest.TestCase):
         add_instance_to_cluster_commands = (
             "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
             "cluster = dba.get_cluster('test_cluster')",
-            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "recoveryMethod": "auto"})',
+            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "label": "mysql-1", "recoveryMethod": "auto"})',
         )
 
-        self.mysql.add_instance_to_cluster("127.0.0.2")
+        self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
 
         _run_mysqlsh_script.assert_called_once_with("\n".join(add_instance_to_cluster_commands))
 
@@ -163,4 +164,4 @@ class TestMySQL(unittest.TestCase):
         _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(cmd="mock", returncode=127)
 
         with self.assertRaises(MySQLAddInstanceToClusterError):
-            self.mysql.add_instance_to_cluster("127.0.0.2")
+            self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")


### PR DESCRIPTION
# Issue
- We are only configuring the instance for the leader unit
- We are not attaching labels to instances (and so units in the cluster appear by their `hostname`s). This would cause problems trying to query the status of an instance using mysqlsh since we do not have access to the hostname in the ops framework
- Config keys cannot have `_`s
- The cluster name cannot have characters other than letters, digits and `_`s. Also, the naming is not consistent with the k8s charm

# Solution
- Configuring all instances, but create cluster only on the leader unit
- Attach labels (unit names) to each instance in the cluster (would appear as `mysql-0` instead of `juju-<hash>-<unit_number>`)
- Use `-`s instead of `_` in config keys and peer relation data keys
- Randomly generate a hash for the cluster name if one is not specified in the config (will look like `cluster_<md5_hash>`

# Release Notes
- Minor updates to get a single node cluster up and running in the charm
