### PR TITLE
Implement scaling up and down of the InnoDB cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
-  integration-test-microk8s:
+  integration-test-lxd:
     name: Integration tests (lxd)
     runs-on: ubuntu-latest
     steps:

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@
 # See LICENSE file for licensing details.
 
 options:
-  cluster_name:
+  cluster-name:
     description: "Optional - Name of the MySQL InnoDB cluster"
     type: "string"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,5 +16,5 @@ maintainers:
   - Shayan Patel <shayan.patel@canonical.com>
 
 peers:
-  mysql-replicas:
-    interface: mysql-replicas
+  database-peers:
+    interface: mysql-peers

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,16 +9,16 @@ summary: |
   MySQL is  a widely used, open-source relational database management system
   (RDBMS). MySQL InnoDB cluster provides a complete high availability solution
   for MySQL via Group Replication.
+source: https://github.com/canonical/mysql-operator
+issues: https://github.com/canonical/mysql-operator/issues
 
   This charm supports MySQL 8 on machines.
 maintainers:
   - Paulo Machado <paulo.machado@canonical.com>
   - Shayan Patel <shayan.patel@canonical.com>
-
 peers:
   database-peers:
     interface: mysql-peers
-
 storage:
   database:
     type: filesystem

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,3 +18,9 @@ maintainers:
 peers:
   database-peers:
     interface: mysql-peers
+
+storage:
+  database:
+    type: filesystem
+    description: Persistent storage for MySQL data
+    location: /var/lib/mysql

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,13 +32,20 @@ def generate_random_password(length: int) -> str:
 
     Args:
         length: length of the randomly generated string to be returned
+
+    Returns:
+        a string with random letters and digits of length specified
     """
     choices = string.ascii_letters + string.digits
     return "".join([secrets.choice(choices) for i in range(length)])
 
 
-def generate_random_hash(length=20) -> str:
-    """Generate a random hash."""
+def generate_random_hash() -> str:
+    """Generate a random hash.
+
+    Returns:
+        A random MD5 hash
+    """
     random_characters = generate_random_password(20)
     return hashlib.md5(random_characters.encode("utf-8")).hexdigest()
 

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -305,7 +305,12 @@ class MySQL:
             raise MySQLCreateClusterError(e.stderr)
 
     def initialize_juju_units_operations_table(self) -> None:
-        """Initialize the mysql.juju_units_operations table using the serverconfig user."""
+        """Initialize the mysql.juju_units_operations table using the serverconfig user.
+
+        Raises
+            MySQLInitializeJujuOperationsTableError if there is an issue
+                initializing the juju_units_opertions table
+        """
         initalize_table_commands = (
             "CREATE TABLE mysql.juju_units_operations (task varchar(20), executor varchar(20), status varchar(20), primary key(task));",
             f"INSERT INTO mysql.juju_units_operations values ('{UNIT_TEARDOWN_LOCKNAME}', '', 'not-started');",

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -12,6 +12,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+from typing import List, Tuple
 
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import snap
@@ -63,12 +64,6 @@ class MySQLAddInstanceToClusterError(Exception):
 
 class MySQLServiceNotRunningError(Exception):
     """Exception raised when the MySQL service is not running."""
-
-    pass
-
-
-class MySQLConfirmAllInstancesOnlineError(Exception):
-    """Exception raised when there is an issue confirming instance's InnoDB configuration."""
 
     pass
 
@@ -388,6 +383,7 @@ class MySQL:
 
         Args:
             instance_address: The instance address for which to confirm InnoDB configuration
+            instance_unit_label: The label of the instance unit to confirm InnoDB configuration
 
         Returns:
             Boolean indicating whether the instance is configured for use in an InnoDB cluster
@@ -507,7 +503,7 @@ class MySQL:
             )
             raise MySQLRemoveInstanceError(e.stderr)
 
-    def _acquire_lock(self, primary_address, unit_label, lock_name):
+    def _acquire_lock(self, primary_address: str, unit_label: str, lock_name: str) -> bool:
         """Attempts to acquire a lock by using the mysql.juju_units_operations table.
 
         Note that there must exist the appropriate rows in the table, created in the
@@ -542,7 +538,7 @@ class MySQL:
 
         return bool(int(matches.group(1)))
 
-    def _release_lock(self, primary_address, unit_label, lock_name):
+    def _release_lock(self, primary_address: str, unit_label: str, lock_name: str) -> None:
         """Releases a lock in the mysql.juju_units_operations table.
 
         Note that there must exist the appropriate rows in the table, created in the
