### PR TITLE
Shared MySQL charm library

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -6,3 +6,9 @@ get-cluster-admin-credentials:
 
 get-server-config-credentials:
   description: Get the credentials for the server config user
+
+get-root-credentials:
+  description: Get the credentials for the root user
+
+get-cluster-status:
+  description: Get cluster status information without topology

--- a/actions.yaml
+++ b/actions.yaml
@@ -11,4 +11,4 @@ get-root-credentials:
   description: Get the credentials for the root user
 
 get-cluster-status:
-  description: Get cluster status information without topology
+  description: Get cluster status information

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -413,7 +413,7 @@ class MySQLBase(ABC):
         )
 
         try:
-            output = self._run_mysqlsh_script("\n".join(status_commands), verbose=0)
+            output = self._run_mysqlsh_script("\n".join(status_commands))
             output_dict = json.loads(output.lower())
             # pop topology from status due it being potentially too long
             # and containing keys with `:` in it

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1,0 +1,672 @@
+# Copyright 2022 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MySQL helper class and functions.
+
+The `mysql` module provides an abstraction class for common methods for
+managing a Group Replication enabled MySQL cluster.
+
+The `MySQL` class must be inherited and have abstract methods defined for
+each platform (vm/k8s). Platform specific methods must be defined in the
+inherited concrete class.
+
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+from abc import ABC, abstractmethod
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from typing import List, Tuple
+
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_fixed,
+    wait_random,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# The unique Charmhub library identifier, never change it
+LIBID = "7c3dbc9c2ad44a47bd6fcb25caa270e5"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 0
+
+
+# TODO: determine if version locking is needed for both mysql-shell and mysql-server
+MYSQL_SHELL_SNAP_NAME = "mysql-shell"
+MYSQL_APT_PACKAGE_NAME = "mysql-server-8.0"
+MYSQL_SHELL_COMMON_DIRECTORY = "/root/snap/mysql-shell/common"
+MYSQLD_SOCK_FILE = "/var/run/mysqld/mysqld.sock"
+MYSQLD_CONFIG_DIRECTORY = "/etc/mysql/mysql.conf.d"
+
+UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
+
+
+class Error(Exception):
+    """Base class for exceptions in this module."""
+
+    def __repr__(self):
+        """String representation of the Error class."""
+        return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
+
+    @property
+    def name(self):
+        """Return a string representation of the model plus class."""
+        return "<{}.{}>".format(type(self).__module__, type(self).__name__)
+
+    @property
+    def message(self):
+        """Return the message passed as an argument."""
+        return self.args[0]
+
+
+class MySQLConfigureMySQLUsersError(Error):
+    """Exception raised when creating a user fails."""
+
+    pass
+
+
+class MySQLConfigureInstanceError(Error):
+    """Exception raised when there is an issue configuring a MySQL instance."""
+
+    pass
+
+
+class MySQLCreateClusterError(Error):
+    """Exception raised when there is an issue creating an InnoDB cluster."""
+
+    pass
+
+
+class MySQLAddInstanceToClusterError(Error):
+    """Exception raised when there is an issue add an instance to the MySQL InnoDB cluster."""
+
+    pass
+
+
+class MySQLRemoveInstanceRetryError(Error):
+    """Exception raised when there is an issue removing an instance.
+
+    Utilized by tenacity to retry the method.
+    """
+
+    pass
+
+
+class MySQLRemoveInstanceError(Error):
+    """Exception raised when there is an issue removing an instance.
+
+    Exempt from the retry mechanism provided by tenacity.
+    """
+
+
+class MySQLInitializeJujuOperationsTableError(Error):
+    """Exception raised when there is an issue initializing the juju units operations table."""
+
+    pass
+
+
+class MySQLClientError(Error):
+    """Exception raised when there is an issue using the mysql cli or mysqlsh.
+
+    Abstract platform specific exceptions for external commands execution Errors.
+    """
+
+    pass
+
+
+class MySQL(ABC):
+    """Abstract class to encapsulate all operations related to the MySQL instance and cluster.
+
+    This class handles the configuration of MySQL instances, and also the
+    creation and configuration of MySQL InnoDB clusters via Group Replication.
+    Some methods are platform specific and must be implemented in the related
+    charm code.
+    """
+
+    def __init__(
+        self,
+        instance_address: str,
+        cluster_name: str,
+        root_password: str,
+        server_config_user: str,
+        server_config_password: str,
+        cluster_admin_user: str,
+        cluster_admin_password: str,
+    ):
+        """Initialize the MySQL class.
+
+        Args:
+            instance_address: address of the targeted instance
+            cluster_name: cluster name
+            root_password: password for the 'root' user
+            server_config_user: user name for the server config user
+            server_config_password: password for the server config user
+            cluster_admin_user: user name for the cluster admin user
+            cluster_admin_password: password for the cluster admin user
+        """
+        self.instance_address = instance_address
+        self.cluster_name = cluster_name
+        self.root_password = root_password
+        self.server_config_user = server_config_user
+        self.server_config_password = server_config_password
+        self.cluster_admin_user = cluster_admin_user
+        self.cluster_admin_password = cluster_admin_password
+
+    def configure_mysql_users(self):
+        """Configure the MySQL users for the instance.
+
+        Creates base `root@%` and `<server_config>@%` users with the
+        appropriate privileges, and reconfigure `root@localhost` user password.
+
+        Raises MySQLConfigureMySQLUsersError if the user creation fails.
+        """
+        # SYSTEM_USER and SUPER privileges to revoke from the root users
+        # Reference: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super
+        privileges_to_revoke = (
+            "SYSTEM_USER",
+            "SYSTEM_VARIABLES_ADMIN",
+            "SUPER",
+            "REPLICATION_SLAVE_ADMIN",
+            "GROUP_REPLICATION_ADMIN",
+            "BINLOG_ADMIN",
+            "SET_USER_ID",
+            "ENCRYPTION_KEY_ADMIN",
+            "VERSION_TOKEN_ADMIN",
+            "CONNECTION_ADMIN",
+        )
+
+        # commands  to create 'root'@'%' user
+        create_root_user_commands = (
+            f"CREATE USER 'root'@'%' IDENTIFIED BY '{self.root_password}';",
+            "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
+        )
+
+        # commands to be run from mysql client with root user and password set above
+        configure_users_commands = (
+            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}';",
+            f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION;",
+            "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
+            f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}';",
+            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@'%';",
+            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@localhost;",
+            "FLUSH PRIVILEGES;",
+        )
+
+        try:
+            logger.debug(f"Configuring MySQL users for {self.instance_address}")
+            self._run_mysqlcli_script(" ".join(create_root_user_commands))
+            # run configure users commands with newly created root user
+            self._run_mysqlcli_script(
+                " ".join(configure_users_commands), password=self.root_password
+            )
+        except MySQLClientError as e:
+            logger.exception(
+                f"Failed to configure users for: {self.instance_address} with error {e.message}",
+                exc_info=e,
+            )
+            raise MySQLConfigureMySQLUsersError(e.message)
+
+    def configure_instance(self, restart: bool = True) -> None:
+        """Configure the instance to be used in an InnoDB cluster.
+
+        Raises MySQLConfigureInstanceError
+            if the was an error configuring the instance for use in an InnoDB cluster.
+        """
+        options = {
+            "clusterAdmin": self.cluster_admin_user,
+            "clusterAdminPassword": self.cluster_admin_password,
+            "restart": "true" if restart else "false",
+        }
+
+        configure_instance_command = (
+            f"dba.configure_instance('{self.server_config_user}:{self.server_config_password}@{self.instance_address}', {json.dumps(options)})",
+        )
+
+        try:
+            logger.debug(f"Configuring instance for InnoDB on {self.instance_address}")
+            self._run_mysqlsh_script("\n".join(configure_instance_command))
+
+        except MySQLClientError as e:
+            logger.exception(
+                f"Failed to configure instance: {self.instance_address} with error {e.message}",
+                exc_info=e,
+            )
+            raise MySQLConfigureInstanceError(e.message)
+
+    def create_cluster(self, unit_label: str) -> None:
+        """Create an InnoDB cluster with Group Replication enabled.
+
+        Raises MySQLCreateClusterError if there was an issue creating the cluster.
+        """
+        commands = (
+            f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
+            f"cluster = dba.create_cluster('{self.cluster_name}')",
+            f"cluster.set_instance_option('{self.instance_address}', 'label', '{unit_label}')",
+        )
+
+        try:
+            logger.debug(f"Creating a MySQL InnoDB cluster on {self.instance_address}")
+            self._run_mysqlsh_script("\n".join(commands))
+        except MySQLClientError as e:
+            logger.exception(
+                f"Failed to create cluster on instance: {self.instance_address} with error {e.message}",
+                exc_info=e,
+            )
+            raise MySQLCreateClusterError(e.message)
+
+    def initialize_juju_units_operations_table(self) -> None:
+        """Initialize the mysql.juju_units_operations table using the serverconfig user.
+
+        Raises
+            MySQLInitializeJujuOperationsTableError if there is an issue
+                initializing the juju_units_operations table
+        """
+        initalize_table_commands = (
+            "CREATE TABLE mysql.juju_units_operations (task varchar(20), executor varchar(20), status varchar(20), primary key(task));",
+            f"INSERT INTO mysql.juju_units_operations values ('{UNIT_TEARDOWN_LOCKNAME}', '', 'not-started');",
+        )
+
+        try:
+            logger.debug(
+                f"Initializing the juju_units_operations table on {self.instance_address}"
+            )
+
+            self._run_mysqlcli_script(
+                " ".join(initalize_table_commands),
+                user=self.server_config_user,
+                password=self.server_config_password,
+            )
+        except MySQLClientError as e:
+            logger.exception(
+                f"Failed to initialize mysql.juju_units_operations table with error {e.message}",
+                exc_info=e,
+            )
+            raise MySQLInitializeJujuOperationsTableError(e.message)
+
+    def add_instance_to_cluster(self, instance_address: str, instance_unit_label: str) -> None:
+        """Add an instance to the InnoDB cluster.
+
+        This method is only called from the juju leader unit (thus locks are
+        obtained locally)
+
+        Raises MySQLADDInstanceToClusterError
+            if there was an issue adding the instance to the cluster.
+
+        Args:
+            instance_address: address of the instance to add to the cluster
+            instance_unit_label: the label/name of the unit
+        """
+        options = {
+            "password": self.cluster_admin_password,
+            "label": instance_unit_label,
+        }
+
+        connect_commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"cluster = dba.get_cluster('{self.cluster_name}')",
+        )
+
+        for recovery_method in ["auto", "clone"]:
+            # Prefer "auto" recovery method, but if it fails, try "clone"
+            try:
+                options["recoveryMethod"] = recovery_method
+                add_instance_command = (
+                    f"cluster.add_instance('{self.cluster_admin_user}@{instance_address}', {json.dumps(options)})",
+                )
+
+                logger.debug(
+                    f"Adding instance {instance_address}/{instance_unit_label} to cluster {self.cluster_name} with recovery method {recovery_method}"
+                )
+                self._run_mysqlsh_script("\n".join(connect_commands + add_instance_command))
+
+                break
+            except MySQLClientError as e:
+                if recovery_method == "clone":
+                    logger.exception(
+                        f"Failed to add instance {instance_address} to cluster {self.cluster_name} on {self.instance_address}",
+                        exc_info=e,
+                    )
+                    raise MySQLAddInstanceToClusterError(e.message)
+
+                logger.debug(
+                    f"Failed to add instance {instance_address} to cluster {self.cluster_name} with recovery method 'auto'. Trying method 'clone'"
+                )
+
+    def is_instance_configured_for_innodb(
+        self, instance_address: str, instance_unit_label: str
+    ) -> bool:
+        """Confirm if instance is configured for use in an InnoDB cluster.
+
+        Args:
+            instance_address: The instance address for which to confirm InnoDB configuration
+            instance_unit_label: The label of the instance unit to confirm InnoDB configuration
+
+        Returns:
+            Boolean indicating whether the instance is configured for use in an InnoDB cluster
+        """
+        commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{instance_address}')",
+            "instance_configured = dba.check_instance_configuration()['status'] == 'ok'",
+            'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
+        )
+
+        try:
+            logger.debug(
+                f"Confirming instance {instance_address}/{instance_unit_label} configuration for InnoDB"
+            )
+
+            output = self._run_mysqlsh_script("\n".join(commands))
+            return "INSTANCE_CONFIGURED" in output
+        except MySQLClientError as e:
+            # confirmation can fail if the clusteradmin user does not yet exist on the instance
+            logger.warning(
+                f"Failed to confirm instance configuration for {instance_address} with error {e.message}",
+                exc_info=e,
+            )
+            return False
+
+    def is_instance_in_cluster(self, unit_label: str) -> bool:
+        """Confirm if instance is in the cluster.
+
+        Args:
+            unit_label: The label of unit to check existence in cluster for
+
+        Returns:
+            Boolean indicating whether the unit is a member of the cluster
+        """
+        commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"cluster = dba.get_cluster('{self.cluster_name}')",
+            f"print(cluster.status()['defaultReplicaSet']['topology'].get('{unit_label}', {{}}).get('status', 'NOT_A_MEMBER'))",
+        )
+
+        try:
+            logger.debug(f"Checking existence of unit {unit_label} in cluster {self.cluster_name}")
+
+            output = self._run_mysqlsh_script("\n".join(commands))
+            return "ONLINE" in output
+        except MySQLClientError:
+            # confirmation can fail if the clusteradmin user does not yet exist on the instance
+            logger.debug(
+                f"Failed to confirm existence of unit {unit_label} in cluster {self.cluster_name}"
+            )
+            return False
+
+    @retry(
+        retry=retry_if_exception_type(MySQLRemoveInstanceRetryError),
+        stop=stop_after_attempt(15),
+        reraise=True,
+        wait=wait_random(min=4, max=30),
+    )
+    def remove_instance(self, unit_label: str) -> None:
+        """Remove instance from the cluster.
+
+        This method is called from each unit being torn down, thus we must obtain
+        locks on the cluster primary. There is a retry mechanism for any issues
+        obtaining the lock, removing instances/dissolving the cluster, or releasing
+        the lock.
+
+        Raises:
+            MySQLRemoveInstanceRetryError - to retry this method if there was an issue
+                obtaining a lock or removing the instance
+            MySQLRemoveInstanceError - if there is an issue releasing
+                the lock after the instance is removed from the cluster (avoids retries)
+
+        Args:
+            unit_label: The label for this unit's instance (to be torn down)
+        """
+        try:
+            # Get the cluster primary's address to direct lock acquisition request to.
+            primary_address = self._get_cluster_primary_address()
+            if not primary_address:
+                raise MySQLRemoveInstanceRetryError(
+                    "Unable to retrieve the cluster primary's address"
+                )
+
+            # Attempt to acquire a lock on the primary instance
+            acquired_lock = self._acquire_lock(primary_address, unit_label, UNIT_TEARDOWN_LOCKNAME)
+            if not acquired_lock:
+                raise MySQLRemoveInstanceRetryError("Did not acquire lock to remove unit")
+
+            # Get remaining cluster member addresses before calling mysqlsh.remove_instance()
+            remaining_cluster_member_addresses, valid = self._get_cluster_member_addresses(
+                exclude_unit_labels=[unit_label]
+            )
+            if not valid:
+                raise MySQLRemoveInstanceRetryError("Unable to retrieve cluster member addresses")
+
+            # Remove instance from cluster, or dissolve cluster if no other members remain
+            logger.debug(
+                f"Removing instance {self.instance_address} from cluster {self.cluster_name}"
+            )
+            remove_instance_options = {
+                "password": self.cluster_admin_password,
+                "force": "true",
+            }
+            dissolve_cluster_options = {
+                "force": "true",
+            }
+            remove_instance_commands = (
+                f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+                f"cluster = dba.get_cluster('{self.cluster_name}')",
+                "number_cluster_members = len(cluster.status()['defaultReplicaSet']['topology'])",
+                f"cluster.remove_instance('{self.cluster_admin_user}@{self.instance_address}', {json.dumps(remove_instance_options)}) if number_cluster_members > 1 else cluster.dissolve({json.dumps(dissolve_cluster_options)})",
+            )
+            self._run_mysqlsh_script("\n".join(remove_instance_commands))
+        except MySQLClientError as e:
+            # In case of an error, raise an error and retry
+            logger.warning(
+                f"Failed to acquire lock and remove instance {self.instance_address} with error {e.message}",
+                exc_info=e,
+            )
+            raise MySQLRemoveInstanceRetryError(e.message)
+
+        # There is no need to release the lock if cluster was dissolved
+        if not remaining_cluster_member_addresses:
+            return
+
+        # The below code should not result in retries of this method since the
+        # instance would already be removed from the cluster.
+        try:
+            # Retrieve the cluster primary's address again (in case the old primary is scaled down)
+            # Release the lock by making a request to this primary member's address
+            primary_address = self._get_cluster_primary_address(
+                connect_instance_address=remaining_cluster_member_addresses[0]
+            )
+            if not primary_address:
+                raise MySQLRemoveInstanceError(
+                    "Unable to retrieve the address of the cluster primary"
+                )
+
+            self._release_lock(primary_address, unit_label, UNIT_TEARDOWN_LOCKNAME)
+        except MySQLClientError as e:
+            # Raise an error that does not lead to a retry of this method
+            logger.exception(
+                f"Failed to release lock on {unit_label} with error {e.message}", exc_info=e
+            )
+            raise MySQLRemoveInstanceError(e.message)
+
+    def _acquire_lock(self, primary_address: str, unit_label: str, lock_name: str) -> bool:
+        """Attempts to acquire a lock by using the mysql.juju_units_operations table.
+
+        Note that there must exist the appropriate rows in the table, created in the
+        initialize_juju_units_operations_table() method.
+
+        Args:
+            primary_address: The address of the cluster's primary
+            unit_label: The label of the unit for which to obtain the lock
+            lock_name: The name of the lock to obtain
+
+        Returns:
+            Boolean indicating whether the lock was obtained
+        """
+        logger.debug(
+            f"Attempting to acquire lock {lock_name} on {primary_address} for unit {unit_label}"
+        )
+
+        acquire_lock_commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{primary_address}')",
+            f"session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='{unit_label}', status='in-progress' WHERE task='{lock_name}' AND executor='';\")",
+            f"acquired_lock = session.run_sql(\"SELECT count(*) FROM mysql.juju_units_operations WHERE task='{lock_name}' AND executor='{unit_label}';\").fetch_one()[0]",
+            "print(f'<ACQUIRED_LOCK>{acquired_lock}</ACQUIRED_LOCK>')",
+        )
+
+        output = self._run_mysqlsh_script("\n".join(acquire_lock_commands))
+        matches = re.search(r"<ACQUIRED_LOCK>(\d)</ACQUIRED_LOCK>", output)
+        if not matches:
+            return False
+
+        return bool(int(matches.group(1)))
+
+    def _release_lock(self, primary_address: str, unit_label: str, lock_name: str) -> None:
+        """Releases a lock in the mysql.juju_units_operations table.
+
+        Note that there must exist the appropriate rows in the table, created in the
+        initialize_juju_units_operations_table() method.
+
+        Args:
+            primary_address: The address of the cluster's primary
+            unit_label: The label of the unit to release the lock for
+            lock_name: The name of the lock to release
+        """
+        logger.debug(f"Releasing lock {lock_name} on {primary_address} for unit {unit_label}")
+
+        release_lock_commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{primary_address}')",
+            f"session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='', status='not-started' WHERE task='{lock_name}' AND executor='{unit_label}';\")",
+        )
+        self._run_mysqlsh_script("\n".join(release_lock_commands))
+
+    def _get_cluster_member_addresses(self, exclude_unit_labels: List = []) -> Tuple[List, bool]:
+        """Get the addresses of the cluster's members.
+
+        Keyword args:
+            exclude_unit_labels: (Optional) unit labels to exclude when retrieving cluster members
+
+        Returns:
+            ([member_addresses], valid): a list of member addresses and
+                whether the method's execution was valid
+        """
+        logger.debug(f"Getting cluster member addresses, excluding units {exclude_unit_labels}")
+
+        get_cluster_members_commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"cluster = dba.get_cluster('{self.cluster_name}')",
+            f"member_addresses = ','.join([member['address'] for label, member in cluster.status()['defaultReplicaSet']['topology'].items() if label not in {exclude_unit_labels}])",
+            "print(f'<MEMBER_ADDRESSES>{member_addresses}</MEMBER_ADDRESSES>')",
+        )
+
+        output = self._run_mysqlsh_script("\n".join(get_cluster_members_commands))
+        matches = re.search(r"<MEMBER_ADDRESSES>(.*)</MEMBER_ADDRESSES>", output)
+
+        if not matches:
+            return ([], False)
+
+        # Filter out any empty values (in case there are no members)
+        member_addresses = [
+            member_address for member_address in matches.group(1).split(",") if member_address
+        ]
+
+        return (member_addresses, "<MEMBER_ADDRESSES>" in output)
+
+    def _get_cluster_primary_address(self, connect_instance_address: str = None) -> str:
+        """Get the cluster primary's address.
+
+        Keyword args:
+            connect_instance_address: The address for the cluster primary
+                (default to this instance's address)
+
+        Returns:
+            The address of the cluster's primary
+        """
+        logger.debug(f"Getting cluster primary member's address from {connect_instance_address}")
+
+        if not connect_instance_address:
+            connect_instance_address = self.instance_address
+
+        get_cluster_primary_commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{connect_instance_address}')",
+            f"cluster = dba.get_cluster('{self.cluster_name}')",
+            "primary_address = sorted([cluster_member['address'] for cluster_member in cluster.status()['defaultReplicaSet']['topology'].values() if cluster_member['mode'] == 'R/W'])[0]",
+            "print(f'<PRIMARY_ADDRESS>{primary_address}</PRIMARY_ADDRESS>')",
+        )
+
+        output = self._run_mysqlsh_script("\n".join(get_cluster_primary_commands))
+        matches = re.search(r"<PRIMARY_ADDRESS>(.+)</PRIMARY_ADDRESS>", output)
+
+        if not matches:
+            return None
+
+        return matches.group(1)
+
+    @abstractmethod
+    def wait_until_mysql_connection(self) -> None:
+        """Wait until a connection to MySQL has been obtained.
+
+        Implemented in subclasses, test for socket file existence.
+        """
+        pass
+
+    @abstractmethod
+    def _run_mysqlsh_script(self, script: str) -> str:
+        """Execute a MySQL shell script.
+
+        Raises MySQLClientError if script execution fails.
+
+        Args:
+            script: Mysqlsh script string
+
+        Returns:
+            String representing the output of the mysqlsh command
+        """
+        pass
+
+    @abstractmethod
+    def _run_mysqlcli_script(self, script: str, user: str = "root", password: str = None) -> None:
+        """Execute a MySQL CLI script.
+
+        Execute SQL script as instance with given user.
+
+        Raises MySQLClientError if script execution fails.
+
+        Args:
+            script: raw SQL script string
+            user: (optional) user to invoke the mysql cli script with (default is "root")
+            password: (optional) password to invoke the mysql cli script with
+        """
+        pass

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -119,7 +119,7 @@ class MySQLClientError(Error):
     pass
 
 
