### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,9 @@ jobs:
         run: tox -e unit
   integration-test-lxd-ha:
     name: Integration tests for HA (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +40,9 @@ jobs:
         run: tox -e integration-ha
   integration-test-lxd-db-router:
     name: Integration tests for db-router relation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,6 +55,9 @@ jobs:
         run: tox -e integration-db-router
   integration-test-lxd-shared-db:
     name: Integration tests for shared-db relation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,6 +70,9 @@ jobs:
         run: tox -e integration-shared-db
   integration-test-lxd-database:
     name: Integration tests for database relation (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -73,6 +85,9 @@ jobs:
         run: tox -e integration-database
   integration-test-lxd-mysql:
     name: Integration tests for mysql interface (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -85,6 +100,9 @@ jobs:
         run: tox -e integration-mysql-interface
   integration-test-self-healing:
     name: Integration tests for self healing scenarios
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,10 @@ jobs:
 
   integration-test-lxd-ha:
     name: Integration tests for HA (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,6 +60,10 @@ jobs:
         run: tox -e integration-ha
   integration-test-lxd-db-router:
     name: Integration tests for db-router relation (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -68,6 +76,10 @@ jobs:
         run: tox -e integration-db-router
   integration-test-lxd-shared-db:
     name: Integration tests for shared-db relation (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -80,6 +92,10 @@ jobs:
         run: tox -e integration-shared-db
   integration-test-lxd-database:
     name: Integration tests for database relation (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -92,6 +108,10 @@ jobs:
         run: tox -e integration-database
   integration-test-lxd-mysql:
     name: Integration tests for mysql interface (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -104,6 +124,10 @@ jobs:
         run: tox -e integration-mysql-interface
   integration-test-self-healing:
     name: Integration tests for self healing scenarios
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Issue
https://warthogs.atlassian.net/browse/DPE-781

# Solution
Avoid a long-running integration test in case of failing gatekeeping tests.
It will slightly increase the complete tests scope runtime but will save (a lot?) of
electricity/money for Canonical as often new pull requests have some typos to polish.

# Context
It will change GitHub Actions tests execution order.

# Testing
Create a new PR.
Integrations tests should start after linian/unit tests.
Integrations tests should not start if linian/unit tests failed.

# Release Notes
Run integration tests for passed lint/unit tests only