### PR TITLE
Minor fixes; getting ready to publish to charmhub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,8 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
-  integration-test-lxd:
-    name: Integration tests (lxd)
+  integration-test-lxd-ha:
+    name: Integration tests for HA (lxd)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,6 +36,29 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          lxd-channel: 4.24/stable # patch until https://bugs.launchpad.net/juju/+bug/1968849 is resolved
-      - name: Run integration tests
-        run: tox -e integration
+      - name: Run integration HA tests
+        run: tox -e integration-ha
+  integration-test-lxd-db-router:
+    name: Integration tests for db-router relation (lxd)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run integration db-router tests
+        run: tox -e integration-db-router
+  integration-test-lxd-shared-db:
+    name: Integration tests for shared-db relation (lxd)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run integration shared-db tests
+        run: tox -e integration-shared-db

--- a/README.md
+++ b/README.md
@@ -36,7 +36,31 @@ Note: the `--destroy-storage` will delete any data persisted by MySQL.
 
 ## Relations
 
-There are no relations implemented yet.
+We have added support for two legacy relations (from the [mysql-innodb-cluster](https://charmhub.io/mysql-innodb-cluster) charm):
+
+1. `db-router` is a relation that one uses with the [mysql router](https://charmhub.io/mysql-router) charm. The following commands can be executed to deploy and relate to the keystone charm:
+```shell
+# Deploy the relevant charms
+juju deploy -n 3 ./mysql_ubuntu-20.04-amd64.charm mysql
+juju deploy keystone
+juju deploy mysql-router keystone-mysql-router
+
+# Relate mysql-router with keystone
+juju relate keystone:shared-db keystone-mysql-router:shared-db
+
+# Relate mysql-router with mysql
+juju relate keystone-mysql-router:db-router mysql:db-router
+```
+
+2. `shared-db` is a relation that one uses when the application needs to connect directly to the database cluster. The following commands can be executed to deploy and relate to the keystone charm:
+```shell
+# Deploy the relevant charms
+juju deploy -n 3 ./mysql_ubuntu-20.04-amd64.charm mysql
+juju deploy keystone
+
+# Relate keystone with mysql
+juju relate keystone:shared-db mysql:shared-db
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ Note: the `--destroy-storage` will delete any data persisted by MySQL.
 We have added support for two legacy relations (from the [mysql-innodb-cluster](https://charmhub.io/mysql-innodb-cluster) charm):
 
 1. `db-router` is a relation that one uses with the [mysql router](https://charmhub.io/mysql-router) charm. The following commands can be executed to deploy and relate to the keystone charm:
+
 ```shell
+# Pack the charm
+charmcraft pack
+
 # Deploy the relevant charms
 juju deploy -n 3 ./mysql_ubuntu-20.04-amd64.charm mysql
 juju deploy keystone
@@ -52,8 +56,12 @@ juju relate keystone:shared-db keystone-mysql-router:shared-db
 juju relate keystone-mysql-router:db-router mysql:db-router
 ```
 
-2. `shared-db` is a relation that one uses when the application needs to connect directly to the database cluster. The following commands can be executed to deploy and relate to the keystone charm:
+1. `shared-db` is a relation that one uses when the application needs to connect directly to the database cluster. The following commands can be executed to deploy and relate to the keystone charm:
+
 ```shell
+# Pack the charm
+charmcraft pack
+
 # Deploy the relevant charms
 juju deploy -n 3 ./mysql_ubuntu-20.04-amd64.charm mysql
 juju deploy keystone

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -76,7 +76,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ra
 logger = logging.getLogger(__name__)
 
 # The unique Charmhub library identifier, never change it
-LIBID = "7c3dbc9c2ad44a47bd6fcb25caa270e5"
+LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -83,7 +83,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 

--- a/src/relations/db_router.py
+++ b/src/relations/db_router.py
@@ -171,7 +171,7 @@ class DBRouterRelation(Object):
                     relation_databag[self.charm.unit][key] = value
 
             # Update the db host as the cluster primary may have changed
-            primary_address = self.charm._mysql.get_cluster_primary_address()
+            primary_address = self.charm._mysql.get_cluster_primary_address().split(":")[0]
             relation_databag[self.charm.unit]["db_host"] = json.dumps(primary_address)
             relation_databag[self.charm.app]["db_host"] = json.dumps(primary_address)
 
@@ -225,7 +225,7 @@ class DBRouterRelation(Object):
                 " ".join(application_allowed_units)
             )
 
-        primary_address = self.charm._mysql.get_cluster_primary_address()
+        primary_address = self.charm._mysql.get_cluster_primary_address().split(":")[0]
         databag_updates["db_host"] = json.dumps(primary_address)
 
         # Copy the databag_updates to both the leader unit databag

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -28,6 +28,7 @@ CLUSTER_NAME = "test_cluster"
 
 @pytest.mark.order(1)
 @pytest.mark.abort_on_fail
+@pytest.mark.ha_tests
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     # Build and deploy charm from local source folder
@@ -56,6 +57,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 @pytest.mark.order(2)
 @pytest.mark.abort_on_fail
+@pytest.mark.ha_tests
 async def test_consistent_data_replication_across_cluster(ops_test: OpsTest) -> None:
     """Confirm that data is replicated from the primary node to all the replicas."""
     # Insert values into a table on the primary unit
@@ -109,6 +111,7 @@ async def test_consistent_data_replication_across_cluster(ops_test: OpsTest) -> 
 
 @pytest.mark.order(3)
 @pytest.mark.abort_on_fail
+@pytest.mark.ha_tests
 async def test_primary_reelection(ops_test: OpsTest) -> None:
     """Confirm that a new primary is elected when the current primary is torn down."""
     await ops_test.model.set_config({"update-status-hook-interval": "10s"})
@@ -159,6 +162,7 @@ async def test_primary_reelection(ops_test: OpsTest) -> None:
 
 @pytest.mark.order(4)
 @pytest.mark.abort_on_fail
+@pytest.mark.ha_tests
 async def test_cluster_preserves_data_on_delete(ops_test: OpsTest) -> None:
     """Test that data is preserved during scale up and scale down."""
     # Insert values into test table from the primary unit

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -54,7 +54,7 @@ async def deploy_and_relate_keystone_with_mysqlrouter(
         apps=[keystone_application_name],
         status="blocked",
         raise_on_blocked=False,
-        timeout=1000,
+        timeout=1500,
     )
 
     # Deploy mysqlrouter and relate it to keystone
@@ -70,7 +70,7 @@ async def deploy_and_relate_keystone_with_mysqlrouter(
         apps=[keystone_mysqlrouter_application_name],
         status="blocked",
         raise_on_blocked=False,
-        timeout=1000,
+        timeout=1500,
     )
 
     # Relate mysqlrouter to mysql
@@ -178,106 +178,102 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
     config = {"cluster-name": CLUSTER_NAME}
     await ops_test.model.deploy(charm, application_name=APP_NAME, config=config, num_units=3)
 
-    # Reduce the update_status frequency until the keystone charm is deployed
-    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
+    # Reduce the update_status frequency for the duration of the test
+    async with ops_test.fast_forward():
+        # Wait until the mysql charm is successfully deployed
+        await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
+        assert len(ops_test.model.applications[APP_NAME].units) == 3
 
-    # Wait until the mysql charm is successfully deployed
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-    )
-    assert len(ops_test.model.applications[APP_NAME].units) == 3
+        for unit in ops_test.model.applications[APP_NAME].units:
+            assert unit.workload_status == "active"
 
-    for unit in ops_test.model.applications[APP_NAME].units:
-        assert unit.workload_status == "active"
+        # Get the server config credentials
+        random_unit = ops_test.model.applications[APP_NAME].units[0]
+        server_config_credentials = await get_server_config_credentials(random_unit)
 
-    # Get the server config credentials
-    random_unit = ops_test.model.applications[APP_NAME].units[0]
-    server_config_credentials = await get_server_config_credentials(random_unit)
+        # Deploy and test the first deployment of keystone
+        await deploy_and_relate_keystone_with_mysqlrouter(
+            ops_test, KEYSTONE_APP_NAME, KEYSTONE_MYSQLROUTER_APP_NAME, 2
+        )
+        await check_successful_keystone_migration(ops_test, server_config_credentials)
 
-    # Deploy and test the first deployment of keystone
-    await deploy_and_relate_keystone_with_mysqlrouter(
-        ops_test, KEYSTONE_APP_NAME, KEYSTONE_MYSQLROUTER_APP_NAME, 2
-    )
-    await check_successful_keystone_migration(ops_test, server_config_credentials)
+        keystone_users = []
+        for unit in ops_test.model.applications[KEYSTONE_APP_NAME].units:
+            unit_address = await unit.get_public_address()
 
-    keystone_users = []
-    for unit in ops_test.model.applications[KEYSTONE_APP_NAME].units:
-        unit_address = await unit.get_public_address()
+            keystone_users.append(f"keystone@{unit_address}")
+            keystone_users.append(f"mysqlrouteruser@{unit_address}")
 
-        keystone_users.append(f"keystone@{unit_address}")
-        keystone_users.append(f"mysqlrouteruser@{unit_address}")
+        await check_keystone_users_existence(ops_test, server_config_credentials, keystone_users, [])
 
-    await check_keystone_users_existence(ops_test, server_config_credentials, keystone_users, [])
+        # Deploy and test another deployment of keystone
+        await deploy_and_relate_keystone_with_mysqlrouter(
+            ops_test, ANOTHER_KEYSTONE_APP_NAME, ANOTHER_KEYSTONE_MYSQLROUTER_APP_NAME, 2
+        )
+        await check_successful_keystone_migration(ops_test, server_config_credentials)
 
-    # Deploy and test another deployment of keystone
-    await deploy_and_relate_keystone_with_mysqlrouter(
-        ops_test, ANOTHER_KEYSTONE_APP_NAME, ANOTHER_KEYSTONE_MYSQLROUTER_APP_NAME, 2
-    )
-    await check_successful_keystone_migration(ops_test, server_config_credentials)
+        another_keystone_users = []
+        for unit in ops_test.model.applications[ANOTHER_KEYSTONE_APP_NAME].units:
+            unit_address = await unit.get_public_address()
 
-    another_keystone_users = []
-    for unit in ops_test.model.applications[ANOTHER_KEYSTONE_APP_NAME].units:
-        unit_address = await unit.get_public_address()
+            another_keystone_users.append(f"keystone@{unit_address}")
+            another_keystone_users.append(f"mysqlrouteruser@{unit_address}")
 
-        another_keystone_users.append(f"keystone@{unit_address}")
-        another_keystone_users.append(f"mysqlrouteruser@{unit_address}")
+        await check_keystone_users_existence(
+            ops_test, server_config_credentials, keystone_users + another_keystone_users, []
+        )
 
-    await check_keystone_users_existence(
-        ops_test, server_config_credentials, keystone_users + another_keystone_users, []
-    )
+        # Scale down the second deployment of keystone and confirm that the first deployment
+        # is still active
+        await scale_application(ops_test, ANOTHER_KEYSTONE_APP_NAME, 0)
+        await ops_test.model.remove_application(ANOTHER_KEYSTONE_APP_NAME, block_until_done=True)
+        await ops_test.model.remove_application(
+            ANOTHER_KEYSTONE_MYSQLROUTER_APP_NAME, block_until_done=True
+        )
 
-    # Scale down the second deployment of keystone and confirm that the first deployment
-    # is still active
-    await scale_application(ops_test, ANOTHER_KEYSTONE_APP_NAME, 0)
-    await ops_test.model.remove_application(ANOTHER_KEYSTONE_APP_NAME, block_until_done=True)
-    await ops_test.model.remove_application(
-        ANOTHER_KEYSTONE_MYSQLROUTER_APP_NAME, block_until_done=True
-    )
+        await check_keystone_users_existence(
+            ops_test, server_config_credentials, keystone_users, another_keystone_users
+        )
 
-    await check_keystone_users_existence(
-        ops_test, server_config_credentials, keystone_users, another_keystone_users
-    )
+        # Scale down the primary unit of mysql
+        primary_unit = await get_primary_unit(
+            ops_test,
+            random_unit,
+            APP_NAME,
+            CLUSTER_NAME,
+            server_config_credentials["username"],
+            server_config_credentials["password"],
+        )
+        primary_unit_name = primary_unit.name
 
-    # Scale down the primary unit of mysql
-    primary_unit = await get_primary_unit(
-        ops_test,
-        random_unit,
-        APP_NAME,
-        CLUSTER_NAME,
-        server_config_credentials["username"],
-        server_config_credentials["password"],
-    )
-    primary_unit_name = primary_unit.name
+        await ops_test.model.destroy_units(primary_unit_name)
 
-    await ops_test.model.destroy_units(primary_unit_name)
+        await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 2)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
 
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 2)
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-    )
+        await check_keystone_users_existence(
+            ops_test, server_config_credentials, keystone_users, another_keystone_users
+        )
 