-class MySQL(ABC):
+class MySQLBase(ABC):
     """Abstract class to encapsulate all operations related to the MySQL instance and cluster.
 
     This class handles the configuration of MySQL instances, and also the

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -415,9 +415,6 @@ class MySQLBase(ABC):
         try:
             output = self._run_mysqlsh_script("\n".join(status_commands))
             output_dict = json.loads(output.lower())
-            # pop topology from status due it being potentially too long
-            # and containing keys with `:` in it
-            output_dict["defaultreplicaset"].pop("topology")
             return output_dict
         except MySQLClientError as e:
             logger.exception(f"Failed to get cluster status for {self.cluster_name}", exc_info=e)

--- a/src/charm.py
+++ b/src/charm.py
@@ -252,7 +252,7 @@ class MySQLOperatorCharm(CharmBase):
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
         """Get the cluster status without topology."""
-        event.set_results(self.mysql._get_cluster_status())
+        event.set_results(self._mysql.get_cluster_status())
 
     # =======================
     #  Helpers

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,12 @@ import logging
 import secrets
 import string
 
+from charms.mysql.v0.mysql import (
+    MySQLConfigureInstanceError,
+    MySQLConfigureMySQLUsersError,
+    MySQLCreateClusterError,
+    MySQLInitializeJujuOperationsTableError,
+)
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -18,13 +24,6 @@ from ops.charm import (
 )
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
-
-from charms.mysql.v0.mysql import (
-    MySQLConfigureInstanceError,
-    MySQLConfigureMySQLUsersError,
-    MySQLCreateClusterError,
-    MySQLInitializeJujuOperationsTableError,
-)
 
 from mysqlsh_helpers import MySQL
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,13 +19,14 @@ from ops.charm import (
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
-from mysqlsh_helpers import (
-    MySQL,
+from charms.mysql.v0.mysql import (
     MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
     MySQLCreateClusterError,
     MySQLInitializeJujuOperationsTableError,
 )
+
+from mysqlsh_helpers import MySQL
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,7 @@ class MySQLOperatorCharm(CharmBase):
         try:
             self._mysql.configure_mysql_users()
             self._mysql.configure_instance()
+            self._mysql.wait_until_mysql_connection()
         except MySQLConfigureMySQLUsersError:
             self.unit.status = BlockedStatus("Failed to initialize MySQL users")
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -251,7 +251,7 @@ class MySQLOperatorCharm(CharmBase):
         )
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
-        """Get the cluster status without topology."""
+        """Action used to retrieve the cluster status."""
         event.set_results(self._mysql.get_cluster_status())
 
     # =======================

--- a/src/charm.py
+++ b/src/charm.py
@@ -81,6 +81,8 @@ class MySQLOperatorCharm(CharmBase):
         self.framework.observe(
             self.on.get_server_config_credentials_action, self._on_get_server_config_credentials
         )
+        self.framework.observe(self.on.get_root_credentials_action, self._on_get_root_credentials)
+        self.framework.observe(self.on.get_cluster_status_action, self._get_cluster_status)
 
     # =======================
     #  Charm Lifecycle Hooks
@@ -236,6 +238,21 @@ class MySQLOperatorCharm(CharmBase):
                 ),
             }
         )
+
+    def _on_get_root_credentials(self, event: ActionEvent) -> None:
+        """Action used to retrieve the root credentials."""
+        event.set_results(
+            {
+                "root-username": "root",
+                "root-password": self._peers.data[self.app].get(
+                    "root-password", "<to_be_generated>"
+                ),
+            }
+        )
+
+    def _get_cluster_status(self, event: ActionEvent) -> None:
+        """Get the cluster status without topology."""
+        event.set_results(self.mysql._get_cluster_status())
 
     # =======================
     #  Helpers

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -4,26 +4,17 @@
 
 """Helper class to manage the MySQL InnoDB cluster lifecycle with MySQL Shell."""
 
-import json
 import logging
 import os
 import pathlib
-import re
 import shutil
 import subprocess
 import tempfile
-from typing import List, Tuple
 
+from charms.mysql.v0.mysql import Error, MySQLBase, MySQLClientError
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import snap
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    stop_after_delay,
-    wait_fixed,
-    wait_random,
-)
+from tenacity import retry, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
 
@@ -35,62 +26,14 @@ MYSQL_SHELL_COMMON_DIRECTORY = "/root/snap/mysql-shell/common"
 MYSQLD_SOCK_FILE = "/var/run/mysqld/mysqld.sock"
 MYSQLD_CONFIG_DIRECTORY = "/etc/mysql/mysql.conf.d"
 
-UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
-
-class MySQLConfigureMySQLUsersError(Exception):
-    """Exception raised when creating a user fails."""
-
-    pass
-
-
-class MySQLConfigureInstanceError(Exception):
-    """Exception raised when there is an issue configuring a MySQL instance."""
-
-    pass
-
-
-class MySQLCreateClusterError(Exception):
-    """Exception raised when there is an issue creating an InnoDB cluster."""
-
-    pass
-
-
-class MySQLAddInstanceToClusterError(Exception):
-    """Exception raised when there is an issue add an instance to the MySQL InnoDB cluster."""
-
-    pass
-
-
-class MySQLServiceNotRunningError(Exception):
+class MySQLServiceNotRunningError(Error):
     """Exception raised when the MySQL service is not running."""
 
     pass
 
 
-class MySQLRemoveInstanceRetryError(Exception):
-    """Exception raised when there is an issue removing an instance.
-
-    Utilized by tenacity to retry the method.
-    """
-
-    pass
-
-
-class MySQLRemoveInstanceError(Exception):
-    """Exception raised when there is an issue removing an instance.
-
-    Exempt from the retry mechanism provided by tenacity.
-    """
-
-
-class MySQLInitializeJujuOperationsTableError(Exception):
-    """Exception raised when there is an issue initializing the juju units operations table."""
-
-    pass
-
-
-class MySQL:
+class MySQL(MySQLBase):
     """Class to encapsulate all operations related to the MySQL instance and cluster.
 
     This class handles the configuration of MySQL instances, and also the