@@ -564,7 +560,7 @@ class MySQL:
         )
         self._run_mysqlsh_script("\n".join(release_lock_commands))
 
-    def _get_cluster_member_addresses(self, exclude_unit_labels=[]):
+    def _get_cluster_member_addresses(self, exclude_unit_labels: List = []) -> Tuple[List, bool]:
         """Get the addresses of the cluster's members.
 
         Keyword args:
@@ -600,7 +596,7 @@ class MySQL:
 
         return (member_addresses, "<MEMBER_ADDRESSES>" in output)
 
-    def _get_cluster_primary_address(self, connect_instance_address=None):
+    def _get_cluster_primary_address(self, connect_instance_address: str = None) -> str:
         """Get the cluster primary's address.
 
         Keyword args:
@@ -664,7 +660,7 @@ class MySQL:
             command = [MySQL.get_mysqlsh_bin(), "--no-wizard", "--python", "-f", _file.name]
             return subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")
 
-    def _run_mysqlcli_script(self, script: str, user="root", password=None) -> None:
+    def _run_mysqlcli_script(self, script: str, user: str = "root", password: str = None) -> None:
         """Execute a MySQL CLI script.
 
         Execute SQL script as instance root user.

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -426,7 +426,7 @@ class MySQL:
                 exc_info=e,
             )
 
-            MySQLRemoveInstanceDBConnectionError(e.stderr)
+            raise MySQLRemoveInstanceDBConnectionError(e.stderr)
 
     @retry(reraise=True, stop=stop_after_delay(30), wait=wait_fixed(5))
     def _wait_until_mysql_connection(self) -> None:
@@ -458,7 +458,7 @@ class MySQL:
             command = [MySQL.get_mysqlsh_bin(), "--no-wizard", "--python", "-f", _file.name]
             return subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")
 
-    def _run_mysqlcli_script(self, script: str, password=None) -> str:
+    def _run_mysqlcli_script(self, script: str, password=None) -> None:
         """Execute a MySQL CLI script.
 
         Execute SQL script as instance root user.
@@ -481,4 +481,4 @@ class MySQL:
         if password:
             command.append(f"--password={password}")
 
-        return subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")
+        return subprocess.check_output(command, stderr=subprocess.PIPE)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -26,7 +26,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     """
     # build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=2)
+    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
 
     # issuing dummy update_status just to trigger an event
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
@@ -37,9 +37,10 @@ async def test_build_and_deploy(ops_test: OpsTest):
         raise_on_blocked=True,
         timeout=1000,
     )
-    assert len(ops_test.model.applications[APP_NAME].units) == 2
+    assert len(ops_test.model.applications[APP_NAME].units) == 3
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
     assert ops_test.model.applications[APP_NAME].units[1].workload_status == "active"
+    assert ops_test.model.applications[APP_NAME].units[2].workload_status == "active"
 
     # effectively disable the update status from firing
     await ops_test.model.set_config({"update-status-hook-interval": "60m"})

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,11 +24,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     Assert on the unit status before any relations/configurations take place.
     """
-    # build and deploy charm from local source folder
+    # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1)
 
-    # issuing dummy update_status just to trigger an event
+    # Issuing dummy update_status just to trigger an event
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
 
     await ops_test.model.wait_for_idle(
@@ -37,12 +37,10 @@ async def test_build_and_deploy(ops_test: OpsTest):
         raise_on_blocked=True,
         timeout=1000,
     )
-    assert len(ops_test.model.applications[APP_NAME].units) == 3
+    assert len(ops_test.model.applications[APP_NAME].units) == 1
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-    assert ops_test.model.applications[APP_NAME].units[1].workload_status == "active"
-    assert ops_test.model.applications[APP_NAME].units[2].workload_status == "active"
 
