### PR TITLE
Fix/speedup integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: Tests
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -37,7 +37,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(charm, application_name=APP_NAME, config=config, num_units=3)
 
     # Reduce the update_status frequency until the cluster is deployed
-    with ops_test.fast_forward():
+    async with ops_test.fast_forward():
 
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[APP_NAME].units) == 3
@@ -134,7 +134,7 @@ async def test_primary_reelection(ops_test: OpsTest) -> None:
     # juju status changed from active
     await ops_test.model.destroy_units(primary_unit.name)
 
-    with ops_test.fast_forward():
+    async with ops_test.fast_forward():
         await ops_test.model.block_until(lambda: len(application.units) == 2)
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
@@ -157,7 +157,7 @@ async def test_primary_reelection(ops_test: OpsTest) -> None:
     assert primary_unit_name != new_primary_unit.name
 
     # Add the unit back and wait until it is active
-    with ops_test.fast_forward():
+    async with ops_test.fast_forward():
         await scale_application(ops_test, APP_NAME, 3)
 
 
@@ -200,7 +200,7 @@ async def test_cluster_preserves_data_on_delete(ops_test: OpsTest) -> None:
     old_unit_names = [unit.name for unit in ops_test.model.applications[APP_NAME].units]
 
     # Add a unit and wait until it is active
-    with ops_test.fast_forward():
+    async with ops_test.fast_forward():
         await scale_application(ops_test, APP_NAME, 4)
 
     added_unit = [unit for unit in application.units if unit.name not in old_unit_names][0]
@@ -222,7 +222,7 @@ async def test_cluster_preserves_data_on_delete(ops_test: OpsTest) -> None:
 
     # Destroy the recently created unit and wait until the application is active
     await ops_test.model.destroy_units(added_unit.name)
-    with ops_test.fast_forward():
+    async with ops_test.fast_forward():
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[APP_NAME].units) == 3
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -37,22 +37,21 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(charm, application_name=APP_NAME, config=config, num_units=3)
 
     # Reduce the update_status frequency until the cluster is deployed
-    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
+    with ops_test.fast_forward():
 
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-    )
-    assert len(ops_test.model.applications[APP_NAME].units) == 3
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APP_NAME].units) == 3
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
+        assert len(ops_test.model.applications[APP_NAME].units) == 3
 
-    for unit in ops_test.model.applications[APP_NAME].units:
-        assert unit.workload_status == "active"
-
-    # Effectively disable the update status from firing
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
+        for unit in ops_test.model.applications[APP_NAME].units:
+            assert unit.workload_status == "active"
 
 
 @pytest.mark.order(2)
@@ -135,13 +134,14 @@ async def test_primary_reelection(ops_test: OpsTest) -> None:
     # juju status changed from active
     await ops_test.model.destroy_units(primary_unit.name)
 
-    await ops_test.model.block_until(lambda: len(application.units) == 2)
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-    )
+    with ops_test.fast_forward():
+        await ops_test.model.block_until(lambda: len(application.units) == 2)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
 
     # Wait for unit to be destroyed and confirm that the new primary unit is different
     random_unit = application.units[0]
@@ -220,14 +220,14 @@ async def test_cluster_preserves_data_on_delete(ops_test: OpsTest) -> None:
 
     # Destroy the recently created unit and wait until the application is active
     await ops_test.model.destroy_units(added_unit.name)
-
-    await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-    )
+    with ops_test.fast_forward():
+        await ops_test.model.block_until(lambda: len(ops_test.model.applications[APP_NAME].units) == 3)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1000,
+        )
 
     # Ensure that the data still exists in all the units
     for unit in application.units:

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -44,36 +44,37 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.deploy(app_charm, application_name=APPLICATION_APP_NAME, num_units=2)
 
     # Reduce the update_status frequency until the cluster is deployed
-    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
+    with ops_test.fast_forward():
 
-    await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[DATABASE_APP_NAME].units) == 3
-    )
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[DATABASE_APP_NAME].units) == 3
+        )
 
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME],
-        status="active",
-        raise_on_blocked=True,
-        timeout=1000,
-    )
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[APPLICATION_APP_NAME].units) == 2
+        )
+
+        asyncio.gather(
+            await ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME],
+                status="active",
+                raise_on_blocked=True,
+                timeout=1000,
+            ),
+            await ops_test.model.wait_for_idle(
+                apps=[APPLICATION_APP_NAME],
+                status="waiting",
+                raise_on_blocked=True,
+                timeout=1000,
+            ),
+        )
+
     assert len(ops_test.model.applications[DATABASE_APP_NAME].units) == 3
 
     for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
         assert unit.workload_status == "active"
 
-    await ops_test.model.block_until(
-        lambda: len(ops_test.model.applications[APPLICATION_APP_NAME].units) == 2
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[APPLICATION_APP_NAME],
-        status="waiting",
-        raise_on_blocked=True,
-        timeout=1000,
-    )
     assert len(ops_test.model.applications[APPLICATION_APP_NAME].units) == 2
-
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
 
 
 @pytest.mark.order(2)
@@ -83,11 +84,12 @@ async def test_relation_creation(ops_test: OpsTest):
     """Relate charms and wait for the expected changes in status."""
     await ops_test.model.relate(APPLICATION_APP_NAME, f"{DATABASE_APP_NAME}:database")
 
-    await ops_test.model.block_until(
-        lambda: is_relation_joined(ops_test, ENDPOINT, ENDPOINT) == True  # noqa: E712
-    )
+    with ops_test.fast_forward():
+        await ops_test.model.block_until(
+            lambda: is_relation_joined(ops_test, ENDPOINT, ENDPOINT) == True  # noqa: E712
+        )
 