@@ -118,13 +61,15 @@ class MySQL:
             cluster_admin_user: user name for the cluster admin user
             cluster_admin_password: password for the cluster admin user
         """
-        self.instance_address = instance_address
-        self.cluster_name = cluster_name
-        self.root_password = root_password
-        self.server_config_user = server_config_user
-        self.server_config_password = server_config_password
-        self.cluster_admin_user = cluster_admin_user
-        self.cluster_admin_password = cluster_admin_password
+        super().__init__(
+            instance_address=instance_address,
+            cluster_name=cluster_name,
+            root_password=root_password,
+            server_config_user=server_config_user,
+            server_config_password=server_config_password,
+            cluster_admin_user=cluster_admin_user,
+            cluster_admin_password=cluster_admin_password,
+        )
 
     @staticmethod
     def get_mysqlsh_bin() -> str:
@@ -195,470 +140,8 @@ class MySQL:
             logger.exception("Encountered an unexpected exception", exc_info=e)
             raise
 
-    def configure_mysql_users(self):
-        """Configure the MySQL users for the instance.
-
-        Creates base `root@%` and `<server_config>@%` users with the
-        appropriate privileges, and reconfigure `root@localhost` user password.
-
-        Raises MySQLConfigureMySQLUsersError if the user creation fails.
-        """
-        # SYSTEM_USER and SUPER privileges to revoke from the root users
-        # Reference: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super
-        privileges_to_revoke = (
-            "SYSTEM_USER",
-            "SYSTEM_VARIABLES_ADMIN",
-            "SUPER",
-            "REPLICATION_SLAVE_ADMIN",
-            "GROUP_REPLICATION_ADMIN",
-            "BINLOG_ADMIN",
-            "SET_USER_ID",
-            "ENCRYPTION_KEY_ADMIN",
-            "VERSION_TOKEN_ADMIN",
-            "CONNECTION_ADMIN",
-        )
-
-        # commands  to create 'root'@'%' user
-        create_root_user_commands = (
-            f"CREATE USER 'root'@'%' IDENTIFIED BY '{self.root_password}';",
-            "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
-        )
-
-        # commands to be run from mysql client with root user and password set above
-        configure_users_commands = (
-            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}';",
-            f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION;",
-            "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
-            f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}';",
-            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@'%';",
-            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM root@localhost;",
-            "FLUSH PRIVILEGES;",
-        )
-
-        try:
-            logger.debug(f"Configuring MySQL users for {self.instance_address}")
-            self._run_mysqlcli_script(" ".join(create_root_user_commands))
-            # run configure users commands with newly created root user
-            self._run_mysqlcli_script(
-                " ".join(configure_users_commands), password=self.root_password
-            )
-        except subprocess.CalledProcessError as e:
-            logger.exception(
-                f"Failed to configure users for: {self.instance_address} with error {e.stderr}",
-                exc_info=e,
-            )
-            raise MySQLConfigureMySQLUsersError(e.stderr)
-
-    def configure_instance(self) -> None:
-        """Configure the instance to be used in an InnoDB cluster.
-
-        Raises MySQLConfigureInstanceError
-            if the was an error configuring the instance for use in an InnoDB cluster.
-        """
-        options = {
-            "clusterAdmin": self.cluster_admin_user,
-            "clusterAdminPassword": self.cluster_admin_password,
-            "restart": "true",
-        }
-
-        commands = (
-            f"dba.configure_instance('{self.server_config_user}:{self.server_config_password}@{self.instance_address}', {json.dumps(options)})",
-        )
-
-        try:
-            logger.debug(f"Configuring instance for InnoDB on {self.instance_address}")
-            self._run_mysqlsh_script("\n".join(commands))
-
-            logger.debug("Waiting until MySQL is restarted")
-            self._wait_until_mysql_connection()
-        except (subprocess.CalledProcessError, MySQLServiceNotRunningError) as e:
-            logger.exception(
-                f"Failed to configure instance: {self.instance_address} with error {e.stderr}",
-                exc_info=e,
-            )
-            raise MySQLConfigureInstanceError(e.stderr)
-
-    def create_cluster(self, unit_label) -> None:
-        """Create an InnoDB cluster with Group Replication enabled.
-
-        Raises MySQLCreateClusterError if there was an issue creating the cluster.
-        """
-        commands = (
-            f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
-            f"cluster = dba.create_cluster('{self.cluster_name}')",
-            f"cluster.set_instance_option('{self.instance_address}', 'label', '{unit_label}')",
-        )
-
-        try:
-            logger.debug(f"Creating a MySQL InnoDB cluster on {self.instance_address}")
-            self._run_mysqlsh_script("\n".join(commands))
-        except subprocess.CalledProcessError as e:
-            logger.exception(
-                f"Failed to create cluster on instance: {self.instance_address} with error {e.stderr}",
-                exc_info=e,
-            )
-            raise MySQLCreateClusterError(e.stderr)
-
-    def initialize_juju_units_operations_table(self) -> None:
-        """Initialize the mysql.juju_units_operations table using the serverconfig user.
-
-        Raises
-            MySQLInitializeJujuOperationsTableError if there is an issue
-                initializing the juju_units_opertions table
-        """
-        initalize_table_commands = (
-            "CREATE TABLE mysql.juju_units_operations (task varchar(20), executor varchar(20), status varchar(20), primary key(task));",
-            f"INSERT INTO mysql.juju_units_operations values ('{UNIT_TEARDOWN_LOCKNAME}', '', 'not-started');",
-        )
-
-        try:
-            logger.debug(
-                f"Initializing the juju_units_operations table on {self.instance_address}"
-            )
-
-            self._run_mysqlcli_script(
-                " ".join(initalize_table_commands),
-                user=self.server_config_user,
-                password=self.server_config_password,
-            )
-        except subprocess.CalledProcessError as e:
-            logger.exception(
-                f"Failed to initialize mysql.juju_units_operations table with error {e.stderr}",
-                exc_info=e,
-            )
-            raise MySQLInitializeJujuOperationsTableError(e.stderr)
-
-    def add_instance_to_cluster(self, instance_address, instance_unit_label) -> None:
-        """Add an instance to the InnoDB cluster.
-
-        This method is only called from the juju leader unit (thus locks are
-        obtained locally)
-
-        Raises MySQLADDInstanceToClusterError
-            if there was an issue adding the instance to the cluster.
-
-        Args:
-            instance_address: address of the instance to add to the cluster
-            instance_unit_label: the label/name of the unit
-        """
-        options = {
-            "password": self.cluster_admin_password,
-            "label": instance_unit_label,
-        }
-
-        connect_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            f"cluster = dba.get_cluster('{self.cluster_name}')",
-        )
-
-        for recovery_method in ["auto", "clone"]:
-            try:
-                options["recoveryMethod"] = recovery_method
-                add_instance_command = (
-                    f"cluster.add_instance('{self.cluster_admin_user}@{instance_address}', {json.dumps(options)})",
-                )
-
-                logger.debug(
-                    f"Adding instance {instance_address}/{instance_unit_label} to cluster {self.cluster_name} with recovery method {recovery_method}"
-                )
-                self._run_mysqlsh_script("\n".join(connect_commands + add_instance_command))
-
-                break
-            except subprocess.CalledProcessError as e:
-                if recovery_method == "clone":
-                    logger.exception(
-                        f"Failed to add instance {instance_address} to cluster {self.cluster_name} on {self.instance_address}",
-                        exc_info=e,
-                    )
-                    raise MySQLAddInstanceToClusterError(e.stderr)
-
-                logger.debug(
-                    f"Failed to add instance {instance_address} to cluster {self.cluster_name} with recovery method 'auto'. Trying method 'clone'"
-                )
-
-    def is_instance_configured_for_innodb(
-        self, instance_address: str, instance_unit_label: str
-    ) -> bool:
-        """Confirm if instance is configured for use in an InnoDB cluster.
-
-        Args:
-            instance_address: The instance address for which to confirm InnoDB configuration
-            instance_unit_label: The label of the instance unit to confirm InnoDB configuration
-
-        Returns:
-            Boolean indicating whether the instance is configured for use in an InnoDB cluster
-        """
-        commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{instance_address}')",
-            "instance_configured = dba.check_instance_configuration()['status'] == 'ok'",
-            'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
-        )
-
-        try:
-            logger.debug(
-                f"Confirming instance {instance_address}/{instance_unit_label} configuration for InnoDB"
-            )
-
-            output = self._run_mysqlsh_script("\n".join(commands))
-            return "INSTANCE_CONFIGURED" in output
-        except subprocess.CalledProcessError as e:
-            # confirmation can fail if the clusteradmin user does not yet exist on the instance
-            logger.warning(
-                f"Failed to confirm instance configuration for {instance_address} with error {e.stderr}",
-                exc_info=e,
-            )
-            return False
-
-    def is_instance_in_cluster(self, unit_label):
-        """Confirm if instance is in the cluster.
-
-        Args:
-            unit_label: The label of unit to check existence in cluster for
-
-        Returns:
-            Boolean indicating whether the unit is a member of the cluster
-        """
-        commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            f"cluster = dba.get_cluster('{self.cluster_name}')",
-            f"print(cluster.status()['defaultReplicaSet']['topology'].get('{unit_label}', {{}}).get('status', 'NOT_A_MEMBER'))",
-        )
-
-        try:
-            logger.debug(f"Checking existence of unit {unit_label} in cluster {self.cluster_name}")
-
-            output = self._run_mysqlsh_script("\n".join(commands))
-            return "ONLINE" in output
-        except subprocess.CalledProcessError:
-            # confirmation can fail if the clusteradmin user does not yet exist on the instance
-            logger.debug(
-                f"Failed to confirm existence of unit {unit_label} in cluster {self.cluster_name}"
-            )
-            return False
-
-    @retry(
-        retry=retry_if_exception_type(MySQLRemoveInstanceRetryError),
-        stop=stop_after_attempt(15),
-        reraise=True,
-        wait=wait_random(min=4, max=30),
-    )
-    def remove_instance(self, unit_label: str) -> None:
-        """Remove instance from the cluster.
-
-        This method is called from each unit being torn down, thus we must obtain
-        locks on the cluster primary. There is a retry mechanism for any issues
-        obtaining the lock, removing instances/dissolving the cluster, or releasing
-        the lock.
-
-        Raises:
-            MySQLRemoveInstanceRetryError - to retry this method if there was an issue
-                obtaining a lock or removing the instance
-            MySQLRemoveInstanceError - if there is an issue releasing
-                the lock after the instance is removed from the cluster (avoids retries)
-
-        Args:
-            unit_label: The label for this unit's instance (to be torn down)
-        """
-        try:
-            # Get the cluster primary's address to direct lock acquisition request to.
-            primary_address = self._get_cluster_primary_address()
-            if not primary_address:
-                raise MySQLRemoveInstanceRetryError(
-                    "Unable to retrieve the cluster primary's address"
-                )
-
-            # Attempt to acquire a lock on the primary instance
-            acquired_lock = self._acquire_lock(primary_address, unit_label, UNIT_TEARDOWN_LOCKNAME)
-            if not acquired_lock:
-                raise MySQLRemoveInstanceRetryError("Did not acquire lock to remove unit")
-
-            # Get remaining cluster member addresses before calling mysqlsh.remove_instance()
-            remaining_cluster_member_addresses, valid = self._get_cluster_member_addresses(
-                exclude_unit_labels=[unit_label]
-            )
-            if not valid:
-                raise MySQLRemoveInstanceRetryError("Unable to retrieve cluster member addresses")
-
-            # Remove instance from cluster, or dissolve cluster if no other members remain
-            logger.debug(
-                f"Removing instance {self.instance_address} from cluster {self.cluster_name}"
-            )
-            remove_instance_options = {
-                "password": self.cluster_admin_password,
-                "force": "true",
-            }
-            dissolve_cluster_options = {
-                "force": "true",
-            }
-            remove_instance_commands = (
-                f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-                f"cluster = dba.get_cluster('{self.cluster_name}')",
-                "number_cluster_members = len(cluster.status()['defaultReplicaSet']['topology'])",
-                f"cluster.remove_instance('{self.cluster_admin_user}@{self.instance_address}', {json.dumps(remove_instance_options)}) if number_cluster_members > 1 else cluster.dissolve({json.dumps(dissolve_cluster_options)})",
-            )
-            self._run_mysqlsh_script("\n".join(remove_instance_commands))
-        except subprocess.CalledProcessError as e:
-            # In case of an error, raise an error and retry
-            logger.warning(
-                f"Failed to acquire lock and remove instance {self.instance_address} with error {e.stderr}",
-                exc_info=e,
-            )
-            raise MySQLRemoveInstanceRetryError(e.stderr)
-
-        # There is no need to release the lock if cluster was dissolved
-        if not remaining_cluster_member_addresses:
-            return
-
-        # The below code should not result in retries of this method since the
-        # instance would already be removed from the cluster.
-        try:
-            # Retrieve the cluster primary's address again (in case the old primary is scaled down)
-            # Release the lock by making a request to this primary member's address
-            primary_address = self._get_cluster_primary_address(
-                connect_instance_address=remaining_cluster_member_addresses[0]
-            )
-            if not primary_address:
-                raise MySQLRemoveInstanceError(
-                    "Unable to retrieve the address of the cluster primary"
-                )
-
-            self._release_lock(primary_address, unit_label, UNIT_TEARDOWN_LOCKNAME)
-        except subprocess.CalledProcessError as e:
-            # Raise an error that does not lead to a retry of this method
-            logger.exception(
-                f"Failed to release lock on {unit_label} with error {e.stderr}", exc_info=e
-            )
-            raise MySQLRemoveInstanceError(e.stderr)
-
-    def _acquire_lock(self, primary_address: str, unit_label: str, lock_name: str) -> bool:
-        """Attempts to acquire a lock by using the mysql.juju_units_operations table.
-
-        Note that there must exist the appropriate rows in the table, created in the
-        initialize_juju_units_operations_table() method.
-
-        Args:
-            primary_address: The address of the cluster's primary
-            unit_label: The label of the unit for which to obtain the lock
-            lock_name: The name of the lock to obtain
-
-        Raises:
-            subprocess.CalledProcessError if there's an issue acquiring the lock
-
-        Returns:
-            Boolean indicating whether the lock was obtained
-        """
-        logger.debug(
-            f"Attempting to acquire lock {lock_name} on {primary_address} for unit {unit_label}"
-        )
-
-        acquire_lock_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{primary_address}')",
-            f"session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='{unit_label}', status='in-progress' WHERE task='{lock_name}' AND executor='';\")",
-            f"acquired_lock = session.run_sql(\"SELECT count(*) FROM mysql.juju_units_operations WHERE task='{lock_name}' AND executor='{unit_label}';\").fetch_one()[0]",
-            "print(f'<ACQUIRED_LOCK>{acquired_lock}</ACQUIRED_LOCK>')",
-        )
-
-        output = self._run_mysqlsh_script("\n".join(acquire_lock_commands))
-        matches = re.search(r"<ACQUIRED_LOCK>(\d)</ACQUIRED_LOCK>", output)
-        if not matches:
-            return False
-
-        return bool(int(matches.group(1)))
-
-    def _release_lock(self, primary_address: str, unit_label: str, lock_name: str) -> None:
-        """Releases a lock in the mysql.juju_units_operations table.
-
-        Note that there must exist the appropriate rows in the table, created in the
-        initialize_juju_units_operations_table() method.
-
-        Args:
-            primary_address: The address of the cluster's primary
-            unit_label: The label of the unit to release the lock for
-            lock_name: The name of the lock to release
-
-        Raises:
-            subprocess.CalledProcessError if there's an issue releasing the lock
-        """
-        logger.debug(f"Releasing lock {lock_name} on {primary_address} for unit {unit_label}")
-
-        release_lock_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{primary_address}')",
-            f"session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='', status='not-started' WHERE task='{lock_name}' AND executor='{unit_label}';\")",
-        )
-        self._run_mysqlsh_script("\n".join(release_lock_commands))
-
-    def _get_cluster_member_addresses(self, exclude_unit_labels: List = []) -> Tuple[List, bool]:
-        """Get the addresses of the cluster's members.
-
-        Keyword args:
-            exclude_unit_labels: (Optional) unit labels to exclude when retrieving cluster members
-
-        Raises:
-            subprocess.CalledProcessError if there is an issue getting cluster
-                members' addresses
-
-        Returns:
-            ([member_addresses], valid): a list of member addresses and
-                whether the method's execution was valid
-        """
-        logger.debug(f"Getting cluster member addresses, excluding units {exclude_unit_labels}")
-
-        get_cluster_members_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            f"cluster = dba.get_cluster('{self.cluster_name}')",
-            f"member_addresses = ','.join([member['address'] for label, member in cluster.status()['defaultReplicaSet']['topology'].items() if label not in {exclude_unit_labels}])",
-            "print(f'<MEMBER_ADDRESSES>{member_addresses}</MEMBER_ADDRESSES>')",
-        )
-
-        output = self._run_mysqlsh_script("\n".join(get_cluster_members_commands))
-        matches = re.search(r"<MEMBER_ADDRESSES>(.*)</MEMBER_ADDRESSES>", output)
-
-        if not matches:
-            return ([], False)
-
-        # Filter out any empty values (in case there are no members)
-        member_addresses = [
-            member_address for member_address in matches.group(1).split(",") if member_address
-        ]
-
-        return (member_addresses, "<MEMBER_ADDRESSES>" in output)
-
-    def _get_cluster_primary_address(self, connect_instance_address: str = None) -> str:
-        """Get the cluster primary's address.
-
-        Keyword args:
-            connect_instance_address: The address for the cluster primary
-                (default to this instance's address)
-
-        Raises:
-            subprocess.CalledProcessError if there is an issue retrieving the
-                cluster primary's address
-
-        Returns:
-            The address of the cluster's primary
-        """
-        logger.debug(f"Getting cluster primary member's address from {connect_instance_address}")
-
-        if not connect_instance_address:
-            connect_instance_address = self.instance_address
-
-        get_cluster_primary_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{connect_instance_address}')",
-            f"cluster = dba.get_cluster('{self.cluster_name}')",
-            "primary_address = sorted([cluster_member['address'] for cluster_member in cluster.status()['defaultReplicaSet']['topology'].values() if cluster_member['mode'] == 'R/W'])[0]",
-            "print(f'<PRIMARY_ADDRESS>{primary_address}</PRIMARY_ADDRESS>')",
-        )
-
-        output = self._run_mysqlsh_script("\n".join(get_cluster_primary_commands))
-        matches = re.search(r"<PRIMARY_ADDRESS>(.+)</PRIMARY_ADDRESS>", output)
-
-        if not matches:
-            return None
-
-        return matches.group(1)
-
     @retry(reraise=True, stop=stop_after_delay(30), wait=wait_fixed(5))
-    def _wait_until_mysql_connection(self) -> None:
+    def wait_until_mysql_connection(self) -> None:
         """Wait until a connection to MySQL has been obtained.
 
         Retry every 5 seconds for 30 seconds if there is an issue obtaining a connection.
@@ -685,7 +168,11 @@ class MySQL:
             # Specify python as this is not the default in the deb version
             # of the mysql-shell snap
             command = [MySQL.get_mysqlsh_bin(), "--no-wizard", "--python", "-f", _file.name]
-            return subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")
+
+            try:
+                return subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")
+            except subprocess.CalledProcessError as e:
+                raise MySQLClientError(e.stderr)
 
     def _run_mysqlcli_script(self, script: str, user: str = "root", password: str = None) -> None:
         """Execute a MySQL CLI script.
@@ -711,4 +198,7 @@ class MySQL:
         if password:
             command.append(f"--password={password}")
 
-        subprocess.check_output(command, stderr=subprocess.PIPE)
+        try:
+            subprocess.check_output(command, stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            raise MySQLClientError(e.stderr)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,9 +9,10 @@ import secrets
 import string
 from typing import Dict, List, Optional
 
-import mysql.connector
 from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
+
+import mysql.connector
 
 
 async def run_command_on_unit(unit, command: str) -> Optional[str]:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,10 +9,9 @@ import secrets
 import string
 from typing import Dict, List, Optional
 
+import mysql.connector
 from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
-
-import mysql.connector
 
 
 async def run_command_on_unit(unit, command: str) -> Optional[str]:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,16 +4,16 @@
 import unittest
 from unittest.mock import patch
 
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
-from ops.testing import Harness
-
-from charm import MySQLOperatorCharm
 from charms.mysql.v0.mysql import (
     MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
     MySQLCreateClusterError,
     MySQLInitializeJujuOperationsTableError,
 )
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.testing import Harness
+
+from charm import MySQLOperatorCharm
 from tests.unit.helpers import patch_network_get
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import MySQLOperatorCharm
-from mysqlsh_helpers import (
+from charms.mysql.v0.mysql import (
     MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
     MySQLCreateClusterError,
@@ -100,6 +100,7 @@ class TestCharm(unittest.TestCase):
         self.assertIsNotNone(peer_relation_databag["cluster-name"])
 
     @patch_network_get(private_address="1.1.1.1")
+    @patch("mysqlsh_helpers.MySQL.wait_until_mysql_connection")
     @patch("mysqlsh_helpers.MySQL.configure_mysql_users")
     @patch("mysqlsh_helpers.MySQL.configure_instance")
     @patch("mysqlsh_helpers.MySQL.initialize_juju_units_operations_table")
@@ -110,6 +111,7 @@ class TestCharm(unittest.TestCase):
         _initialize_juju_units_operations_table,
         _configure_instance,
         _configure_mysql_users,
+        _wait_until_mysql_connection,
     ):
         # execute on_leader_elected and config_changed to populate the peer databag
         self.harness.set_leader(True)

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -1,0 +1,511 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit test for MySQL shared library."""
+
+import unittest
+from unittest.mock import call, patch
+
+import tenacity
+from charms.mysql.v0.mysql import (
+    MySQLAddInstanceToClusterError,
+    MySQLBase,
+    MySQLClientError,
+    MySQLConfigureInstanceError,
+    MySQLConfigureMySQLUsersError,
+    MySQLCreateClusterError,
+    MySQLInitializeJujuOperationsTableError,
+    MySQLRemoveInstanceError,
+    MySQLRemoveInstanceRetryError,
+)
+
+
+class TestMySQLBase(unittest.TestCase):
+    # Patch abstract methods so it's
+    # possible to instantiate abstract class.
+    @patch.multiple(MySQLBase, __abstractmethods__=set())
+    def setUp(self):
+        self.mysql = MySQLBase(
+            "127.0.0.1",
+            "test_cluster",
+            "password",
+            "serverconfig",
+            "serverconfigpassword",
+            "clusteradmin",
+            "clusteradminpassword",
+        )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_configure_mysql_users(self, mock_run_mysqlcli_script):
+        """Test failed to configuring the MySQL users."""
+        mock_run_mysqlcli_script.return_value = b""
+
+        _expected_create_root_user_commands = " ".join(
+            (
+                "CREATE USER 'root'@'%' IDENTIFIED BY 'password';",
+                "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
+            )
+        )
+
+        _expected_configure_user_commands = " ".join(
+            (
+                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';",
+                "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;",
+                "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
+                "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';",
+                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@'%';",
+                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@localhost;",
+                "FLUSH PRIVILEGES;",
+            )
+        )
+
+        self.mysql.configure_mysql_users()
+
+        self.assertEqual(mock_run_mysqlcli_script.call_count, 2)
+
+        self.assertEqual(
+            sorted(mock_run_mysqlcli_script.mock_calls),
+            sorted(
+                [
+                    call(_expected_create_root_user_commands),
+                    call(_expected_configure_user_commands, password="password"),
+                ]
+            ),
+        )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_configure_mysql_users_fail(self, _run_mysqlcli_script):
+        """Test failed to configuring the MySQL users."""
+        _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLConfigureMySQLUsersError):
+            self.mysql.configure_mysql_users()
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    @patch("charms.mysql.v0.mysql.MySQLBase.wait_until_mysql_connection")
+    def test_configure_instance(self, _wait_until_mysql_connection, _run_mysqlsh_script):
+        """Test a successful execution of configure_instance."""
+        configure_instance_commands = (
+            'dba.configure_instance(\'serverconfig:serverconfigpassword@127.0.0.1\', {"clusterAdmin": "clusteradmin", "clusterAdminPassword": "clusteradminpassword", "restart": "true"})',
+        )
+
+        self.mysql.configure_instance()
+
+        _run_mysqlsh_script.assert_called_once_with("\n".join(configure_instance_commands))
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    @patch("charms.mysql.v0.mysql.MySQLBase.wait_until_mysql_connection")
+    def test_configure_instance_exceptions(
+        self, _wait_until_mysql_connection, _run_mysqlsh_script
+    ):
+        """Test exceptions raise while running configure_instance."""
+        # Test an issue with _run_mysqlsh_script
+        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLConfigureInstanceError):
+            self.mysql.configure_instance()
+
+        _wait_until_mysql_connection.assert_not_called()
+
+        # Reset mocks
+        _run_mysqlsh_script.reset_mock()
+        _wait_until_mysql_connection.reset_mock()
+
+        # Test an issue with _wait_until_mysql_connection
+        _wait_until_mysql_connection.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLConfigureInstanceError):
+            self.mysql.configure_instance()
+
+        _run_mysqlsh_script.assert_called_once()
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_initialize_juju_units_operations_table(self, _run_mysqlcli_script):
+        """Test a successful initialization of the mysql.juju_units_operations table."""
+        expected_initialize_table_commands = (
+            "CREATE TABLE mysql.juju_units_operations (task varchar(20), executor varchar(20), status varchar(20), primary key(task));",
+            "INSERT INTO mysql.juju_units_operations values ('unit-teardown', '', 'not-started');",
+        )
+
+        self.mysql.initialize_juju_units_operations_table()
+
+        _run_mysqlcli_script.assert_called_once_with(
+            " ".join(expected_initialize_table_commands),
+            user="serverconfig",
+            password="serverconfigpassword",
+        )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_initialize_juju_units_operations_table_exception(self, _run_mysqlcli_script):
+        """Test an exception initialization of the mysql.juju_units_operations table."""
+        _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLInitializeJujuOperationsTableError):
+            self.mysql.initialize_juju_units_operations_table()
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_create_cluster(self, _run_mysqlsh_script):
+        """Test a successful execution of create_cluster."""
+        create_cluster_commands = (
+            "shell.connect('serverconfig:serverconfigpassword@127.0.0.1')",
+            "cluster = dba.create_cluster('test_cluster')",
+            "cluster.set_instance_option('127.0.0.1', 'label', 'mysql-0')",
+        )
+
+        self.mysql.create_cluster("mysql-0")
+
+        _run_mysqlsh_script.assert_called_once_with("\n".join(create_cluster_commands))
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_create_cluster_exceptions(self, _run_mysqlsh_script):
+        """Test exceptions raised while running create_cluster."""
+        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLCreateClusterError):
+            self.mysql.create_cluster("mysql-0")
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_add_instance_to_cluster(self, _run_mysqlsh_script):
+        """Test a successful execution of create_cluster."""
+        add_instance_to_cluster_commands = (
+            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+            "cluster = dba.get_cluster('test_cluster')",
+            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "label": "mysql-1", "recoveryMethod": "auto"})',
+        )
+
+        self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
+
+        _run_mysqlsh_script.assert_called_once_with("\n".join(add_instance_to_cluster_commands))
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_add_instance_to_cluster_exception(self, _run_mysqlsh_script):
+        """Test exceptions raised while running add_instance_to_cluster."""
+        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLAddInstanceToClusterError):
+            self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
+
+    @patch(
+        "charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script", return_value="INSTANCE_CONFIGURED"
+    )
+    def test_is_instance_configured_for_innodb(self, _run_mysqlsh_script):
+        """Test with no exceptions while calling the is_instance_configured_for_innodb method."""
+        # test successfully configured instance
+        check_instance_configuration_commands = (
+            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.2')",
+            "instance_configured = dba.check_instance_configuration()['status'] == 'ok'",
+            'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
+        )
+
+        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
+            "127.0.0.2", "mysql-1"
+        )
+
+        _run_mysqlsh_script.assert_called_once_with(
+            "\n".join(check_instance_configuration_commands)
+        )
+        self.assertTrue(is_instance_configured)
+
+        # reset mocks
+        _run_mysqlsh_script.reset_mock()
+
+        # test instance not configured for innodb
+        _run_mysqlsh_script.return_value = "INSTANCE_NOT_CONFIGURED"
+
+        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
+            "127.0.0.2", "mysql-1"
+        )
+
+        _run_mysqlsh_script.assert_called_once_with(
+            "\n".join(check_instance_configuration_commands)
+        )
+        self.assertFalse(is_instance_configured)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_is_instance_configured_for_innodb_exceptions(self, _run_mysqlsh_script):
+        """Test an exception while calling the is_instance_configured_for_innodb method."""
+        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
+
+        check_instance_configuration_commands = (
+            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.2')",
+            "instance_configured = dba.check_instance_configuration()['status'] == 'ok'",
+            'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
+        )
+
+        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
+            "127.0.0.2", "mysql-1"
+        )
+
+        _run_mysqlsh_script.assert_called_once_with(
+            "\n".join(check_instance_configuration_commands)
+        )
+        self.assertFalse(is_instance_configured)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._get_cluster_primary_address")
+    @patch("charms.mysql.v0.mysql.MySQLBase._acquire_lock")
+    @patch("charms.mysql.v0.mysql.MySQLBase._get_cluster_member_addresses")
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    @patch("charms.mysql.v0.mysql.MySQLBase._release_lock")
+    def test_remove_primary_instance(
+        self,
+        _release_lock,
+        _run_mysqlsh_script,
+        _get_cluster_member_addresses,
+        _acquire_lock,
+        _get_cluster_primary_address,
+    ):
+        """Test with no exceptions while running the remove_instance() method."""
+        _get_cluster_primary_address.side_effect = ["1.1.1.1", "2.2.2.2"]
+        _acquire_lock.return_value = True
+        _get_cluster_member_addresses.return_value = ("2.2.2.2", True)
+
+        self.mysql.remove_instance("mysql-0")
+
+        expected_remove_instance_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "cluster = dba.get_cluster('test_cluster')",
+                "number_cluster_members = len(cluster.status()['defaultReplicaSet']['topology'])",
+                'cluster.remove_instance(\'clusteradmin@127.0.0.1\', {"password": "clusteradminpassword", "force": "true"}) if number_cluster_members > 1 else cluster.dissolve({"force": "true"})',
+            ]
+        )
+
+        self.assertEqual(_get_cluster_primary_address.call_count, 2)
+        _acquire_lock.assert_called_once_with("1.1.1.1", "mysql-0", "unit-teardown")
+        _get_cluster_member_addresses.assert_called_once_with(exclude_unit_labels=["mysql-0"])
+        _run_mysqlsh_script.assert_called_once_with(expected_remove_instance_commands)
+        _release_lock.assert_called_once_with("2.2.2.2", "mysql-0", "unit-teardown")
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._get_cluster_primary_address")
+    @patch("charms.mysql.v0.mysql.MySQLBase._acquire_lock")
+    @patch("charms.mysql.v0.mysql.MySQLBase._get_cluster_member_addresses")
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    @patch("charms.mysql.v0.mysql.MySQLBase._release_lock")
+    def test_remove_primary_instance_error_acquiring_lock(
+        self,
+        _release_lock,
+        _run_mysqlsh_script,
+        _get_cluster_member_addresses,
+        _acquire_lock,
+        _get_cluster_primary_address,
+    ):
+        """Test an issue acquiring lock while running the remove_instance() method."""
+        _get_cluster_primary_address.side_effect = ["1.1.1.1", "2.2.2.2"]
+        _acquire_lock.return_value = False
+
+        # disable tenacity retry
+        self.mysql.remove_instance.retry.retry = tenacity.retry_if_not_result(lambda x: True)
+
+        with self.assertRaises(MySQLRemoveInstanceRetryError):
+            self.mysql.remove_instance("mysql-0")
+
+        self.assertEqual(_get_cluster_primary_address.call_count, 1)
+        _acquire_lock.assert_called_once_with("1.1.1.1", "mysql-0", "unit-teardown")
+        _get_cluster_member_addresses.assert_not_called()
+        _run_mysqlsh_script.assert_not_called()
+        _release_lock.assert_not_called()
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._get_cluster_primary_address")
+    @patch("charms.mysql.v0.mysql.MySQLBase._acquire_lock")
+    @patch("charms.mysql.v0.mysql.MySQLBase._get_cluster_member_addresses")
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    @patch("charms.mysql.v0.mysql.MySQLBase._release_lock")
+    def test_remove_primary_instance_error_releasing_lock(
+        self,
+        _release_lock,
+        _run_mysqlsh_script,
+        _get_cluster_member_addresses,
+        _acquire_lock,
+        _get_cluster_primary_address,
+    ):
+        """Test an issue releasing locks while running the remove_instance() method."""
+        _get_cluster_primary_address.side_effect = ["1.1.1.1", "2.2.2.2"]
+        _acquire_lock.return_value = True
+        _get_cluster_member_addresses.return_value = ("2.2.2.2", True)
+        _release_lock.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLRemoveInstanceError):
+            self.mysql.remove_instance("mysql-0")
+
+        expected_remove_instance_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "cluster = dba.get_cluster('test_cluster')",
+                "number_cluster_members = len(cluster.status()['defaultReplicaSet']['topology'])",
+                'cluster.remove_instance(\'clusteradmin@127.0.0.1\', {"password": "clusteradminpassword", "force": "true"}) if number_cluster_members > 1 else cluster.dissolve({"force": "true"})',
+            ]
+        )
+
+        self.assertEqual(_get_cluster_primary_address.call_count, 2)
+        _acquire_lock.assert_called_once_with("1.1.1.1", "mysql-0", "unit-teardown")
+        _get_cluster_member_addresses.assert_called_once_with(exclude_unit_labels=["mysql-0"])
+        _run_mysqlsh_script.assert_called_once_with(expected_remove_instance_commands)
+        _release_lock.assert_called_once_with("2.2.2.2", "mysql-0", "unit-teardown")
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_acquire_lock(self, _run_mysqlsh_script):
+        """Test a successful execution of _acquire_lock()."""
+        _run_mysqlsh_script.return_value = "<ACQUIRED_LOCK>1</ACQUIRED_LOCK>"
+
+        acquired_lock = self.mysql._acquire_lock("1.1.1.1", "mysql-0", "unit-teardown")
+
+        self.assertTrue(acquired_lock)
+
+        expected_acquire_lock_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@1.1.1.1')",
+                "session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='mysql-0', status='in-progress' WHERE task='unit-teardown' AND executor='';\")",
+                "acquired_lock = session.run_sql(\"SELECT count(*) FROM mysql.juju_units_operations WHERE task='unit-teardown' AND executor='mysql-0';\").fetch_one()[0]",
+                "print(f'<ACQUIRED_LOCK>{acquired_lock}</ACQUIRED_LOCK>')",
+            ]
+        )
+        _run_mysqlsh_script.assert_called_once_with(expected_acquire_lock_commands)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_unable_to_acquire_lock(self, _run_mysqlsh_script):
+        """Test a successful execution of _acquire_lock() but failure to acquire lock."""
+        _run_mysqlsh_script.return_value = "<ACQUIRED_LOCK>0</ACQUIRED_LOCK>"
+
+        acquired_lock = self.mysql._acquire_lock("1.1.1.1", "mysql-0", "unit-teardown")
+
+        self.assertFalse(acquired_lock)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_issue_with_acquire_lock(self, _run_mysqlsh_script):
+        """Test an issue while executing _acquire_lock()."""
+        _run_mysqlsh_script.return_value = ""
+
+        acquired_lock = self.mysql._acquire_lock("1.1.1.1", "mysql-0", "unit-teardown")
+
+        self.assertFalse(acquired_lock)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_release_lock(self, _run_mysqlsh_script):
+        """Test a successful execution of _acquire_lock()."""
+        self.mysql._release_lock("2.2.2.2", "mysql-0", "unit-teardown")
+
+        expected_release_lock_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@2.2.2.2')",
+                "session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='', status='not-started' WHERE task='unit-teardown' AND executor='mysql-0';\")",
+            ]
+        )
+        _run_mysqlsh_script.assert_called_once_with(expected_release_lock_commands)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_get_cluster_member_addresses(self, _run_mysqlsh_script):
+        """Test a successful execution of _get_cluster_member_addresses()."""
+        _run_mysqlsh_script.return_value = "<MEMBER_ADDRESSES>1.1.1.1,2.2.2.2</MEMBER_ADDRESSES>"
+
+        cluster_members, valid = self.mysql._get_cluster_member_addresses(
+            exclude_unit_labels=["mysql-0"]
+        )
+
+        self.assertEqual(cluster_members, ["1.1.1.1", "2.2.2.2"])
+        self.assertTrue(valid)
+
+        expected_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "cluster = dba.get_cluster('test_cluster')",
+                "member_addresses = ','.join([member['address'] for label, member in cluster.status()['defaultReplicaSet']['topology'].items() if label not in ['mysql-0']])",
+                "print(f'<MEMBER_ADDRESSES>{member_addresses}</MEMBER_ADDRESSES>')",
+            ]
+        )
+        _run_mysqlsh_script.assert_called_once_with(expected_commands)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_empty_get_cluster_member_addresses(self, _run_mysqlsh_script):
+        """Test successful execution of _get_cluster_member_addresses() with empty return value."""
+        _run_mysqlsh_script.return_value = "<MEMBER_ADDRESSES></MEMBER_ADDRESSES>"
+
+        cluster_members, valid = self.mysql._get_cluster_member_addresses(
+            exclude_unit_labels=["mysql-0"]
+        )
+
+        self.assertEqual(cluster_members, [])
+        self.assertTrue(valid)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_error_get_cluster_member_addresses(self, _run_mysqlsh_script):
+        """Test an issue executing _get_cluster_member_addresses()."""
+        _run_mysqlsh_script.return_value = ""
+
+        cluster_members, valid = self.mysql._get_cluster_member_addresses(
+            exclude_unit_labels=["mysql-0"]
+        )
+
+        self.assertEqual(cluster_members, [])
+        self.assertFalse(valid)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_get_cluster_primary_address(self, _run_mysqlsh_script):
+        """Test a successful execution of _get_cluster_primary_address()."""
+        _run_mysqlsh_script.return_value = "<PRIMARY_ADDRESS>1.1.1.1</PRIMARY_ADDRESS>"
+
+        primary_address = self.mysql._get_cluster_primary_address()
+
+        self.assertEqual(primary_address, "1.1.1.1")
+
+        expected_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "cluster = dba.get_cluster('test_cluster')",
+                "primary_address = sorted([cluster_member['address'] for cluster_member in cluster.status()['defaultReplicaSet']['topology'].values() if cluster_member['mode'] == 'R/W'])[0]",
+                "print(f'<PRIMARY_ADDRESS>{primary_address}</PRIMARY_ADDRESS>')",
+            ]
+        )
+        _run_mysqlsh_script.assert_called_once_with(expected_commands)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_no_match_cluster_primary_address_with_connect_instance_address(
+        self, _run_mysqlsh_script
+    ):
+        """Test an issue executing _get_cluster_primary_address()."""
+        _run_mysqlsh_script.return_value = ""
+
+        primary_address = self.mysql._get_cluster_primary_address(
+            connect_instance_address="127.0.0.2"
+        )
+
+        self.assertIsNone(primary_address)
+
+        expected_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.2')",
+                "cluster = dba.get_cluster('test_cluster')",
+                "primary_address = sorted([cluster_member['address'] for cluster_member in cluster.status()['defaultReplicaSet']['topology'].values() if cluster_member['mode'] == 'R/W'])[0]",
+                "print(f'<PRIMARY_ADDRESS>{primary_address}</PRIMARY_ADDRESS>')",
+            ]
+        )
+        _run_mysqlsh_script.assert_called_once_with(expected_commands)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_is_instance_in_cluster(self, _run_mysqlsh_script):
+        """Test a successful execution of is_instance_in_cluster() method."""
+        _run_mysqlsh_script.return_value = "ONLINE"
+
+        result = self.mysql.is_instance_in_cluster("mysql-0")
+        self.assertTrue(result)
+
+        expected_commands = "\n".join(
+            [
+                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "cluster = dba.get_cluster('test_cluster')",
+                "print(cluster.status()['defaultReplicaSet']['topology'].get('mysql-0', {}).get('status', 'NOT_A_MEMBER'))",
+            ]
+        )
+        _run_mysqlsh_script.assert_called_once_with(expected_commands)
+
+        _run_mysqlsh_script.return_value = "NOT_A_MEMBER"
+
+        result = self.mysql.is_instance_in_cluster("mysql-0")
+        self.assertFalse(result)
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_is_instance_in_cluster_exception(self, _run_mysqlsh_script):
+        """Test an exception executing is_instance_in_cluster() method."""
+        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
+
+        result = self.mysql.is_instance_in_cluster("mysql-0")
+        self.assertFalse(result)

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -1,22 +1,15 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+"""Unit tests for MySQL class."""
+
+import subprocess
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import patch
 
