### PR TITLE
Implement the legacy db-router relation

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -109,43 +109,29 @@ class Error(Exception):
 class MySQLConfigureMySQLUsersError(Error):
     """Exception raised when creating a user fails."""
 
-    pass
-
 
 class MySQLCheckUserExistenceError(Error):
     """Exception raised when checking for the existence of a MySQL user."""
-
-    pass
 
 
 class MySQLConfigureRouterUserError(Error):
     """Exception raised when configuring the MySQLRouter user."""
 
-    pass
-
 
 class MySQLCreateApplicationDatabaseAndScopedUserError(Error):
     """Exception raised when creating application database and scoped user."""
-
-    pass
 
 
 class MySQLConfigureInstanceError(Error):
     """Exception raised when there is an issue configuring a MySQL instance."""
 
-    pass
-
 
 class MySQLCreateClusterError(Error):
     """Exception raised when there is an issue creating an InnoDB cluster."""
 
-    pass
-
 
 class MySQLAddInstanceToClusterError(Error):
     """Exception raised when there is an issue add an instance to the MySQL InnoDB cluster."""
-
-    pass
 
 
 class MySQLRemoveInstanceRetryError(Error):
@@ -153,8 +139,6 @@ class MySQLRemoveInstanceRetryError(Error):
 
     Utilized by tenacity to retry the method.
     """
-
-    pass
 
 
 class MySQLRemoveInstanceError(Error):
@@ -167,16 +151,12 @@ class MySQLRemoveInstanceError(Error):
 class MySQLInitializeJujuOperationsTableError(Error):
     """Exception raised when there is an issue initializing the juju units operations table."""
 
-    pass
-
 
 class MySQLClientError(Error):
     """Exception raised when there is an issue using the mysql cli or mysqlsh.
 
     Abstract platform specific exceptions for external commands execution Errors.
     """
-
-    pass
 
 
 class MySQLBase(ABC):
@@ -271,15 +251,19 @@ class MySQLBase(ABC):
             )
             raise MySQLConfigureMySQLUsersError(e.message)
 
-    def does_mysql_user_exist(self, username, hostname="%"):
+    def does_mysql_user_exist(self, username: str, hostname: str = "%") -> bool:
         """Checks if a mysqlrouter user already exists.
 
         Args:
             username: The username for the mysql user
             hostname (optional): The hostname for the mysql user (defaults to %)
-        """
-        pass
 
+        Returns:
+            A boolean indicating whether the provided mysql user exists
+
+        Raises MySQLCheckUserExistenceError
+            if there is an issue confirming that the mysql user exists
+        """
         user_existence_commands = (
             f"select if((select count(*) from mysql.user where user = '{username}' and host = '{hostname}'), 'USER_EXISTS', 'USER_DOES_NOT_EXIST') as ''",
         )
@@ -294,12 +278,15 @@ class MySQLBase(ABC):
             )
             raise MySQLCheckUserExistenceError(e.message)
 
-    def configure_mysqlrouter_user(self, username, password):
+    def configure_mysqlrouter_user(self, username: str, password: str) -> None:
         """Configure a mysqlrouter user and grant the appropriate permissions to the user.
 
         Args:
             username: The username for the mysqlrouter user
             password: The password for the mysqlrouter user
+
+        Raises MySQLConfigureRouterUserError
+            if there is an issue creating and configuring the mysqlrouter user
         """
         create_mysqlrouter_user_commands = (
             f"CREATE USER '{username}'@'%' IDENTIFIED BY '{password}'",
@@ -325,17 +312,20 @@ class MySQLBase(ABC):
             )
             raise MySQLConfigureRouterUserError(e.message)
 
-    def create_application_database_and_scoped_user(self, database_name, username, password):
+    def create_application_database_and_scoped_user(
+        self, database_name: str, username: str, password: str
+    ) -> None:
         """Create an application database and a user scoped to the created database.
 
         Args:
             database_name: The name of the database to create
             username: The username of the scoped user
             password: The password of the scoped user
+
+        Raises MySQLCreateApplicationDatabaseAndScopedUserError
+            if there is an issue creating the application database or a user scoped to the database
         """
