### PR TITLE
Avoid printing error trace for warning logs of is_instance_configured_for_innodb

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -83,7 +83,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -598,7 +598,6 @@ class MySQLBase(ABC):
             # confirmation can fail if the clusteradmin user does not yet exist on the instance
             logger.warning(
                 f"Failed to confirm instance configuration for {instance_address} with error {e.message}",
-                exc_info=e,
             )
             return False
 


### PR DESCRIPTION
# Issue
```
unit-mysql-k8s-0: 19:52:19 ERROR unit.mysql-k8s/0.juju-log database-peers:1:   mysqlsh.DBError: MySQL Error (2003): Shell.connect: Can't connect to MySQL server on 'mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local:3306' (111)
unit-mysql-k8s-0: 19:52:19 WARNING unit.mysql-k8s/0.juju-log database-peers:1: Failed to confirm instance configuration for mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local with error Cannot set LC_ALL to locale en_US.UTF-8: No such file or directory
verbose: 2022-07-20T18:52:19Z: About to connect to MySQL at: clusteradmin@mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local
mysqlsh.DBError: MySQL Error (2003): Shell.connect: Can't connect to MySQL server on 'mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local:3306' (111)
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/src/mysqlsh_helpers.py", line 272, in _run_mysqlsh_script
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/venv/ops/pebble.py", line 1103, in wait_output
ops.pebble.ExecError: non-zero exit code 1 executing ['/usr/bin/mysqlsh', '--no-wizard', '--python', '--verbose=1', '-f', '/tmp/script.py', ';', 'rm', '/tmp/script.py'], stdout='', stderr='Cannot set LC_ALL to locale en_US.UTF-8: No such file or directory\nverbose: 2022-07-20T18:52:19Z: Loading startup files...\nverbose: 2022-07-20T18:52:19Z: Loading plugins...\nverbose: 2022-07-20T18:52:19Z: About to connect to MySQL at: clusteradmin@mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local\nTraceback (most recent call last):\n  File "<string>", line 1, in <module>\nmysqlsh.DBError: MySQL Error (2003): Shell.connect: Can\'t connect to MySQL server on \'mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local:3306\' (111)\n'
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/lib/charms/mysql/v0/mysql.py", line 540, in is_instance_configured_for_innodb
    output = self._run_mysqlsh_script("\n".join(commands))
  File "/var/lib/juju/agents/unit-mysql-k8s-0/charm/src/mysqlsh_helpers.py", line 279, in _run_mysqlsh_script
charms.mysql.v0.mysql.MySQLClientError: Cannot set LC_ALL to locale en_US.UTF-8: No such file or directory
verbose: 2022-07-20T18:52:19Z: About to connect to MySQL at: clusteradmin@mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local
mysqlsh.DBError: MySQL Error (2003): Shell.connect: Can't connect to MySQL server on 'mysql-k8s-1.mysql-k8s-endpoints.dev.svc.cluster.local:3306' (111)
```
The above stack trace is printed when `is_instance_configured_for_innodb` returns `False`. The statement should just be printing a warning statement without the error trace.

# Solution
Remove the error trace

# Release Notes
n/a