-import tenacity
-from charms.mysql.v0.mysql import (
-    MySQLAddInstanceToClusterError,
-    MySQLClientError,
-    MySQLConfigureInstanceError,
-    MySQLConfigureMySQLUsersError,
-    MySQLCreateClusterError,
-    MySQLInitializeJujuOperationsTableError,
-    MySQLRemoveInstanceError,
-    MySQLRemoveInstanceRetryError,
-)
+from charms.mysql.v0.mysql import MySQLClientError
 
-from mysqlsh_helpers import MySQL
+from mysqlsh_helpers import MySQL, MySQLServiceNotRunningError
 
 
 class TestMySQL(unittest.TestCase):
@@ -31,52 +24,6 @@ class TestMySQL(unittest.TestCase):
             "clusteradminpassword",
         )
 
-    @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
-    def test_configure_mysql_users(self, _run_mysqlcli_script):
-        """Test failed to configuring the MySQL users."""
-        _run_mysqlcli_script.return_value = b""
-
-        _expected_create_root_user_commands = " ".join(
-            (
-                "CREATE USER 'root'@'%' IDENTIFIED BY 'password';",
-                "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
-            )
-        )
-
-        _expected_configure_user_commands = " ".join(
-            (
-                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';",
-                "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;",
-                "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
-                "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';",
-                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@'%';",
-                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@localhost;",
-                "FLUSH PRIVILEGES;",
-            )
-        )
-
-        self.mysql.configure_mysql_users()
-
-        self.assertEqual(_run_mysqlcli_script.call_count, 2)
-
-        self.assertEqual(
-            sorted(_run_mysqlcli_script.mock_calls),
-            sorted(
-                [
-                    call(_expected_create_root_user_commands),
-                    call(_expected_configure_user_commands, password="password"),
-                ]
-            ),
-        )
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
-    def test_configure_mysql_users_fail(self, _run_mysqlcli_script):
-        """Test failed to configuring the MySQL users."""
-        _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
-
-        with self.assertRaises(MySQLConfigureMySQLUsersError):
-            self.mysql.configure_mysql_users()
-
     @patch("os.path.exists")
     def test_mysqlsh_bin(self, _exists):
         """Test the mysqlsh_bin property."""
