### PR TITLE
Fix update endpoints

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -176,11 +176,13 @@ class MySQLOperatorCharm(CharmBase):
             event.defer()
             return
 
-        # Safeguard againts event deferall
+        # Safeguard against event deferall
         if self._mysql.is_instance_in_cluster(event_unit_label):
-            logger.debug(f"Unit {event_unit_label} is already part of the cluster, don't try to add it again.")
+            logger.debug(
+                f"Unit {event_unit_label} is already part of the cluster, don't try to add it again."
+            )
             return
-            
+
         # Add the instance to the cluster. This operation uses locks to ensure that
         # only one instance is added to the cluster at a time
         # (so only one instance is involved in a state transfer at a time)

--- a/src/charm.py
+++ b/src/charm.py
@@ -176,6 +176,11 @@ class MySQLOperatorCharm(CharmBase):
             event.defer()
             return
 
+        # Safeguard againts event deferall
+        if self._mysql.is_instance_in_cluster(event_unit_label):
+            logger.debug(f"Unit {event_unit_label} is already part of the cluster, don't try to add it again.")
+            return
+            
         # Add the instance to the cluster. This operation uses locks to ensure that
         # only one instance is added to the cluster at a time
         # (so only one instance is involved in a state transfer at a time)

--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -65,6 +65,13 @@ class DatabaseRelation(Object):
             logger.debug("Waiting cluster to be initialized")
             return
         
+        logger.info(f"self charm: {self.charm.unit.name} and departing unit: {event.departing_unit.name}")
+        # check if the leader is departing
+        logger.info(f"is leader leaving: {self.charm.unit.name == event.departing_unit.name}")
+        if self.charm.unit.name == event.departing_unit.name:
+            event.defer()
+            return
+
         # get unit name that departed
         dep_unit_name = event.departing_unit.name.replace("/", "-")
         
@@ -140,7 +147,7 @@ class DatabaseRelation(Object):
                 }
             )
             self.database.set_read_only_endpoints(relation_id, ",".join(read_only_endpoints))
-            logger.debug(f"Updateed endpoints for {remote_app}")
+            logger.debug(f"Updated endpoints for {remote_app}")
 
         except MySQLCreateApplicationDatabaseAndScopedUserError:
             logger.error(f"Failed to create scoped user for app {remote_app}")

--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -50,7 +50,6 @@ class DatabaseRelation(Object):
 
     def _on_leader_elected(self, _):
         """Handle on leader elected event for the database relation."""
-
         if not self.charm.unit.is_leader():
             return
         # get all relations involving the database relation