-    # effectively disable the update status from firing
+    # Effectively disable the update status from firing
     await ops_test.model.set_config({"update-status-hook-interval": "60m"})
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,7 +21,7 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(MySQLOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
-        self.peer_relation_id = self.harness.add_relation("mysql-replicas", "mysql-replicas")
+        self.peer_relation_id = self.harness.add_relation("database-peers", "database-peers")
         self.harness.add_relation_unit(self.peer_relation_id, "mysql/1")
         self.charm = self.harness.charm
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,6 +12,7 @@ from mysqlsh_helpers import (
     MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
     MySQLCreateClusterError,
+    MySQLInitializeJujuOperationsTableError,
 )
 from tests.unit.helpers import patch_network_get
 
@@ -101,8 +102,15 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("mysqlsh_helpers.MySQL.configure_mysql_users")
     @patch("mysqlsh_helpers.MySQL.configure_instance")
+    @patch("mysqlsh_helpers.MySQL.initialize_juju_units_operations_table")
     @patch("mysqlsh_helpers.MySQL.create_cluster")
-    def test_on_start(self, _create_cluster, _configure_instance, _configure_mysql_users):
+    def test_on_start(
+        self,
+        _create_cluster,
+        _initialize_juju_units_operations_table,
+        _configure_instance,
+        _configure_mysql_users,
+    ):
         # execute on_leader_elected and config_changed to populate the peer databag
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
@@ -114,9 +122,14 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("mysqlsh_helpers.MySQL.configure_mysql_users")
     @patch("mysqlsh_helpers.MySQL.configure_instance")
+    @patch("mysqlsh_helpers.MySQL.initialize_juju_units_operations_table")
     @patch("mysqlsh_helpers.MySQL.create_cluster")
     def test_on_start_exceptions(
-        self, _create_cluster, _configure_instance, _configure_mysql_users
+        self,
+        _create_cluster,
+        _initialize_juju_units_operations_table,
+        _configure_instance,
+        _configure_mysql_users,
     ):
         # execute on_leader_elected and config_changed to populate the peer databag
         self.harness.set_leader(True)
@@ -137,6 +150,16 @@ class TestCharm(unittest.TestCase):
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
 
         _configure_instance.reset_mock()
+
+        # test an exception initializing the mysql.juju_units_operations table
+        _initialize_juju_units_operations_table.side_effect = (
+            MySQLInitializeJujuOperationsTableError
+        )
+
+        self.charm.on.start.emit()
+        self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+        _initialize_juju_units_operations_table.reset_mock()
 
         # test an exception with creating a cluster
         _create_cluster.side_effect = MySQLCreateClusterError

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -129,10 +129,11 @@ class TestMySQL(unittest.TestCase):
         """Test a successful execution of create_cluster."""
         create_cluster_commands = (
             "shell.connect('serverconfig:serverconfigpassword@127.0.0.1')",
-            "dba.create_cluster('test_cluster')",
+            "cluster = dba.create_cluster('test_cluster')",
+            "cluster.set_instance_option('127.0.0.1', 'label', 'mysql-0')",
         )
 
-        self.mysql.create_cluster()
+        self.mysql.create_cluster("mysql-0")
 
         _run_mysqlsh_script.assert_called_once_with("\n".join(create_cluster_commands))
 
@@ -142,7 +143,7 @@ class TestMySQL(unittest.TestCase):
         _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(cmd="mock", returncode=127)
 
         with self.assertRaises(MySQLCreateClusterError):
-            self.mysql.create_cluster()
+            self.mysql.create_cluster("mysql-0")
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
     def test_add_instance_to_cluster(self, _run_mysqlsh_script):
@@ -150,10 +151,10 @@ class TestMySQL(unittest.TestCase):
         add_instance_to_cluster_commands = (
             "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
             "cluster = dba.get_cluster('test_cluster')",
-            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "recoveryMethod": "auto"})',
+            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "label": "mysql-1", "recoveryMethod": "auto"})',
         )
 
-        self.mysql.add_instance_to_cluster("127.0.0.2")
+        self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
 
         _run_mysqlsh_script.assert_called_once_with("\n".join(add_instance_to_cluster_commands))
 
@@ -163,4 +164,4 @@ class TestMySQL(unittest.TestCase):
         _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(cmd="mock", returncode=127)
 
         with self.assertRaises(MySQLAddInstanceToClusterError):
-            self.mysql.add_instance_to_cluster("127.0.0.2")
+            self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -150,8 +150,10 @@ class TestMySQL(unittest.TestCase):
         """Test a successful execution of create_cluster."""
         add_instance_to_cluster_commands = (
             "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+            "session.run_sql(\"SELECT get_lock('add_instance', -1);\")",
             "cluster = dba.get_cluster('test_cluster')",
             'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "label": "mysql-1", "recoveryMethod": "auto"})',
+            "session.run_sql(\"SELECT release_lock('add_instance');\")",
         )
 
         self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
@@ -176,9 +178,13 @@ class TestMySQL(unittest.TestCase):
             'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
         )
 