@@ -86,429 +33,54 @@ class TestMySQL(unittest.TestCase):
         _exists.return_value = False
         self.assertEqual(MySQL.get_mysqlsh_bin(), "/snap/bin/mysql-shell")
 
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    @patch("mysqlsh_helpers.MySQL.wait_until_mysql_connection")
-    def test_configure_instance(self, _wait_until_mysql_connection, _run_mysqlsh_script):
-        """Test a successful execution of configure_instance."""
-        configure_instance_commands = (
-            'dba.configure_instance(\'serverconfig:serverconfigpassword@127.0.0.1\', {"clusterAdmin": "clusteradmin", "clusterAdminPassword": "clusteradminpassword", "restart": "true"})',
-        )
+    @patch("tempfile.NamedTemporaryFile")
+    @patch("subprocess.check_output")
+    def test_run_mysqlsh_script(self, _check_output, _):
+        """Test a successful execution of run_mysqlsh_script."""
+        _check_output.return_value = b"stdout"
 
-        self.mysql.configure_instance()
+        self.mysql._run_mysqlsh_script("script")
 
-        _run_mysqlsh_script.assert_called_once_with("\n".join(configure_instance_commands))
+        _check_output.assert_called_once()
 
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    @patch("mysqlsh_helpers.MySQL.wait_until_mysql_connection")
-    def test_configure_instance_exceptions(
-        self, _wait_until_mysql_connection, _run_mysqlsh_script
-    ):
-        """Test exceptions raise while running configure_instance."""
-        # Test an issue with _run_mysqlsh_script
-        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
+    @patch("tempfile.NamedTemporaryFile")
+    @patch("subprocess.check_output")
+    def test_run_mysqlsh_script_exception(self, _check_output, _):
+        """Test a failed execution of run_mysqlsh_script."""
+        _check_output.side_effect = subprocess.CalledProcessError(cmd="", returncode=-1)
 