-        create_database_commands = (
-            f"CREATE DATABASE IF NOT EXISTS {database_name} CHARACTER SET UTF8",
-        )
+        create_database_commands = (f"CREATE DATABASE IF NOT EXISTS {database_name}",)
         create_scoped_user_commands = (
             f"CREATE USER '{username}'@'%' IDENTIFIED BY '{password}'",
             f"GRANT USAGE ON *.* TO '{username}'@`%`",

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -320,7 +320,7 @@ class MySQLBase(ABC):
             self._run_mysqlcli_script("; ".join(mysqlrouter_user_grant_commands))
         except MySQLClientError as e:
             logger.exception(
-                f"Failed to configure mysqlrouter user for: {self.instance_address} with error {e.stderr}",
+                f"Failed to configure mysqlrouter user for: {self.instance_address} with error {e.message}",
                 exc_info=e,
             )
             raise MySQLConfigureRouterUserError(e.message)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,6 +19,9 @@ maintainers:
 peers:
   database-peers:
     interface: mysql-peers
+provides:
+  db-router:
+    interface: mysql-router
 storage:
   database:
     type: filesystem

--- a/src/charm.py
+++ b/src/charm.py
@@ -219,6 +219,7 @@ class MySQLOperatorCharm(CharmBase):
         ):
             self.unit.status = ActiveStatus()
 