-    await ops_test.model.wait_for_idle(apps=APPS, status="active")
+        await ops_test.model.wait_for_idle(apps=APPS, status="active")
 
 
 @pytest.mark.order(3)
@@ -103,11 +105,12 @@ async def test_relation_broken(ops_test: OpsTest):
         lambda: is_relation_broken(ops_test, ENDPOINT, ENDPOINT) == True  # noqa: E712
     )
 
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(
-            apps=[DATABASE_APP_NAME], status="active", raise_on_blocked=True
-        ),
-        ops_test.model.wait_for_idle(
-            apps=[APPLICATION_APP_NAME], status="waiting", raise_on_blocked=True
-        ),
-    )
+    with ops_test.fast_forward():
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME], status="active", raise_on_blocked=True
+            ),
+            ops_test.model.wait_for_idle(
+                apps=[APPLICATION_APP_NAME], status="waiting", raise_on_blocked=True
+            ),
+        )

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -27,6 +27,8 @@ KEYSTONE_APP_NAME = "keystone"
 KEYSTONE_MYSQLROUTER_APP_NAME = "keystone-mysql-router"
 ANOTHER_KEYSTONE_APP_NAME = "another-keystone"
 ANOTHER_KEYSTONE_MYSQLROUTER_APP_NAME = "another-keystone-mysql-router"
+SLOW_WAIT_TIMEOUT = 25 * 60
+FAST_WAIT_TIMEOUT = 15 * 60
 
 
 async def deploy_and_relate_keystone_with_mysqlrouter(
@@ -68,13 +70,13 @@ async def deploy_and_relate_keystone_with_mysqlrouter(
             apps=[keystone_application_name],
             status="blocked",
             raise_on_blocked=False,
-            timeout=1500,
+            timeout=SLOW_WAIT_TIMEOUT,
         ),
         ops_test.model.wait_for_idle(
             apps=[keystone_mysqlrouter_application_name],
             status="blocked",
             raise_on_blocked=False,
-            timeout=1500,
+            timeout=SLOW_WAIT_TIMEOUT,
         ),
     )
 
@@ -85,7 +87,7 @@ async def deploy_and_relate_keystone_with_mysqlrouter(
     await ops_test.model.block_until(
         lambda: keystone_app.status in ("active", "error")
         and keystone_mysqlrouter_app.status in ("active", "error"),
-        timeout=1500,
+        timeout=SLOW_WAIT_TIMEOUT,
     )
     assert keystone_app.status == "active" and keystone_mysqlrouter_app.status == "active"
 
@@ -193,7 +195,7 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
             apps=[APP_NAME],
             status="active",
             raise_on_blocked=True,
-            timeout=1000,
+            timeout=FAST_WAIT_TIMEOUT,
         )
         assert len(ops_test.model.applications[APP_NAME].units) == 3
 
@@ -273,7 +275,7 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
             apps=[APP_NAME],
             status="active",
             raise_on_blocked=True,
-            timeout=1000,
+            timeout=FAST_WAIT_TIMEOUT,
         )
 
         await check_keystone_users_existence(

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -24,6 +24,8 @@ APP_NAME = METADATA["name"]
 CLUSTER_NAME = "test_cluster"
 KEYSTONE_APP_NAME = "keystone"
 ANOTHER_KEYSTONE_APP_NAME = "another-keystone"
+SLOW_WAIT_TIMEOUT = 25 * 60
+FAST_WAIT_TIMEOUT = 15 * 60
 
 
 async def deploy_and_relate_keystone_with_mysql(
@@ -50,7 +52,7 @@ async def deploy_and_relate_keystone_with_mysql(
         apps=[keystone_application_name],
         status="blocked",
         raise_on_blocked=False,
-        timeout=1000,
+        timeout=SLOW_WAIT_TIMEOUT,
     )
 
     # Relate keystone to mysql
@@ -59,7 +61,7 @@ async def deploy_and_relate_keystone_with_mysql(
         apps=[keystone_application_name],
         status="active",
         raise_on_blocked=False,  # both applications are blocked initially
-        timeout=1000,
+        timeout=SLOW_WAIT_TIMEOUT,
     )
 
 
@@ -156,14 +158,14 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest) -> None:
     config = {"cluster-name": CLUSTER_NAME}
     await ops_test.model.deploy(charm, application_name=APP_NAME, config=config, num_units=3)
 
-    # Reduce the update_status frequency for the duration of the teset
+    # Reduce the update_status frequency for the duration of the test
     async with ops_test.fast_forward():
         # Wait until the mysql charm is successfully deployed
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
             status="active",
             raise_on_blocked=True,
-            timeout=1000,
+            timeout=FAST_WAIT_TIMEOUT,
             wait_for_exact_units=3,
         )
         assert len(ops_test.model.applications[APP_NAME].units) == 3
@@ -229,7 +231,7 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest) -> None:
             apps=[APP_NAME],
             status="active",
             raise_on_blocked=True,
-            timeout=1000,
+            timeout=FAST_WAIT_TIMEOUT,
             wait_for_exact_units=2,
         )
 


### PR DESCRIPTION
# Issue

Integration tests, specially ones for legacy relations using production apps, are very slow running.

# Solution

Usage of `Ops_Test.fast_forward` here and there, and `asyncio.gather` when possible.
Got 7%-12% faster testing on serverstack. (~~will try to measure on GH  ci also~~ longest running test went from ~54min to ~40min)
**Note:** There's no new feature on this PR.

# Testing

Let the CI burn.

# Release Notes
Besides modifications in `tests/integration/test_*.py` removed redundant test execution when merge to main, which is done by the release workflow.