-        with self.assertRaises(MySQLConfigureInstanceError):
-            self.mysql.configure_instance()
+        with self.assertRaises(MySQLClientError):
+            self.mysql._run_mysqlsh_script("script")
 
-        _wait_until_mysql_connection.assert_not_called()
+    @patch("subprocess.check_output")
+    def test_run_mysqlcli_script(self, _check_output):
+        """Test a successful execution of run_mysqlsh_script."""
+        self.mysql._run_mysqlcli_script("script")
 
-        # Reset mocks
-        _run_mysqlsh_script.reset_mock()
-        _wait_until_mysql_connection.reset_mock()
-
-        # Test an issue with _wait_until_mysql_connection
-        _wait_until_mysql_connection.side_effect = MySQLClientError("Error on subprocess")
-
-        with self.assertRaises(MySQLConfigureInstanceError):
-            self.mysql.configure_instance()
-
-        _run_mysqlsh_script.assert_called_once()
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
-    def test_initialize_juju_units_operations_table(self, _run_mysqlcli_script):
-        """Test a successful initialization of the mysql.juju_units_operations table."""
-        expected_initialize_table_commands = (
-            "CREATE TABLE mysql.juju_units_operations (task varchar(20), executor varchar(20), status varchar(20), primary key(task));",
-            "INSERT INTO mysql.juju_units_operations values ('unit-teardown', '', 'not-started');",
-        )
-
-        self.mysql.initialize_juju_units_operations_table()
-
-        _run_mysqlcli_script.assert_called_once_with(
-            " ".join(expected_initialize_table_commands),
-            user="serverconfig",
-            password="serverconfigpassword",
-        )
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
-    def test_initialize_juju_units_operations_table_exception(self, _run_mysqlcli_script):
-        """Test an exception initialization of the mysql.juju_units_operations table."""
-        _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
-
-        with self.assertRaises(MySQLInitializeJujuOperationsTableError):
-            self.mysql.initialize_juju_units_operations_table()
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_create_cluster(self, _run_mysqlsh_script):
-        """Test a successful execution of create_cluster."""
-        create_cluster_commands = (
-            "shell.connect('serverconfig:serverconfigpassword@127.0.0.1')",
-            "cluster = dba.create_cluster('test_cluster')",
-            "cluster.set_instance_option('127.0.0.1', 'label', 'mysql-0')",
-        )
-
-        self.mysql.create_cluster("mysql-0")
-
-        _run_mysqlsh_script.assert_called_once_with("\n".join(create_cluster_commands))
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_create_cluster_exceptions(self, _run_mysqlsh_script):
-        """Test exceptions raised while running create_cluster."""
-        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
-
-        with self.assertRaises(MySQLCreateClusterError):
-            self.mysql.create_cluster("mysql-0")
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_add_instance_to_cluster(self, _run_mysqlsh_script):
-        """Test a successful execution of create_cluster."""
-        add_instance_to_cluster_commands = (
-            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-            "cluster = dba.get_cluster('test_cluster')",
-            'cluster.add_instance(\'clusteradmin@127.0.0.2\', {"password": "clusteradminpassword", "label": "mysql-1", "recoveryMethod": "auto"})',
-        )
-
-        self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
-
-        _run_mysqlsh_script.assert_called_once_with("\n".join(add_instance_to_cluster_commands))
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_add_instance_to_cluster_exception(self, _run_mysqlsh_script):
-        """Test exceptions raised while running add_instance_to_cluster."""
-        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
-
-        with self.assertRaises(MySQLAddInstanceToClusterError):
-            self.mysql.add_instance_to_cluster("127.0.0.2", "mysql-1")
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script", return_value="INSTANCE_CONFIGURED")
-    def test_is_instance_configured_for_innodb(self, _run_mysqlsh_script):
-        """Test with no exceptions while calling the is_instance_configured_for_innodb method."""
-        # test successfully configured instance
-        check_instance_configuration_commands = (
-            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.2')",
-            "instance_configured = dba.check_instance_configuration()['status'] == 'ok'",
-            'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
-        )
-
-        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
-            "127.0.0.2", "mysql-1"
-        )
-
-        _run_mysqlsh_script.assert_called_once_with(
-            "\n".join(check_instance_configuration_commands)
-        )
-        self.assertTrue(is_instance_configured)
-
-        # reset mocks
-        _run_mysqlsh_script.reset_mock()
-
-        # test instance not configured for innodb
-        _run_mysqlsh_script.return_value = "INSTANCE_NOT_CONFIGURED"
-
-        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
-            "127.0.0.2", "mysql-1"
-        )
-
-        _run_mysqlsh_script.assert_called_once_with(
-            "\n".join(check_instance_configuration_commands)
-        )
-        self.assertFalse(is_instance_configured)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_is_instance_configured_for_innodb_exceptions(self, _run_mysqlsh_script):
-        """Test an exception while calling the is_instance_configured_for_innodb method."""
-        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
-
-        check_instance_configuration_commands = (
-            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.2')",
-            "instance_configured = dba.check_instance_configuration()['status'] == 'ok'",
-            'print("INSTANCE_CONFIGURED" if instance_configured else "INSTANCE_NOT_CONFIGURED")',
-        )
-
-        is_instance_configured = self.mysql.is_instance_configured_for_innodb(
-            "127.0.0.2", "mysql-1"
-        )
-
-        _run_mysqlsh_script.assert_called_once_with(
-            "\n".join(check_instance_configuration_commands)
-        )
-        self.assertFalse(is_instance_configured)
-
-    @patch("mysqlsh_helpers.MySQL._get_cluster_primary_address")
-    @patch("mysqlsh_helpers.MySQL._acquire_lock")
-    @patch("mysqlsh_helpers.MySQL._get_cluster_member_addresses")
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    @patch("mysqlsh_helpers.MySQL._release_lock")
-    def test_remove_primary_instance(
-        self,
-        _release_lock,
-        _run_mysqlsh_script,
-        _get_cluster_member_addresses,
-        _acquire_lock,
-        _get_cluster_primary_address,
-    ):
-        """Test with no exceptions while running the remove_instance() method."""
-        _get_cluster_primary_address.side_effect = ["1.1.1.1", "2.2.2.2"]
-        _acquire_lock.return_value = True
-        _get_cluster_member_addresses.return_value = ("2.2.2.2", True)
-
-        self.mysql.remove_instance("mysql-0")
-
-        expected_remove_instance_commands = "\n".join(
+        _check_output.assert_called_once_with(
             [
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-                "cluster = dba.get_cluster('test_cluster')",
-                "number_cluster_members = len(cluster.status()['defaultReplicaSet']['topology'])",
-                'cluster.remove_instance(\'clusteradmin@127.0.0.1\', {"password": "clusteradminpassword", "force": "true"}) if number_cluster_members > 1 else cluster.dissolve({"force": "true"})',
-            ]
+                "mysql",
+                "-u",
+                "root",
+                "--protocol=SOCKET",
+                "--socket=/var/run/mysqld/mysqld.sock",
+                "-e",
+                "script",
+            ],
+            stderr=subprocess.PIPE,
         )
 