-    await check_keystone_users_existence(
-        ops_test, server_config_credentials, keystone_users, another_keystone_users
-    )
+        # Scale mysql back up to 3 units
+        await scale_application(ops_test, APP_NAME, 3)
 
-    # Scale mysql back up to 3 units
-    await scale_application(ops_test, APP_NAME, 3)
+        # Scale down the first deployment of keystone
+        await scale_application(ops_test, KEYSTONE_APP_NAME, 0)
+        await ops_test.model.remove_application(KEYSTONE_APP_NAME, block_until_done=True)
+        await ops_test.model.remove_application(KEYSTONE_MYSQLROUTER_APP_NAME, block_until_done=True)
 
-    # Scale down the first deployment of keystone
-    await scale_application(ops_test, KEYSTONE_APP_NAME, 0)
-    await ops_test.model.remove_application(KEYSTONE_APP_NAME, block_until_done=True)
-    await ops_test.model.remove_application(KEYSTONE_MYSQLROUTER_APP_NAME, block_until_done=True)
-
-    # Scale down the mysql application
-    await scale_application(ops_test, APP_NAME, 0)
-    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
-
-    # Effectively disable the update status from firing
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+        # Scale down the mysql application
+        await scale_application(ops_test, APP_NAME, 0)
+        await ops_test.model.remove_application(APP_NAME, block_until_done=True)

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -164,8 +164,9 @@ async def check_keystone_users_existence(
         assert user not in output
 
 
-@pytest.mark.order(100)
+@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
+@pytest.mark.db_router_tests
 async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
     """Deploy the keystone bundle to test the 'db-router' relation.
 

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -181,7 +181,9 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
     # Reduce the update_status frequency for the duration of the test
     async with ops_test.fast_forward():
         # Wait until the mysql charm is successfully deployed
-        await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APP_NAME].units) == 3
+        )
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
             status="active",
@@ -210,7 +212,9 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
             keystone_users.append(f"keystone@{unit_address}")
             keystone_users.append(f"mysqlrouteruser@{unit_address}")
 
-        await check_keystone_users_existence(ops_test, server_config_credentials, keystone_users, [])
+        await check_keystone_users_existence(
+            ops_test, server_config_credentials, keystone_users, []
+        )
 
         # Deploy and test another deployment of keystone
         await deploy_and_relate_keystone_with_mysqlrouter(
@@ -254,7 +258,9 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
 
         await ops_test.model.destroy_units(primary_unit_name)
 
-        await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 2)
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APP_NAME].units) == 2
+        )
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
             status="active",
@@ -272,7 +278,9 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
         # Scale down the first deployment of keystone
         await scale_application(ops_test, KEYSTONE_APP_NAME, 0)
         await ops_test.model.remove_application(KEYSTONE_APP_NAME, block_until_done=True)
-        await ops_test.model.remove_application(KEYSTONE_MYSQLROUTER_APP_NAME, block_until_done=True)
+        await ops_test.model.remove_application(
+            KEYSTONE_MYSQLROUTER_APP_NAME, block_until_done=True
+        )
 
         # Scale down the mysql application
         await scale_application(ops_test, APP_NAME, 0)

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -166,7 +166,7 @@ async def check_keystone_users_existence(
 
 @pytest.mark.order(100)
 @pytest.mark.abort_on_fail
-async def test_keystone_bundle(ops_test: OpsTest) -> None:
+async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
     """Deploy the keystone bundle to test the 'db-router' relation.
 
     Args:

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -142,8 +142,9 @@ async def check_keystone_users_existence(
         assert user not in output
 
 
-@pytest.mark.order(100)
+@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
+@pytest.mark.shared_db_tests
 async def test_keystone_bundle_shared_db(ops_test: OpsTest) -> None:
     """Deploy the keystone bundle to test the 'shared-db' relation.
 

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -144,7 +144,7 @@ async def check_keystone_users_existence(
 
 @pytest.mark.order(100)
 @pytest.mark.abort_on_fail
-async def test_keystone_bundle(ops_test: OpsTest) -> None:
+async def test_keystone_bundle_shared_db(ops_test: OpsTest) -> None:
     """Deploy the keystone bundle to test the 'shared-db' relation.
 
     Args:

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -156,9 +156,8 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest) -> None:
     config = {"cluster-name": CLUSTER_NAME}
     await ops_test.model.deploy(charm, application_name=APP_NAME, config=config, num_units=3)
 
-    # Reduce the update_status frequency until the keystone charm is deployed
+    # Reduce the update_status frequency for the duration of the teset
     async with ops_test.fast_forward():
-
         # Wait until the mysql charm is successfully deployed
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],

--- a/tox.ini
+++ b/tox.ini
@@ -76,3 +76,39 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+
+[testenv:integration-ha]
+description = Run integration tests
+deps =
+    juju
+    mysql-connector-python
+    pytest
+    pytest-operator
+    pytest-order
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "ha_tests"
+
+[testenv:integration-db-router]
+description = Run integration tests
+deps =
+    juju
+    mysql-connector-python
+    pytest
+    pytest-operator
+    pytest-order
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "db_router_tests"
+
+[testenv:integration-shared-db]
+description = Run integration tests
+deps =
+    juju
+    mysql-connector-python
+    pytest
+    pytest-operator
+    pytest-order
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "shared_db_tests"


### PR DESCRIPTION
# Issue
- `mysql.get_cluster_primary_address()` returns a `host:port`, while we only need the host
- integration tests for legacy relations are named the same
- the lib patch version needs to be incremented to be able to publish the charm on charmhub

# Solution
- use `.split(":")[0]` to only get the host
- rename the integration tests
- update the lib patch version

# Release Notes
Get charm ready for publish to charmhub