+    # flake8: noqa: C901
     def _on_db_router_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle the db_router relation changed event."""
         if not self.unit.is_leader():
@@ -286,8 +287,13 @@ class MySQLOperatorCharm(CharmBase):
                     event_relation_databag[f"{application_name}_allowed_units"] = json.dumps(
                         unit_names
                     )
-            except (MySQLCheckUserExistenceError, MySQLCreateApplicationDatabaseAndScopedUserError):
-                self.unit.status = BlockedStatus("Failed to create application database and scoped user")
+            except (
+                MySQLCheckUserExistenceError,
+                MySQLCreateApplicationDatabaseAndScopedUserError,
+            ):
+                self.unit.status = BlockedStatus(
+                    "Failed to create application database and scoped user"
+                )
                 return
 
         self.unit.status = ActiveStatus()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -180,12 +180,12 @@ class TestCharm(unittest.TestCase):
     @patch("mysqlsh_helpers.MySQL.configure_mysqlrouter_user")
     @patch("mysqlsh_helpers.MySQL.create_application_database_and_scoped_user")
     def test_db_router_relation_changed(
-            self,
-            _create_application_database_and_scoped_user,
-            _configure_mysqlrouter_user,
-            _does_mysql_user_exist,
-            _generate_random_password,
-        ):
+        self,
+        _create_application_database_and_scoped_user,
+        _configure_mysqlrouter_user,
+        _does_mysql_user_exist,
+        _generate_random_password,
+    ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
@@ -228,25 +228,35 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-        _configure_mysqlrouter_user.assert_called_once_with("mysqlrouteruser", "super_secure_password")
-        _create_application_database_and_scoped_user.assert_called_once_with("keystone_database", "keystone_user", "super_secure_password")
+        _configure_mysqlrouter_user.assert_called_once_with(
+            "mysqlrouteruser", "super_secure_password"
+        )
+        _create_application_database_and_scoped_user.assert_called_once_with(
+            "keystone_database", "keystone_user", "super_secure_password"
+        )
 
         # confirm that credentials in the mysql leader unit databag is set correctly
-        self.assertEqual(db_router_relation.data.get(app_unit), {
-            "MRUP_database": "keystone_database",
-            "MRUP_hostname": "1.1.1.2",
-            "MRUP_username": "keystone_user",
-            "mysqlrouter_hostname": "1.1.1.3",
-            "mysqlrouter_username": "mysqlrouteruser",
-        })
+        self.assertEqual(
+            db_router_relation.data.get(app_unit),
+            {
+                "MRUP_database": "keystone_database",
+                "MRUP_hostname": "1.1.1.2",
+                "MRUP_username": "keystone_user",
+                "mysqlrouter_hostname": "1.1.1.3",
+                "mysqlrouter_username": "mysqlrouteruser",
+            },
+        )
 
-        self.assertEqual(db_router_relation.data.get(self.charm.unit), {
-            "db_host": '"1.1.1.1"',
-            "mysqlrouter_password": '"super_secure_password"',
-            "mysqlrouter_allowed_units": '"app/0"',
-            "MRUP_password": '"super_secure_password"',
-            "MRUP_allowed_units": '"app/0"',
-        })
+        self.assertEqual(
+            db_router_relation.data.get(self.charm.unit),
+            {
+                "db_host": '"1.1.1.1"',
+                "mysqlrouter_password": '"super_secure_password"',
+                "mysqlrouter_allowed_units": '"app/0"',
+                "MRUP_password": '"super_secure_password"',
+                "MRUP_allowed_units": '"app/0"',
+            },
+        )
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.generate_random_password", return_value="super_secure_password")
@@ -254,12 +264,12 @@ class TestCharm(unittest.TestCase):
     @patch("mysqlsh_helpers.MySQL.configure_mysqlrouter_user")
     @patch("mysqlsh_helpers.MySQL.create_application_database_and_scoped_user")
     def test_db_router_relation_changed_exceptions(
-            self,
-            _create_application_database_and_scoped_user,
-            _configure_mysqlrouter_user,
-            _does_mysql_user_exist,
-            _generate_random_password,
-        ):
+        self,
+        _create_application_database_and_scoped_user,
+        _configure_mysqlrouter_user,
+        _does_mysql_user_exist,
+        _generate_random_password,
+    ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
@@ -312,7 +322,9 @@ class TestCharm(unittest.TestCase):
         _configure_mysqlrouter_user.reset_mock()
 
         # test an exception while creating the application database and scoped user
-        _create_application_database_and_scoped_user.side_effect = MySQLCreateApplicationDatabaseAndScopedUserError
+        _create_application_database_and_scoped_user.side_effect = (
+            MySQLCreateApplicationDatabaseAndScopedUserError
+        )
         self.harness.update_relation_data(
             self.db_router_relation_id,
             "app/0",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,11 +2,14 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from charms.mysql.v0.mysql import (
+    MySQLCheckUserExistenceError,
     MySQLConfigureInstanceError,
     MySQLConfigureMySQLUsersError,
+    MySQLConfigureRouterUserError,
+    MySQLCreateApplicationDatabaseAndScopedUserError,
     MySQLCreateClusterError,
     MySQLInitializeJujuOperationsTableError,
 )
@@ -24,6 +27,8 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
         self.peer_relation_id = self.harness.add_relation("database-peers", "database-peers")
         self.harness.add_relation_unit(self.peer_relation_id, "mysql/1")
+        self.db_router_relation_id = self.harness.add_relation("db-router", "app")
+        self.harness.add_relation_unit(self.db_router_relation_id, "app/0")
         self.charm = self.harness.charm
 
     @patch("mysqlsh_helpers.MySQL.install_and_configure_mysql_dependencies")
@@ -168,3 +173,158 @@ class TestCharm(unittest.TestCase):
 
         self.charm.on.start.emit()
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+    @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.generate_random_password", return_value="super_secure_password")
+    @patch("mysqlsh_helpers.MySQL.does_mysql_user_exist", return_value=False)
+    @patch("mysqlsh_helpers.MySQL.configure_mysqlrouter_user")
+    @patch("mysqlsh_helpers.MySQL.create_application_database_and_scoped_user")
+    def test_db_router_relation_changed(
+            self,
+            _create_application_database_and_scoped_user,
+            _configure_mysqlrouter_user,
+            _does_mysql_user_exist,
+            _generate_random_password,
+        ):
+        # run start-up events to enable usage of the helper class
+        self.harness.set_leader(True)
+        self.charm.on.config_changed.emit()
+
+        # confirm that the relation databag is empty
+        db_router_relation_databag = self.harness.get_relation_data(
+            self.db_router_relation_id, self.harness.charm.app
+        )
+        db_router_relation = self.charm.model.get_relation("db-router")
+        app_unit = list(db_router_relation.units)[0]
+
+        self.assertEqual(db_router_relation_databag, {})
+        self.assertEqual(db_router_relation.data.get(app_unit), {})
+        self.assertEqual(db_router_relation.data.get(self.charm.unit), {})
+
+        # update the app leader unit data to trigger db_router_relation_changed event
+        self.harness.update_relation_data(
+            self.db_router_relation_id,
+            "app/0",
+            {
+                "MRUP_database": "keystone_database",
+                "MRUP_hostname": "1.1.1.2",
+                "MRUP_username": "keystone_user",
+                "mysqlrouter_hostname": "1.1.1.3",
+                "mysqlrouter_username": "mysqlrouteruser",
+            },
+        )
+
+        # 4 calls during start-up events, and 2 calls during the db_router_relation_changed event
+        self.assertEqual(_generate_random_password.call_count, 6)
+
+        self.assertEqual(_does_mysql_user_exist.call_count, 2)
+        self.assertEqual(
+            sorted(_does_mysql_user_exist.mock_calls),
+            sorted(
+                [
+                    call("mysqlrouteruser"),
+                    call("keystone_user"),
+                ]
+            ),
+        )
+
+        _configure_mysqlrouter_user.assert_called_once_with("mysqlrouteruser", "super_secure_password")
+        _create_application_database_and_scoped_user.assert_called_once_with("keystone_database", "keystone_user", "super_secure_password")
+
+        # confirm that credentials in the mysql leader unit databag is set correctly
+        self.assertEqual(db_router_relation.data.get(app_unit), {
+            "MRUP_database": "keystone_database",
+            "MRUP_hostname": "1.1.1.2",
+            "MRUP_username": "keystone_user",
+            "mysqlrouter_hostname": "1.1.1.3",
+            "mysqlrouter_username": "mysqlrouteruser",
+        })
+
+        self.assertEqual(db_router_relation.data.get(self.charm.unit), {
+            "db_host": '"1.1.1.1"',
+            "mysqlrouter_password": '"super_secure_password"',
+            "mysqlrouter_allowed_units": '"app/0"',
+            "MRUP_password": '"super_secure_password"',
+            "MRUP_allowed_units": '"app/0"',
+        })
+
+    @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.generate_random_password", return_value="super_secure_password")
+    @patch("mysqlsh_helpers.MySQL.does_mysql_user_exist", return_value=False)
+    @patch("mysqlsh_helpers.MySQL.configure_mysqlrouter_user")
+    @patch("mysqlsh_helpers.MySQL.create_application_database_and_scoped_user")
+    def test_db_router_relation_changed_exceptions(
+            self,
+            _create_application_database_and_scoped_user,
+            _configure_mysqlrouter_user,
+            _does_mysql_user_exist,
+            _generate_random_password,
+        ):
+        # run start-up events to enable usage of the helper class
+        self.harness.set_leader(True)
+        self.charm.on.config_changed.emit()
+
+        # confirm that the relation databag is empty
+        db_router_relation_databag = self.harness.get_relation_data(
+            self.db_router_relation_id, self.harness.charm.app
+        )
+        db_router_relation = self.charm.model.get_relation("db-router")
+        app_unit = list(db_router_relation.units)[0]
+
+        self.assertEqual(db_router_relation_databag, {})
+        self.assertEqual(db_router_relation.data.get(app_unit), {})
+        self.assertEqual(db_router_relation.data.get(self.charm.unit), {})
+
+        # test an exception while configuring mysql users
+        _does_mysql_user_exist.side_effect = MySQLCheckUserExistenceError
+        self.harness.update_relation_data(
+            self.db_router_relation_id,
+            "app/0",
+            {
+                "MRUP_database": "keystone_database",
+                "MRUP_hostname": "1.1.1.2",
+                "MRUP_username": "keystone_user",
+                "mysqlrouter_hostname": "1.1.1.3",
+                "mysqlrouter_username": "mysqlrouteruser",
+            },
+        )
+
+        self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+        _does_mysql_user_exist.reset_mock()
+
+        # test an exception while creating the mysql router user
+        _configure_mysqlrouter_user.side_effect = MySQLConfigureRouterUserError
+        self.harness.update_relation_data(
+            self.db_router_relation_id,
+            "app/0",
+            {
+                "MRUP_database": "keystone_database",
+                "MRUP_hostname": "1.1.1.2",
+                "MRUP_username": "keystone_user",
+                "mysqlrouter_hostname": "1.1.1.3",
+                "mysqlrouter_username": "mysqlrouteruser",
+            },
+        )
+
+        self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+        _configure_mysqlrouter_user.reset_mock()
+
+        # test an exception while creating the application database and scoped user
+        _create_application_database_and_scoped_user.side_effect = MySQLCreateApplicationDatabaseAndScopedUserError
+        self.harness.update_relation_data(
+            self.db_router_relation_id,
+            "app/0",
+            {
+                "MRUP_database": "keystone_database",
+                "MRUP_hostname": "1.1.1.2",
+                "MRUP_username": "keystone_user",
+                "mysqlrouter_hostname": "1.1.1.3",
+                "mysqlrouter_username": "mysqlrouteruser",
+            },
+        )
+
+        self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
+
+        _create_application_database_and_scoped_user.reset_mock()

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -162,7 +162,7 @@ class TestMySQLBase(unittest.TestCase):
         _run_mysqlcli_script.return_value = b""
 
         _expected_create_database_commands = "; ".join(
-            ("CREATE DATABASE IF NOT EXISTS test_database CHARACTER SET UTF8",)
+            ("CREATE DATABASE IF NOT EXISTS test_database",)
         )
 
         _expected_create_scoped_user_commands = "; ".join(

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -89,7 +89,7 @@ class TestMySQLBase(unittest.TestCase):
         """Test successful execution of does_mysql_user_exist."""
         # Test passing in a custom hostname
         user_existence_command = (
-            f"select if((select count(*) from mysql.user where user = 'test_username' and host = 'test_hostname'), 'USER_EXISTS', 'USER_DOES_NOT_EXIST') as ''",
+            "select if((select count(*) from mysql.user where user = 'test_username' and host = 'test_hostname'), 'USER_EXISTS', 'USER_DOES_NOT_EXIST') as ''",
         )
 
         self.mysql.does_mysql_user_exist("test_username", hostname="test_hostname")
@@ -100,7 +100,7 @@ class TestMySQLBase(unittest.TestCase):
 
         # Test default hostname
         user_existence_command = (
-            f"select if((select count(*) from mysql.user where user = 'test_username' and host = '%'), 'USER_EXISTS', 'USER_DOES_NOT_EXIST') as ''",
+            "select if((select count(*) from mysql.user where user = 'test_username' and host = '%'), 'USER_EXISTS', 'USER_DOES_NOT_EXIST') as ''",
         )
 
         self.mysql.does_mysql_user_exist("test_username")
@@ -120,19 +120,17 @@ class TestMySQLBase(unittest.TestCase):
         _run_mysqlcli_script.return_value = b""
 
         _expected_create_mysqlrouter_user_commands = "; ".join(
-            (
-                f"CREATE USER 'test_username'@'%' IDENTIFIED BY 'test_password'",
-            )
+            ("CREATE USER 'test_username'@'%' IDENTIFIED BY 'test_password'",)
         )
 
         _expected_mysqlrouter_user_grant_commands = "; ".join(
             (
-                f"GRANT CREATE USER ON *.* TO 'test_username'@'%' WITH GRANT OPTION",
-                f"GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON mysql_innodb_cluster_metadata.* TO 'test_username'@'%'",
-                f"GRANT SELECT ON mysql.user TO 'test_username'@'%'",
-                f"GRANT SELECT ON performance_schema.replication_group_members TO 'test_username'@'%'",
-                f"GRANT SELECT ON performance_schema.replication_group_member_stats TO 'test_username'@'%'",
-                f"GRANT SELECT ON performance_schema.global_variables TO 'test_username'@'%'",
+                "GRANT CREATE USER ON *.* TO 'test_username'@'%' WITH GRANT OPTION",
+                "GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON mysql_innodb_cluster_metadata.* TO 'test_username'@'%'",
+                "GRANT SELECT ON mysql.user TO 'test_username'@'%'",
+                "GRANT SELECT ON performance_schema.replication_group_members TO 'test_username'@'%'",
+                "GRANT SELECT ON performance_schema.replication_group_member_stats TO 'test_username'@'%'",
+                "GRANT SELECT ON performance_schema.global_variables TO 'test_username'@'%'",
             )
         )
 
@@ -164,20 +162,20 @@ class TestMySQLBase(unittest.TestCase):
         _run_mysqlcli_script.return_value = b""
 
         _expected_create_database_commands = "; ".join(
-            (
-                "CREATE DATABASE IF NOT EXISTS test_database CHARACTER SET UTF8",
-            )
+            ("CREATE DATABASE IF NOT EXISTS test_database CHARACTER SET UTF8",)
         )
 
         _expected_create_scoped_user_commands = "; ".join(
             (
-                f"CREATE USER 'test_username'@'%' IDENTIFIED BY 'test_password'",
-                f"GRANT USAGE ON *.* TO 'test_username'@`%`",
-                f"GRANT ALL PRIVILEGES ON `test_database`.* TO `test_username`@`%`",
+                "CREATE USER 'test_username'@'%' IDENTIFIED BY 'test_password'",
+                "GRANT USAGE ON *.* TO 'test_username'@`%`",
+                "GRANT ALL PRIVILEGES ON `test_database`.* TO `test_username`@`%`",
             )
         )
 
-        self.mysql.create_application_database_and_scoped_user("test_database", "test_username", "test_password")
+        self.mysql.create_application_database_and_scoped_user(
+            "test_database", "test_username", "test_password"
+        )
 
         self.assertEqual(_run_mysqlcli_script.call_count, 2)
 
@@ -197,7 +195,9 @@ class TestMySQLBase(unittest.TestCase):
         _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
 
         with self.assertRaises(MySQLCreateApplicationDatabaseAndScopedUserError):
-            self.mysql.create_application_database_and_scoped_user("test_database", "test_username", "test_password")
+            self.mysql.create_application_database_and_scoped_user(
+                "test_database", "test_username", "test_password"
+            )
 
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
     @patch("charms.mysql.v0.mysql.MySQLBase.wait_until_mysql_connection")

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -33,25 +33,25 @@ class TestMySQL(unittest.TestCase):
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
     def test_configure_mysql_users(self, _run_mysqlcli_script):
-        """Test failed to configuring the MySQL users."""
+        """Test successful configuration of the MySQL users."""
         _run_mysqlcli_script.return_value = b""
 
-        _expected_create_root_user_commands = " ".join(
+        _expected_create_root_user_commands = "; ".join(
             (
-                "CREATE USER 'root'@'%' IDENTIFIED BY 'password';",
-                "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION;",
+                "CREATE USER 'root'@'%' IDENTIFIED BY 'password'",
+                "GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION",
             )
         )
 
-        _expected_configure_user_commands = " ".join(
+        _expected_configure_user_commands = "; ".join(
             (
-                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword';",
-                "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION;",
-                "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost';",
-                "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password';",
-                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@'%';",
-                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@localhost;",
-                "FLUSH PRIVILEGES;",
+                "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword'",
+                "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION",
+                "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost'",
+                "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password'",
+                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@'%'",
+                "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM root@localhost",
+                "FLUSH PRIVILEGES",
             )
         )
 
@@ -71,7 +71,7 @@ class TestMySQL(unittest.TestCase):
 
     @patch("mysqlsh_helpers.MySQL._run_mysqlcli_script")
     def test_configure_mysql_users_fail(self, _run_mysqlcli_script):
-        """Test failed to configuring the MySQL users."""
+        """Test failure of configuring the MySQL users."""
         _run_mysqlcli_script.side_effect = subprocess.CalledProcessError(
             cmd="mysqlsh", returncode=127
         )
@@ -133,14 +133,14 @@ class TestMySQL(unittest.TestCase):
     def test_initialize_juju_units_operations_table(self, _run_mysqlcli_script):
         """Test a successful initialization of the mysql.juju_units_operations table."""
         expected_initialize_table_commands = (
-            "CREATE TABLE mysql.juju_units_operations (task varchar(20), executor varchar(20), status varchar(20), primary key(task));",
-            "INSERT INTO mysql.juju_units_operations values ('unit-teardown', '', 'not-started');",
+            "CREATE TABLE mysql.juju_units_operations (task varchar(20), executor varchar(20), status varchar(20), primary key(task))",
+            "INSERT INTO mysql.juju_units_operations values ('unit-teardown', '', 'not-started')",
         )
 
         self.mysql.initialize_juju_units_operations_table()
 
         _run_mysqlcli_script.assert_called_once_with(
-            " ".join(expected_initialize_table_commands),
+            "; ".join(expected_initialize_table_commands),
             user="serverconfig",
             password="serverconfigpassword",
         )


### PR DESCRIPTION
# Issue
We are not currently supporting the legacy `db-router` relation. The relation works by first setting some relevant data (see below) on the application leader unit databag, after which the database leader unit also sets some relevant data in its databag. After this exchange of data information, the mysql router charm bootstraps itself and the application is unblocked into using the mysql and mysqlrouter charms.

# Solution
Implement the legacy `db-router` relation. The charm implements a single (idempotent) `db_router_relation_changed` event handler which then parses and also populates the relevant data to/from the correct databag locations.

# Context
Below is an example of an application (keystone) databag inspection for the `db-router` relation:
```
(venv) ubuntu@shayanp-bastion:~/jhack$ python3 jhack.py utils show-relation keystone-mysql-router/0:db-router mysql/0:db-router
                                         relation data v0.1                                          
┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ category  ┃                      keys ┃ keystone-mysql-router/0 ┃ mysql/0                         ┃
┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ metadata  │                  endpoint │ 'db-router'             │ 'db-router'                     │
│           │                    leader │ True                    │ True                            │
├───────────┼───────────────────────────┼─────────────────────────┼─────────────────────────────────┤
│ unit data │        MRUP_allowed_units │                         │ "keystone-mysql-router/0"       │
│           │             MRUP_database │ keystone                │                                 │
│           │             MRUP_hostname │ 10.5.0.150              │                                 │
│           │             MRUP_password │                         │ "yRRg35dsGGtBkGwMwzZgr5BcRrdbk… │
│           │             MRUP_username │ keystone                │                                 │
│           │                   db_host │                         │ "10.5.1.208"                    │
│           │ mysqlrouter_allowed_units │                         │ "keystone-mysql-router/0"       │
│           │      mysqlrouter_hostname │ 10.5.0.150              │                                 │
│           │      mysqlrouter_password │                         │ "bVcp78RCcSSRCVzj79T3GPGLxK486… │
│           │      mysqlrouter_username │ mysqlrouteruser         │                                 │
│           │              wait_timeout │                         │ 3600                            │
└───────────┴───────────────────────────┴─────────────────────────┴─────────────────────────────────┘
```

- Data in the reactive charms was shared by setting in the leader units of the application and database units.
- The data (like passwords) are json encoded to be consumed in the mysqlrouter reactive charm.

# Release Notes
Implement the legacy db-router relation
