### PR TITLE
add missing config after removing defaults

### DIFF
--- a/tests/unit/test_relation_mysql_legacy.py
+++ b/tests/unit/test_relation_mysql_legacy.py
@@ -39,6 +39,9 @@ class TestMariaDBRelation(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
+        self.harness.update_config(
+            {"mysql-interface-user": "mysql", "mysql-interface-database": "default_database"}
+        )
 
         # Relate to emit relation created event
         self.maria_db_relation_id = self.harness.add_relation(LEGACY_MYSQL, "other-app")


### PR DESCRIPTION
# Issue

Removed a couple of config default values on previous PR #28 and forgot to replicate change to unit test.


# Solution

Add config values on unit test.

