### PR TITLE
Implement scaling and replication related integration tests

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,8 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+get-cluster-admin-credentials:
+  description: Get the credentials for the cluster admin user
+
+get-server-config-credentials:
+  description: Get the credentials for the server config user

--- a/src/charm.py
+++ b/src/charm.py
@@ -157,6 +157,9 @@ class MySQLOperatorCharm(CharmBase):
 
     def _on_update_status(self, _) -> None:
         """Handle the update_status event."""
+        if not self._is_peer_data_set:
+            return
+
         unit_label = self.unit.name.replace("/", "-")
         if isinstance(self.unit.status, WaitingStatus) and self._mysql.is_instance_in_cluster(
             unit_label

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -409,6 +409,33 @@ class MySQL:
             )
             return False
 
+    def is_instance_in_cluster(self, unit_label):
+        """Confirm if instance is in the cluster.
+
+        Args:
+            unit_label: The label of unit to check existence in cluster for
+
+        Returns:
+            Boolean indicating whether the unit is a member of the cluster
+        """
+        commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"cluster = dba.get_cluster('{self.cluster_name}')",
+            f"print(cluster.status()['defaultReplicaSet']['topology'].get('{unit_label}', {{}}).get('status', 'NOT_A_MEMBER'))",
+        )
+
+        try:
+            logger.debug(f"Checking existence of unit {unit_label} in cluster {self.cluster_name}")
+
+            output = self._run_mysqlsh_script("\n".join(commands))
+            return "ONLINE" in output
+        except subprocess.CalledProcessError:
+            # confirmation can fail if the clusteradmin user does not yet exist on the instance
+            logger.debug(
+                f"Failed to check existence of unit {unit_label} in cluster {self.cluster_name}"
+            )
+            return False
+
     @retry(
         retry=retry_if_exception_type(MySQLRemoveInstanceRetryError),
         stop=stop_after_attempt(15),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,6 +2,8 @@
 # See LICENSE file for licensing details.
 
 
+import secrets
+import string
 from typing import Optional
 
 
@@ -18,3 +20,16 @@ async def run_command_on_unit(unit, command: str) -> Optional[str]:
     """
     action = await unit.run(command)
     return action.results.get("Stdout", None)
+
+
+def generate_random_string(length: int) -> str:
+    """Generate a random string of the provided length.
+
+    Args:
+        length: the length of the random string to generate
+
+    Returns:
+        A random string comprised of letters and digits
+    """
+    choices = string.ascii_letters + string.digits
+    return "".join([secrets.choice(choices) for i in range(length)])

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,32 +3,37 @@
 # See LICENSE file for licensing details.
 
 
+import json
 import logging
+import re
+import time
 from pathlib import Path
+from typing import Dict
 
 import pytest
 import yaml
+from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import run_command_on_unit
+from tests.integration.helpers import generate_random_string, run_command_on_unit
 
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
+CLUSTER_NAME = "test_cluster"
 
 
+@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
-    """Build the charm-under-test and deploy it together with related charms.
-
-    Assert on the unit status before any relations/configurations take place.
-    """
+    """Build the charm and deploy 3 units to ensure a cluster is formed."""
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    config = {"cluster-name": CLUSTER_NAME}
+    await ops_test.model.deploy(charm, application_name=APP_NAME, config=config, num_units=3)
 
-    # Issuing dummy update_status just to trigger an event
+    # Reduce the update_status frequency until the cluster is deployed
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
 
     await ops_test.model.wait_for_idle(
@@ -38,25 +43,235 @@ async def test_build_and_deploy(ops_test: OpsTest):
         timeout=1000,
     )
     assert len(ops_test.model.applications[APP_NAME].units) == 3
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-    assert ops_test.model.applications[APP_NAME].units[1].workload_status == "active"
-    assert ops_test.model.applications[APP_NAME].units[2].workload_status == "active"
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        assert unit.workload_status == "active"
 
     # Effectively disable the update status from firing
     await ops_test.model.set_config({"update-status-hook-interval": "60m"})
 
 
+@pytest.mark.order(2)
 @pytest.mark.abort_on_fail
-async def test_database_package_installation(ops_test: OpsTest):
-    """Confirm that the charm units contain installed software."""
-    # Test each MySQL unit
-    for unit in ops_test.model.applications[APP_NAME].units:
-        # Ensure that mysql-server is installed correctly
-        result = await run_command_on_unit(unit, "mysqld --version")
-        mysql_version = result.strip().split()
-        assert mysql_version[2] == "8.0.28-0ubuntu0.20.04.3"
+async def test_consistent_data_replication_across_cluster(ops_test: OpsTest):
+    """Confirm that data is replicated from the primary node to all the replicas."""
+    # Insert values into a table on the primary unit
+    random_unit = ops_test.model.applications[APP_NAME].units[0]
+    server_config_credentials = await get_server_config_credentials(random_unit)
 
-        # Ensure that mysql-shell is installed correctly
-        result = await run_command_on_unit(unit, "mysqlsh --version")
-        mysqlsh_version = result.strip().split()
-        assert mysqlsh_version[2] == "8.0.23"
+    primary_unit = await get_primary_unit(
+        ops_test,
+        random_unit,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+    )
+
+    random_chars = generate_random_string(40)
+    create_records_sql = (
+        "CREATE DATABASE IF NOT EXISTS test",
+        "CREATE TABLE IF NOT EXISTS test.data_replication_table (id varchar(40), primary key(id))",
+        f"INSERT INTO test.data_replication_table VALUES ('{random_chars}')",
+    )
+
+    mysqlsh_sql_base_command = f"mysqlsh --sql {server_config_credentials['username']}:{server_config_credentials['password']}@127.0.0.1"
+
+    await run_command_on_unit(
+        primary_unit, f"{mysqlsh_sql_base_command} -e \"{';'.join(create_records_sql)}\""
+    )
+
+    # Allow time for the data to be replicated
+    time.sleep(2)
+
+    # Confirm that the values are available on all units
+    for unit in ops_test.model.applications[APP_NAME].units:
+        output = await run_command_on_unit(
+            unit,
+            f"{mysqlsh_sql_base_command} -e \"SELECT * FROM test.data_replication_table WHERE id = '{random_chars}'\"",
+        )
+        assert random_chars in output
+
+
+@pytest.mark.order(3)
+@pytest.mark.abort_on_fail
+async def test_primary_reelection(ops_test: OpsTest):
+    """Confirm that a new primary is elected when the current primary is torn down."""
+    random_unit = ops_test.model.applications[APP_NAME].units[0]
+    server_config_credentials = await get_server_config_credentials(random_unit)
+
+    primary_unit = await get_primary_unit(
+        ops_test,
+        random_unit,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+    )
+    primary_unit_name = primary_unit.name
+
+    assert len(ops_test.model.applications[APP_NAME].units) == 3
+
+    # Destroy the primary unit and wait 5 seconds to ensure that the
+    # juju status changed from active
+    await ops_test.model.destroy_units(primary_unit.name)
+    time.sleep(5)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=True,
+        timeout=1000,
+    )
+
+    # Wait for unit to be destroyed and confirm that the new primary unit is different
+    assert len(ops_test.model.applications[APP_NAME].units) == 2
+
+    random_unit = ops_test.model.applications[APP_NAME].units[0]
+    new_primary_unit = await get_primary_unit(
+        ops_test,
+        random_unit,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+    )
+
+    assert primary_unit_name != new_primary_unit.name
+
+
+@pytest.mark.order(4)
+@pytest.mark.abort_on_fail
+async def test_cluster_preserves_data_on_delete(ops_test: OpsTest):
+    """Test that data is preserved during scale up and scale down."""
+    # Insert values into test table from the primary unit
+    random_unit = ops_test.model.applications[APP_NAME].units[0]
+    server_config_credentials = await get_server_config_credentials(random_unit)
+
+    primary_unit = await get_primary_unit(
+        ops_test,
+        random_unit,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+    )
+
+    random_chars = generate_random_string(40)
+    create_records_sql = (
+        "CREATE DATABASE IF NOT EXISTS test",
+        "CREATE TABLE IF NOT EXISTS test.instance_state_replication (id varchar(40), primary key(id))",
+        f"INSERT INTO test.instance_state_replication VALUES ('{random_chars}')",
+    )
+
+    mysqlsh_sql_base_command = f"mysqlsh --sql {server_config_credentials['username']}:{server_config_credentials['password']}@127.0.0.1"
+
+    await run_command_on_unit(
+        primary_unit, f"{mysqlsh_sql_base_command} -e \"{';'.join(create_records_sql)}\""
+    )
+
+    assert len(ops_test.model.applications[APP_NAME].units) == 2
+    old_unit_names = [unit.name for unit in ops_test.model.applications[APP_NAME].units]
+
+    # Add a unit and wait until it is active
+    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
+
+    await ops_test.model.applications[APP_NAME].add_unit()
+    time.sleep(5)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=True,
+        timeout=1000,
+    )
+
+    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+
+    assert len(ops_test.model.applications[APP_NAME].units) == 3
+
+    added_unit = [
+        unit
+        for unit in ops_test.model.applications[APP_NAME].units
+        if unit.name not in old_unit_names
+    ][0]
+
+    # Ensure that all units have the above inserted data
+    for unit in ops_test.model.applications[APP_NAME].units:
+        output = await run_command_on_unit(
+            unit,
+            f"{mysqlsh_sql_base_command} -e \"SELECT * FROM test.instance_state_replication WHERE id = '{random_chars}'\"",
+        )
+        assert random_chars in output
+
+    # Destroy the recently created unit and wait until the application is active
+    await ops_test.model.destroy_units(added_unit.name)
+    time.sleep(5)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        raise_on_blocked=True,
+        timeout=1000,
+    )
+
+    assert len(ops_test.model.applications[APP_NAME].units) == 2
+
+    # Ensure that the data still exists in all the units
+    for unit in ops_test.model.applications[APP_NAME].units:
+        output = await run_command_on_unit(
+            unit,
+            f"{mysqlsh_sql_base_command} -e \"SELECT * FROM test.instance_state_replication WHERE id = '{random_chars}'\"",
+        )
+        assert random_chars in output
+
+
+async def get_primary_unit(
+    ops_test: OpsTest, unit: Unit, server_config_username: str, server_config_password: str
+) -> str:
+    """Helper to retrieve the primary unit.
+
+    Args:
+        ops_test: The ops test object passed into every test case
+        unit: A unit on which to run dba.get_cluster().status() on
+        server_config_username: The server config username
+        server_config_password: The server config password
+
+    Returns:
+        A juju unit that is a MySQL primary
+    """
+    commands = [
+        "mysqlsh",
+        "--python",
+        f"{server_config_username}:{server_config_password}@127.0.0.1",
+        "-e",
+        f"\"print('<CLUSTER_STATUS>' + dba.get_cluster('{CLUSTER_NAME}').status().__repr__() + '</CLUSTER_STATUS>')\"",
+    ]
+    raw_output = await run_command_on_unit(unit, " ".join(commands))
+    if not raw_output:
+        return None
+
+    matches = re.search("<CLUSTER_STATUS>(.+)</CLUSTER_STATUS>", raw_output)
+    if not matches:
+        return None
+
+    cluster_status = json.loads(matches.group(1).strip())
+
+    primary_name = [
+        label
+        for label, member in cluster_status["defaultReplicaSet"]["topology"].items()
+        if member["mode"] == "R/W"
+    ][0].replace("-", "/")
+
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if unit.name == primary_name:
+            return unit
+
+    return None
+
+
+async def get_server_config_credentials(unit: Unit) -> Dict:
+    """Helper to run an action to retrieve server config credentials.
+
+    Args:
+        unit: The juju unit on which to run the get-server-config-credentials action
+
+    Returns:
+        A dictionary with the server config username and password
+    """
+    action = await unit.run_action("get-server-config-credentials")
+    result = await action.wait()
+
+    return {
+        "username": result.results["server-config-username"],
+        "password": result.results["server-config-password"],
+    }

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -26,7 +26,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     """
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=1)
+    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
 
     # Issuing dummy update_status just to trigger an event
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
@@ -37,8 +37,10 @@ async def test_build_and_deploy(ops_test: OpsTest):
         raise_on_blocked=True,
         timeout=1000,
     )