@@ -147,7 +146,6 @@ class DatabaseRelation(Object):
             relation_id (int): The id of the relation
             remote_app (str): The name of the remote application
         """
-
         try:
 
             primary_endpoint = self.charm._mysql.get_cluster_primary_address()

--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -19,13 +19,11 @@ from charms.mysql.v0.mysql import (
     MySQLGrantPrivilegesToUserError,
     MySQLUpgradeUserForMySQLRouterError,
 )
-
-from ops.charm import RelationDepartedEvent, RelationJoinedEvent, RelationBrokenEvent
+from ops.charm import RelationBrokenEvent, RelationDepartedEvent, RelationJoinedEvent
 from ops.framework import Object
 from ops.model import BlockedStatus
 
 from constants import DB_RELATION_NAME, PASSWORD_LENGTH, PEER
-from tests.integration.helpers import app_name
 from utils import generate_random_password
 
 logger = logging.getLogger(__name__)
@@ -45,20 +43,15 @@ class DatabaseRelation(Object):
         self.framework.observe(
             self.charm.on[DB_RELATION_NAME].relation_broken, self._on_database_broken
         )
-        self.framework.observe(
-            self.charm.on[PEER].relation_joined, self._on_relation_joined
-        )
-        self.framework.observe(
-            self.charm.on[PEER].relation_departed, self._on_relation_departed
-        )
+        self.framework.observe(self.charm.on[PEER].relation_joined, self._on_relation_joined)
+        self.framework.observe(self.charm.on[PEER].relation_departed, self._on_relation_departed)
 
-        self.framework.observe(
-            self.charm.on.leader_elected, self._on_leader_elected
-        )
+        self.framework.observe(self.charm.on.leader_elected, self._on_leader_elected)
 
-    def _on_leader_elected(self, _ ):
-        logger.info(f"On leader elected!")
-        
+    def _on_leader_elected(self, _):
+        """Handle on leader elected event for the database relation."""
+        logger.info("On leader elected!")
+
         if not self.charm.unit.is_leader():
             return
         # get all relations involving the database relation
@@ -70,7 +63,7 @@ class DatabaseRelation(Object):
         if not self.charm.cluster_initialized:
             logger.debug("Waiting cluster to be initialized")
             return
-        
+
         relation_data = self.database.fetch_relation_data()
         # for all relations update the read-only-endpoints
         for relation in relations:
@@ -80,7 +73,6 @@ class DatabaseRelation(Object):
                 continue
             self._update_endpoints(relation_id=relation.id, app_name=self.charm.unit.name)
 
-        
     def _on_relation_departed(self, event: RelationDepartedEvent):
         """Handle the peer relation departed event for the database relation."""
         if not self.charm.unit.is_leader():
@@ -94,8 +86,10 @@ class DatabaseRelation(Object):
         if not self.charm.cluster_initialized:
             logger.debug("Waiting cluster to be initialized")
             return
-        
-        logger.info(f"self charm: {self.charm.unit.name} and departing unit: {event.departing_unit.name}")
+
+        logger.info(
+            f"self charm: {self.charm.unit.name} and departing unit: {event.departing_unit.name}"
+        )
         # check if the leader is departing
         logger.info(f"is leader leaving: {self.charm.unit.name == event.departing_unit.name}")
         if self.charm.unit.name == event.departing_unit.name:
@@ -104,13 +98,13 @@ class DatabaseRelation(Object):
 
         # get unit name that departed
         dep_unit_name = event.departing_unit.name.replace("/", "-")
-        
+
         # differ if the added unit is still in the cluster
         if self.charm._mysql.is_instance_in_cluster(dep_unit_name):
             logger.info(f"Departing unit {dep_unit_name} is still in the cluster!")
             event.defer()
             return
-        
+
         relation_data = self.database.fetch_relation_data()
         # for all relations update the read-only-endpoints
         for relation in relations:
@@ -120,7 +114,6 @@ class DatabaseRelation(Object):
                 continue
             # update the endpoints
             self._update_endpoints(relation.id, event)
-
 
     def _on_relation_joined(self, event: RelationJoinedEvent):
         """Handle the peer relation joined event for the database relation."""
@@ -135,9 +128,9 @@ class DatabaseRelation(Object):
         if not self.charm.cluster_initialized:
             logger.debug("Waiting cluster to be initialized")
             return
-         
+
         # get unit name that joined
-        event_unit_label = event.unit.name.replace("/", "-")    
+        event_unit_label = event.unit.name.replace("/", "-")
 
         # differ if the added unit is not in the cluster
         if not self.charm._mysql.is_instance_in_cluster(event_unit_label):
@@ -154,12 +147,11 @@ class DatabaseRelation(Object):
             # update the endpoints
             self._update_endpoints(relation.id, event)
 
-
     def _update_endpoints(self, relation_id: int, remote_app: str):
-        """Update the read-only-endpoints
+        """Update the read-only-endpoints.
 
         Args:
-            relation_id (int): The id of the relation 
+            relation_id (int): The id of the relation
             remote_app (str): The name of the remote application
         """
         logger.info("Start endpoint update: ")
@@ -282,8 +274,7 @@ class DatabaseRelation(Object):
             # https://github.com/canonical/mysql-operator/issues/32
             return
 
-
-        logger.info(f"On database broken!")
+        logger.info("On database broken!")
         try:
             relation_id = event.relation.id
             self.charm._mysql.delete_user_for_relation(relation_id)

--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -254,6 +254,7 @@ class DatabaseRelation(Object):
             # https://github.com/canonical/mysql-operator/issues/32
             return
 
+
         logger.info(f"On database broken!")
         try:
             relation_id = event.relation.id

--- a/src/relations/database.py
+++ b/src/relations/database.py
@@ -240,7 +240,6 @@ class DatabaseRelation(Object):
         if not self.charm.unit.is_leader():
             # run once by the leader
             return
-<<<<<<< HEAD
 
         if self.charm._peers.data[self.charm.unit].get("unit-status", None) == "removing":
             # safeguard against relation broken being triggered for
@@ -248,9 +247,7 @@ class DatabaseRelation(Object):
             # https://github.com/canonical/mysql-operator/issues/32
             return
 
-=======
         logger.info(f"On database broken!")
->>>>>>> Correctlt update the read-only-endpoints when a unit is added or removed
         try:
             relation_id = event.relation.id
             self.charm._mysql.delete_user_for_relation(relation_id)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,7 +4,6 @@
 
 import itertools
 import json
-import logging
 import re
 import secrets
 import string