-        is_instance_configured = self.mysql.is_instance_configured_for_innodb("127.0.0.2", "mysql-1")
+        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
+            "127.0.0.2", "mysql-1"
+        )
 
-        _run_mysqlsh_script.assert_called_once_with("\n".join(check_instance_configuration_commands))
+        _run_mysqlsh_script.assert_called_once_with(
+            "\n".join(check_instance_configuration_commands)
+        )
         self.assertTrue(is_instance_configured)
 
         # reset mocks
@@ -187,9 +193,13 @@ class TestMySQL(unittest.TestCase):
         # test instance not configured for innodb
         _run_mysqlsh_script.return_value = "INSTANCE_NOT_CONFIGURED"
 
-        is_instance_configured = self.mysql.is_instance_configured_for_innodb("127.0.0.2", "mysql-1")
+        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
+            "127.0.0.2", "mysql-1"
+        )
 
-        _run_mysqlsh_script.assert_called_once_with("\n".join(check_instance_configuration_commands))
+        _run_mysqlsh_script.assert_called_once_with(
+            "\n".join(check_instance_configuration_commands)
+        )
         self.assertFalse(is_instance_configured)
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
@@ -203,7 +213,11 @@ class TestMySQL(unittest.TestCase):
             'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
         )
 
-        is_instance_configured = self.mysql.is_instance_configured_for_innodb("127.0.0.2", "mysql-1")
+        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
+            "127.0.0.2", "mysql-1"
+        )
 
-        _run_mysqlsh_script.assert_called_once_with("\n".join(check_instance_configuration_commands))
+        _run_mysqlsh_script.assert_called_once_with(
+            "\n".join(check_instance_configuration_commands)
+        )
         self.assertFalse(is_instance_configured)

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -180,10 +180,8 @@ class TestMySQL(unittest.TestCase):
         """Test a successful execution of create_cluster."""
         add_instance_to_cluster_commands = (
             "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-            "session.run_sql(\"SELECT get_lock('add_instance', -1);\")",
             "cluster = dba.get_cluster('test_cluster')",
             'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "label": "mysql-1", "recoveryMethod": "auto"})',
-            "session.run_sql(\"SELECT release_lock('add_instance');\")",
         )
 
         self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
@@ -327,7 +325,7 @@ class TestMySQL(unittest.TestCase):
     def test_remove_instance_subprocess_execption(
         self, _get_cluster_member_addresses, _run_mysqlsh_script, _get_cluster_primary_address
     ):
-        """Test CalledProcessError to acquire lock while running the remove_instance() method."""
+        """Test CalledProcessError while acquiring lock running the remove_instance() method."""
         _get_cluster_primary_address.side_effect = ["1.1.1.1", "2.2.2.2"]
         _run_mysqlsh_script.side_effect = subprocess.CalledProcessError(cmd="mock", returncode=127)
         _get_cluster_member_addresses.return_value = ("2.2.2.2", True)


### PR DESCRIPTION
[Jira ticket](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&selectedIssue=DPE-215)

# Issue
- We can only provision a cluster of one instance (we have not yet implemented the inclusion of additional instances to the InnoDB cluster)
- We are not attaching any storage volumes in the charm's metadata
- We are unable to scale down the cluster correctly

# Solution
- Add instances to the cluster on the leader unit's `on_<peer>_relation_joined` event
- Attach a storage volume for each unit at path `/var/lib/mysql/` (where MySQL's data is stored)
- Scale down in `storage_detaching` event (utilizing locks provided by the underlying database to ensure that only one instance is scaled down at a time - a requirement to avoid leaving the cluster in a bad state).

# Context
To ensure that we only remove one instance at a time from the cluster (to avoid split-brain or lack of majority issues), we create a `mysql.juju_units_operations` table to which we [update+select](https://github.com/canonical/mysql-operator/pull/9/files#diff-6e566a7b93efc3f3e7ac0e6d8989256725f876f06af78c45d0ae3815d4bcf82eR431-R436) to acquire a lock, and [update](https://github.com/canonical/mysql-operator/pull/9/files#diff-6e566a7b93efc3f3e7ac0e6d8989256725f876f06af78c45d0ae3815d4bcf82eR487-R490) again to release the lock.

# Testing
More comprehensive integration tests will be added in a followup PR

# Release Notes
- Enable the scale up and scale down of the MySQL InnoDB cluster
