### PR TITLE
Add guards to not remove instance from cluster if it is not already a member

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -193,9 +193,18 @@ class MySQLOperatorCharm(CharmBase):
 
     def _on_database_storage_detaching(self, _) -> None:
         """Handle the database storage detaching event."""
+        # Only execute if peer relation data contains cluster config values
+        if not self._is_peer_data_set:
+            return
+
+        unit_label = self.unit.name.replace("/", "-")
+
+        # No need to remove the instance from the cluster if it is not a member of the cluster
+        if not self._mysql.is_instance_in_cluster(unit_label):
+            return
+
         # The following operation uses locks to ensure that only one instance is removed
         # from the cluster at a time (to avoid split-brain or lack of majority issues)
-        unit_label = self.unit.name.replace("/", "-")
         self._mysql.remove_instance(unit_label)
 
     # =======================

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -167,9 +167,9 @@ async def execute_commands_on_unit(
     unit_address: str,
     username: str,
     password: str,
-    queries: List,
+    queries: List[str],
     commit: bool = False,
-):
+) -> List:
     """Execute given MySQL queries on a unit.
 
     Args:


### PR DESCRIPTION
# Issue
[Issue](https://github.com/canonical/mysql-operator/issues/23)
The above issue is caused by a race condition where the model (and thus cluster) is torn down before being fully initialized. The error trace is encountered when the instance/unit being torn down is not a member of the cluster and is being attempted to be removed from the cluster in the `storage_detached` event handler.

# Solution
Add guards to not attempt to remove the instance from the cluster if it is not already a member of the cluster.

# Release Notes
Add guards to not remove instance from cluster if it is not already a member