-        self.assertEqual(_get_cluster_primary_address.call_count, 2)
-        _acquire_lock.assert_called_once_with("1.1.1.1", "mysql-0", "unit-teardown")
-        _get_cluster_member_addresses.assert_called_once_with(exclude_unit_labels=["mysql-0"])
-        _run_mysqlsh_script.assert_called_once_with(expected_remove_instance_commands)
-        _release_lock.assert_called_once_with("2.2.2.2", "mysql-0", "unit-teardown")
+    @patch("subprocess.check_output")
+    def test_run_mysqlcli_script_exception(self, _check_output):
+        """Test a failed execution of run_mysqlsh_script."""
+        _check_output.side_effect = subprocess.CalledProcessError(cmd="", returncode=-1)
 
-    @patch("mysqlsh_helpers.MySQL._get_cluster_primary_address")
-    @patch("mysqlsh_helpers.MySQL._acquire_lock")
-    @patch("mysqlsh_helpers.MySQL._get_cluster_member_addresses")
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    @patch("mysqlsh_helpers.MySQL._release_lock")
-    def test_remove_primary_instance_error_acquiring_lock(
-        self,
-        _release_lock,
-        _run_mysqlsh_script,
-        _get_cluster_member_addresses,
-        _acquire_lock,
-        _get_cluster_primary_address,
-    ):
-        """Test an issue acquiring lock while running the remove_instance() method."""
-        _get_cluster_primary_address.side_effect = ["1.1.1.1", "2.2.2.2"]
-        _acquire_lock.return_value = False
+        with self.assertRaises(MySQLClientError):
+            self.mysql._run_mysqlcli_script("script")
 
