### PR TITLE
Bugfix/relation broken

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -214,6 +214,9 @@ class MySQLOperatorCharm(CharmBase):
         # from the cluster at a time (to avoid split-brain or lack of majority issues)
         self._mysql.remove_instance(unit_label)
 
+        # Inform other hooks of current status
+        self._peers.data[self.unit]["unit-status"] = "removing"
+
     # =======================
     #  Custom Action Handlers
     # =======================

--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -121,7 +121,7 @@ class DatabaseRelation(Object):
             # run once by the leader
             return
 
-        if len(self.charm._peers.units) == 0:
+        if self.charm._peers.data[self.charm.unit].get("unit-status", None) == "removing":
             # safeguard against relation broken being triggered for
             # a unit being torn down (instead of un-related)
             # https://github.com/canonical/mysql-operator/issues/32

--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -17,7 +17,7 @@ from charms.mysql.v0.mysql import (
     MySQLGetClusterMembersAddressesError,
     MySQLGetMySQLVersionError,
 )
-from ops.charm import RelationDepartedEvent
+from ops.charm import RelationBrokenEvent
 from ops.framework import Object
 from ops.model import BlockedStatus
 
@@ -112,13 +112,19 @@ class DatabaseRelation(Object):
             logger.exception("Failed to get primary", exc_info=e)
             self.charm.unit.status = BlockedStatus("Failed to get primary")
 
-    def _on_database_broken(self, event: RelationDepartedEvent) -> None:
+    def _on_database_broken(self, event: RelationBrokenEvent) -> None:
         """Handle the removal of database relation.
 
         Remove user, keeping database intact.
         """
         if not self.charm.unit.is_leader():
             # run once by the leader
+            return
+
+        if len(self.charm._peers.units) == 0:
+            # safeguard against relation broken being triggered for
+            # a unit being torn down (instead of un-related)
+            # https://github.com/canonical/mysql-operator/issues/32
             return
 
         try:

--- a/src/relations/shared_db.py
+++ b/src/relations/shared_db.py
@@ -169,7 +169,6 @@ class SharedDBRelation(Object):
         departing_unit = event.departing_unit.name
         local_unit_data = event.relation.data[self._charm.unit]
         local_app_data = event.relation.data[self._charm.app]
-        # from ipdb import set_trace; set_trace()
 
         current_allowed_units = local_unit_data.get("allowed_units", "")
 


### PR DESCRIPTION
# Issue

Refer to issue #32 

# Solution

Check peer access to diagnose if the unit is being torn down or if the relation is really broken.

# Context

Juju generates a `relation-broken` event for a departing unit, even if the relation is not being broken.
This was reported in [this bug](https://bugs.launchpad.net/juju/+bug/1979811).

# Testing

Manual validation using reported scenario. Integration test is going to be added in shakedown tests PR.