-    assert len(ops_test.model.applications[APP_NAME].units) == 1
+    assert len(ops_test.model.applications[APP_NAME].units) == 3
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+    assert ops_test.model.applications[APP_NAME].units[1].workload_status == "active"
+    assert ops_test.model.applications[APP_NAME].units[2].workload_status == "active"
 
     # Effectively disable the update status from firing
     await ops_test.model.set_config({"update-status-hook-interval": "60m"})

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -498,11 +498,13 @@ class TestMySQL(unittest.TestCase):
         result = self.mysql.is_instance_in_cluster("mysql-0")
         self.assertTrue(result)
 
-        expected_commands = "\n".join([
-            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-            "cluster = dba.get_cluster('test_cluster')",
-            "print(cluster.status()['defaultReplicaSet']['topology'].get('mysql-0', {}).get('status', 'NOT_A_MEMBER'))",
-        ])
+        expected_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "cluster = dba.get_cluster('test_cluster')",
+                "print(cluster.status()['defaultReplicaSet']['topology'].get('mysql-0', {}).get('status', 'NOT_A_MEMBER'))",
+            ]
+        )
         _run_mysqlsh_script.assert_called_once_with(expected_commands)
 
         _run_mysqlsh_script.return_value = "NOT_A_MEMBER"

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ deps =
     pytest
     juju
     pytest-operator
+    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
# Issue
- Non-leader units are not moved from `WaitingStatus` to `ActiveStatus` when the unit joins a cluster
- We do not have actions to retrieve either `cluster admin` or `server config` credentials
- We do not have integration tests for scaling up+down and replication

# Solution
- Move non-leader units from `WaitingStatus` to `ActiveStatus` in the update-status event handler if the unit is part of the cluster
- Implement actions to retrieve `cluster admin` and `server config` credentials
- Implement integration tests for scaling up+down and replication

# Context
I am using an annotation `pytest.mark.order()` (provided by the `pytest-order` package) to serialize the integration tests in a specific order

# Release Notes
- Implement scaling and replication related integration tests