@@ -456,6 +455,7 @@ def get_read_only_endpoint_hostnames(relation_data: list) -> List[str]:
             raise ValueError("Malformed endpoint")
     return roe_hostnames
 
+
 async def remove_leader_unit(ops_test: OpsTest, application_name: str):
     """Removes the leader unit of a specified application.
 
@@ -486,15 +486,16 @@ async def remove_leader_unit(ops_test: OpsTest, application_name: str):
             raise_on_blocked=True,
             timeout=1000,
         )
-    
 
 
 async def get_unit_hostname(ops_test: OpsTest, app_name: str) -> List[str]:
     """Retrieves hostnames of given application units.
-    
+
     Args:
         ops_test: The ops test framework instance
-        application_name: The name of the application
+        app_name: The name of the application
+    Returns:
+        a list that contains the hostnames of a given application
     """
     units = [app_unit.name for app_unit in ops_test.model.applications[app_name].units]
     status = await ops_test.model.get_status()  # noqa: F821

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -381,6 +381,7 @@ async def get_relation_data(
     ops_test: OpsTest,
     application_name: str,
     relation_name: str,
+    unit_id: int = 0
 ) -> list:
     """Returns a that contains the relation-data
     Args:
@@ -390,7 +391,7 @@ async def get_relation_data(
     Returns:
         a dictionary that contains the relation-data
     """
-    unit_name = f"{application_name}/0"
+    unit_name = f"{application_name}/{unit_id}"
     raw_data = (await ops_test.juju("show-unit", unit_name))[1]
     if not raw_data:
         raise ValueError(f"no unit info could be grabbed for {unit_name}")

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -2,10 +2,9 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 import asyncio
-from email.mime import application
 import logging
-from pathlib import Path
 import time
+from pathlib import Path
 
 import pytest
 import yaml
@@ -258,7 +257,6 @@ async def test_relation_creation(ops_test: OpsTest):
 @pytest.mark.database_tests
 async def test_ready_only_endpoints(ops_test: OpsTest):
     """Check read-only-endpoints are correctly updated."""
-
     relation_data = await get_relation_data(
         ops_test=ops_test, application_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
     )
@@ -293,7 +291,7 @@ async def test_ready_only_endpoints(ops_test: OpsTest):
     # decrease the number of units
     async with ops_test.fast_forward():
         await scale_application(ops_test, DATABASE_APP_NAME, 2)
-    
+
     # wait for the update of the endpoints
     time.sleep(2 * 60)
     # check update for read-only-endpoints
@@ -313,9 +311,9 @@ async def test_ready_only_endpoints(ops_test: OpsTest):
     async with ops_test.fast_forward():
         await scale_application(ops_test, DATABASE_APP_NAME, 3)
 
-    # remove the leader unit 
+    # remove the leader unit
     await remove_leader_unit(ops_test=ops_test, application_name=DATABASE_APP_NAME)
-    
+
     # wait for the update of the endpoints
     time.sleep(2 * 60)
     relation_data = await get_relation_data(

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -2,8 +2,10 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 import asyncio
+from email.mime import application
 import logging
 from pathlib import Path
+import time
 
 import pytest
 import yaml
@@ -13,6 +15,7 @@ from helpers import (
     get_unit_hostname,
     is_relation_broken,
     is_relation_joined,
+    remove_leader_unit,
     scale_application,
 )
 from pytest_operator.plugin import OpsTest
@@ -254,7 +257,7 @@ async def test_relation_creation(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 @pytest.mark.database_tests
 async def test_ready_only_endpoints(ops_test: OpsTest):
-    """TODO."""
+    """Check read-only-endpoints are correctly updated."""
 
     relation_data = await get_relation_data(
         ops_test=ops_test, application_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
@@ -266,13 +269,10 @@ async def test_ready_only_endpoints(ops_test: OpsTest):
         read_only_endpoints
     )
     app_hostnames = await get_unit_hostname(ops_test=ops_test, app_name=DATABASE_APP_NAME)
-    logger.info(f"Hostnames from status: {app_hostnames}")
-    logger.info(f"Read-only-endpoints: {read_only_endpoints}")
     # check that endpoints are the one of the application
     for r_endpoint in read_only_endpoints:
         assert r_endpoint in app_hostnames
 
-    logger.info("Scale to 4 unit")
     # increase the number of units
     async with ops_test.fast_forward():
         await scale_application(ops_test, DATABASE_APP_NAME, 4)
@@ -281,91 +281,55 @@ async def test_ready_only_endpoints(ops_test: OpsTest):
         ops_test=ops_test, application_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
     )
     read_only_endpoints = get_read_only_endpoint_hostnames(relation_data)
-    logger.info(
-        f"Read-only-endpoitns: {read_only_endpoints} --- number of units: {len(ops_test.model.applications[DATABASE_APP_NAME].units)}"
-    )
+    # check that the number of read-only-endpoints is correct
     assert len(ops_test.model.applications[DATABASE_APP_NAME].units) - 1 == len(
         read_only_endpoints
-    )
-    logger.info(
-        f"Read-only-endpoints after unit addition: {read_only_endpoints} [{len(read_only_endpoints)}]"
     )
     app_hostnames = await get_unit_hostname(ops_test=ops_test, app_name=DATABASE_APP_NAME)
     # check that endpoints are the one of the application
     for r_endpoint in read_only_endpoints:
         assert r_endpoint in app_hostnames
 
-    logger.info("Scale to 2 units")
-    # increase the number of units
+    # decrease the number of units
     async with ops_test.fast_forward():
         await scale_application(ops_test, DATABASE_APP_NAME, 2)
+    
+    # wait for the update of the endpoints
+    time.sleep(2 * 60)
     # check update for read-only-endpoints
     relation_data = await get_relation_data(
         ops_test=ops_test, application_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
     )
     read_only_endpoints = get_read_only_endpoint_hostnames(relation_data)
-    logger.info(
-        f"Read-only-endpoitns: {read_only_endpoints} --- number of units: {len(ops_test.model.applications[DATABASE_APP_NAME].units)}"
-    )
     assert len(ops_test.model.applications[DATABASE_APP_NAME].units) - 1 == len(
         read_only_endpoints
-    )
-    logger.info(
-        f"Read-only-endpoints after unit addition: {read_only_endpoints} [{len(read_only_endpoints)}]"
     )
     app_hostnames = await get_unit_hostname(ops_test=ops_test, app_name=DATABASE_APP_NAME)
     # check that endpoints are the one of the application
     for r_endpoint in read_only_endpoints:
         assert r_endpoint in app_hostnames
 
-    logger.info("Scale up to 3 units and delete the leader unit ")
     # increase the number of units
     async with ops_test.fast_forward():
         await scale_application(ops_test, DATABASE_APP_NAME, 3)
 
-    leader_unit = None
-    for app_unit in ops_test.model.applications[DATABASE_APP_NAME].units:
-        is_leader = await app_unit.is_leader_from_status()
-        if is_leader:
-            leader_unit = app_unit.name
-
-    units_to_destroy = [leader_unit]
-    logger.info(f"Units to be destroyed: {units_to_destroy}")
-
-    for unit_to_destroy in units_to_destroy:
-        await ops_test.model.destroy_units(unit_to_destroy)
-
-    count = 2
-
-    application = ops_test.model.applications[DATABASE_APP_NAME]
-    await ops_test.model.block_until(lambda: len(application.units) == count)
-
-    if count > 0:
-        await ops_test.model.wait_for_idle(
-            apps=[DATABASE_APP_NAME],
-            status="active",
-            raise_on_blocked=True,
-            timeout=1000,
-        )
+    # remove the leader unit 
+    await remove_leader_unit(ops_test=ops_test, application_name=DATABASE_APP_NAME)
+    
+    # wait for the update of the endpoints
+    time.sleep(2 * 60)
     relation_data = await get_relation_data(
         ops_test=ops_test, application_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
     )
+
     read_only_endpoints = get_read_only_endpoint_hostnames(relation_data)
-    logger.info(
-        f"Read-only-endpoitns: {read_only_endpoints} --- number of units: {len(ops_test.model.applications[DATABASE_APP_NAME].units)}"
-    )
     assert len(ops_test.model.applications[DATABASE_APP_NAME].units) - 1 == len(
         read_only_endpoints
-    )
-    logger.info(
-        f"Read-only-endpoints after unit addition: {read_only_endpoints} [{len(read_only_endpoints)}]"
     )
     app_hostnames = await get_unit_hostname(ops_test=ops_test, app_name=DATABASE_APP_NAME)
     # check that endpoints are the one of the application
     for r_endpoint in read_only_endpoints:
         assert r_endpoint in app_hostnames
-
-    logger.info(f"Done with read-only-endpoints test!")
 
 
 @pytest.mark.order(7)


### PR DESCRIPTION
# Issue
Ready-only endpoints were not updated if a unit joined or left the cluster.


# Solution
Check peer relations joined and departed on the relation to manage the update of the endpoints. A special case is the change of leadership that is handled on leader_elected hook.

# Context
When adding or removing a unit of MySQL the endpoints were not updated.


# Testing
Integration tests includes tests to check the correct update of the endpoints.