-        # disable tenacity retry
-        self.mysql.remove_instance.retry.retry = tenacity.retry_if_not_result(lambda x: True)
-
-        with self.assertRaises(MySQLRemoveInstanceRetryError):
-            self.mysql.remove_instance("mysql-0")
-
-        self.assertEqual(_get_cluster_primary_address.call_count, 1)
-        _acquire_lock.assert_called_once_with("1.1.1.1", "mysql-0", "unit-teardown")
-        _get_cluster_member_addresses.assert_not_called()
-        _run_mysqlsh_script.assert_not_called()
-        _release_lock.assert_not_called()
-
-    @patch("mysqlsh_helpers.MySQL._get_cluster_primary_address")
-    @patch("mysqlsh_helpers.MySQL._acquire_lock")
-    @patch("mysqlsh_helpers.MySQL._get_cluster_member_addresses")
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    @patch("mysqlsh_helpers.MySQL._release_lock")
-    def test_remove_primary_instance_error_releasing_lock(
-        self,
-        _release_lock,
-        _run_mysqlsh_script,
-        _get_cluster_member_addresses,
-        _acquire_lock,
-        _get_cluster_primary_address,
-    ):
-        """Test an issue releasing locks while running the remove_instance() method."""
-        _get_cluster_primary_address.side_effect = ["1.1.1.1", "2.2.2.2"]
-        _acquire_lock.return_value = True
-        _get_cluster_member_addresses.return_value = ("2.2.2.2", True)
-        _release_lock.side_effect = MySQLClientError("Error on subprocess")
-
-        with self.assertRaises(MySQLRemoveInstanceError):
-            self.mysql.remove_instance("mysql-0")
-
-        expected_remove_instance_commands = "\n".join(
-            [
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-                "cluster = dba.get_cluster('test_cluster')",
-                "number_cluster_members = len(cluster.status()['defaultReplicaSet']['topology'])",
-                'cluster.remove_instance(\'clusteradmin@127.0.0.1\', {"password": "clusteradminpassword", "force": "true"}) if number_cluster_members > 1 else cluster.dissolve({"force": "true"})',
-            ]
-        )
-
-        self.assertEqual(_get_cluster_primary_address.call_count, 2)
-        _acquire_lock.assert_called_once_with("1.1.1.1", "mysql-0", "unit-teardown")
-        _get_cluster_member_addresses.assert_called_once_with(exclude_unit_labels=["mysql-0"])
-        _run_mysqlsh_script.assert_called_once_with(expected_remove_instance_commands)
-        _release_lock.assert_called_once_with("2.2.2.2", "mysql-0", "unit-teardown")
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_acquire_lock(self, _run_mysqlsh_script):
-        """Test a successful execution of _acquire_lock()."""
-        _run_mysqlsh_script.return_value = "<ACQUIRED_LOCK>1</ACQUIRED_LOCK>"
-
-        acquired_lock = self.mysql._acquire_lock("1.1.1.1", "mysql-0", "unit-teardown")
-
-        self.assertTrue(acquired_lock)
-
-        expected_acquire_lock_commands = "\n".join(
-            [
-                "shell.connect('clusteradmin:clusteradminpassword@1.1.1.1')",
-                "session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='mysql-0', status='in-progress' WHERE task='unit-teardown' AND executor='';\")",
-                "acquired_lock = session.run_sql(\"SELECT count(*) FROM mysql.juju_units_operations WHERE task='unit-teardown' AND executor='mysql-0';\").fetch_one()[0]",
-                "print(f'<ACQUIRED_LOCK>{acquired_lock}</ACQUIRED_LOCK>')",
-            ]
-        )
-        _run_mysqlsh_script.assert_called_once_with(expected_acquire_lock_commands)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_unable_to_acquire_lock(self, _run_mysqlsh_script):
-        """Test a successful execution of _acquire_lock() but failure to acquire lock."""
-        _run_mysqlsh_script.return_value = "<ACQUIRED_LOCK>0</ACQUIRED_LOCK>"
-
-        acquired_lock = self.mysql._acquire_lock("1.1.1.1", "mysql-0", "unit-teardown")
-
-        self.assertFalse(acquired_lock)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_issue_with_acquire_lock(self, _run_mysqlsh_script):
-        """Test an issue while executing _acquire_lock()."""
-        _run_mysqlsh_script.return_value = ""
-
-        acquired_lock = self.mysql._acquire_lock("1.1.1.1", "mysql-0", "unit-teardown")
-
-        self.assertFalse(acquired_lock)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_release_lock(self, _run_mysqlsh_script):
-        """Test a successful execution of _acquire_lock()."""
-        self.mysql._release_lock("2.2.2.2", "mysql-0", "unit-teardown")
-
-        expected_release_lock_commands = "\n".join(
-            [
-                "shell.connect('clusteradmin:clusteradminpassword@2.2.2.2')",
-                "session.run_sql(\"UPDATE mysql.juju_units_operations SET executor='', status='not-started' WHERE task='unit-teardown' AND executor='mysql-0';\")",
-            ]
-        )
-        _run_mysqlsh_script.assert_called_once_with(expected_release_lock_commands)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_get_cluster_member_addresses(self, _run_mysqlsh_script):
-        """Test a successful execution of _get_cluster_member_addresses()."""
-        _run_mysqlsh_script.return_value = "<MEMBER_ADDRESSES>1.1.1.1,2.2.2.2</MEMBER_ADDRESSES>"
-
-        cluster_members, valid = self.mysql._get_cluster_member_addresses(
-            exclude_unit_labels=["mysql-0"]
-        )
-
-        self.assertEqual(cluster_members, ["1.1.1.1", "2.2.2.2"])
-        self.assertTrue(valid)
-
-        expected_commands = "\n".join(
-            [
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-                "cluster = dba.get_cluster('test_cluster')",
-                "member_addresses = ','.join([member['address'] for label, member in cluster.status()['defaultReplicaSet']['topology'].items() if label not in ['mysql-0']])",
-                "print(f'<MEMBER_ADDRESSES>{member_addresses}</MEMBER_ADDRESSES>')",
-            ]
-        )
-        _run_mysqlsh_script.assert_called_once_with(expected_commands)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_empty_get_cluster_member_addresses(self, _run_mysqlsh_script):
-        """Test successful execution of _get_cluster_member_addresses() with empty return value."""
-        _run_mysqlsh_script.return_value = "<MEMBER_ADDRESSES></MEMBER_ADDRESSES>"
-
-        cluster_members, valid = self.mysql._get_cluster_member_addresses(
-            exclude_unit_labels=["mysql-0"]
-        )
-
-        self.assertEqual(cluster_members, [])
-        self.assertTrue(valid)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_error_get_cluster_member_addresses(self, _run_mysqlsh_script):
-        """Test an issue executing _get_cluster_member_addresses()."""
-        _run_mysqlsh_script.return_value = ""
-
-        cluster_members, valid = self.mysql._get_cluster_member_addresses(
-            exclude_unit_labels=["mysql-0"]
-        )
-
-        self.assertEqual(cluster_members, [])
-        self.assertFalse(valid)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_get_cluster_primary_address(self, _run_mysqlsh_script):
-        """Test a successful execution of _get_cluster_primary_address()."""
-        _run_mysqlsh_script.return_value = "<PRIMARY_ADDRESS>1.1.1.1</PRIMARY_ADDRESS>"
-
-        primary_address = self.mysql._get_cluster_primary_address()
-
-        self.assertEqual(primary_address, "1.1.1.1")
-
-        expected_commands = "\n".join(
-            [
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-                "cluster = dba.get_cluster('test_cluster')",
-                "primary_address = sorted([cluster_member['address'] for cluster_member in cluster.status()['defaultReplicaSet']['topology'].values() if cluster_member['mode'] == 'R/W'])[0]",
-                "print(f'<PRIMARY_ADDRESS>{primary_address}</PRIMARY_ADDRESS>')",
-            ]
-        )
-        _run_mysqlsh_script.assert_called_once_with(expected_commands)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_no_match_cluster_primary_address_with_connect_instance_address(
-        self, _run_mysqlsh_script
-    ):
-        """Test an issue executing _get_cluster_primary_address()."""
-        _run_mysqlsh_script.return_value = ""
-
-        primary_address = self.mysql._get_cluster_primary_address(
-            connect_instance_address="127.0.0.2"
-        )
-
-        self.assertIsNone(primary_address)
-
-        expected_commands = "\n".join(
-            [
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.2')",
-                "cluster = dba.get_cluster('test_cluster')",
-                "primary_address = sorted([cluster_member['address'] for cluster_member in cluster.status()['defaultReplicaSet']['topology'].values() if cluster_member['mode'] == 'R/W'])[0]",
-                "print(f'<PRIMARY_ADDRESS>{primary_address}</PRIMARY_ADDRESS>')",
-            ]
-        )
-        _run_mysqlsh_script.assert_called_once_with(expected_commands)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_is_instance_in_cluster(self, _run_mysqlsh_script):
-        """Test a successful execution of is_instance_in_cluster() method."""
-        _run_mysqlsh_script.return_value = "ONLINE"
-
-        result = self.mysql.is_instance_in_cluster("mysql-0")
-        self.assertTrue(result)
-
-        expected_commands = "\n".join(
-            [
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
-                "cluster = dba.get_cluster('test_cluster')",
-                "print(cluster.status()['defaultReplicaSet']['topology'].get('mysql-0', {}).get('status', 'NOT_A_MEMBER'))",
-            ]
-        )
-        _run_mysqlsh_script.assert_called_once_with(expected_commands)
-
-        _run_mysqlsh_script.return_value = "NOT_A_MEMBER"
-
-        result = self.mysql.is_instance_in_cluster("mysql-0")
-        self.assertFalse(result)
-
-    @patch("mysqlsh_helpers.MySQL._run_mysqlsh_script")
-    def test_is_instance_in_cluster_exception(self, _run_mysqlsh_script):
-        """Test an exception executing is_instance_in_cluster() method."""
-        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
-
-        result = self.mysql.is_instance_in_cluster("mysql-0")
-        self.assertFalse(result)
+    @patch("mysqlsh_helpers.MySQL.wait_until_mysql_connection.retry.stop", return_value=1)
+    @patch("os.path.exists", return_value=False)
+    def test_wait_until_mysql_connection(self, _exists, _stop):
+        """Test a failed execution of wait_until_mysql_connection."""
+        with self.assertRaises(MySQLServiceNotRunningError):
+            self.mysql.wait_until_mysql_connection()

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -5,10 +5,6 @@ import unittest
 from unittest.mock import call, patch
 
 import tenacity
-
-from mysqlsh_helpers import MySQL
-
-
 from charms.mysql.v0.mysql import (
     MySQLAddInstanceToClusterError,
     MySQLClientError,
@@ -19,6 +15,8 @@ from charms.mysql.v0.mysql import (
     MySQLRemoveInstanceError,
     MySQLRemoveInstanceRetryError,
 )
+
+from mysqlsh_helpers import MySQL
 
 
 class TestMySQL(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tst_path}
+lib_path = {toxinidir}/lib/charms/mysql
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]src_path} \
+    coverage run --source={[vars]src_path},{[vars]lib_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 


### PR DESCRIPTION
# Issue

Even though vm and k8s charm share a great deal of code on dealing with mysql, there were no library in place.
Task link is [DPE-205](https://warthogs.atlassian.net/browse/DPE-205)

# Solution

This PR extract the shared code into a library.
The library contains custom exceptions and a abstract class (`MySQLBase`) with the shared domain knowledge.
We choose to implement `MySQLBase` as an abstract class to enforce the implementation of platform specific methods in the subclass, keeping consistency high across both charms.
The figures on the charm library, as from the current features are:
* 16 common methods (being 3 abstract methods)
* 2 additional methods vm specific
* 4 additional methods k8s specific

# Testing
Testing is done through unit and integration testing that were already in place.
Since this PR does not add any big features (there are some opportunistic addition), just a bit more of coverage was added.
The main change was in test structure, since a big portion of tests migrated to use the library.

# Release Notes
* creation of `charms.mysql.v0.mysql.py` with shared code, migrated from `src/mysqlsh_helpers.py`
  * `MySQLBase` abstract class
  * added `get_cluster_status` function from k8s operator code base
* creation of `tests/unit/test_mysql.py` unit tests, with much of its code migrated from `tests/unit/mysqlsh_helpers.py`
* added two new actions handlers to `charm.py` (get root credentials and get cluster status)
* function `wait_until_mysql_connection` now must be called from the charm code, instead of from inside the helper function that was using it. This is due the fact that on k8s, mysqld restart is done on the charm scope only.
