### PR TITLE
Refactor for newer mysql-shell snap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration HA tests
         run: tox -e integration-ha
   integration-test-lxd-db-router:
@@ -51,6 +52,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration db-router tests
         run: tox -e integration-db-router
   integration-test-lxd-shared-db:
@@ -66,6 +68,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration shared-db tests
         run: tox -e integration-shared-db
   integration-test-lxd-database:
@@ -81,6 +84,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
         run: tox -e integration-database
   integration-test-lxd-mysql:
@@ -96,6 +100,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
         run: tox -e integration-mysql-interface
   integration-test-self-healing:
@@ -111,6 +116,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
         run: tox -e integration-healing
   integration-test-tls:
@@ -126,5 +132,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
+          bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
         run: tox -e integration-tls

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -69,7 +69,7 @@ import json
 import logging
 import re
 from abc import ABC, abstractmethod
-from typing import Iterable, List, Optional, Set, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -1077,7 +1077,6 @@ class MySQLBase(ABC):
 
     def reboot_from_complete_outage(self) -> None:
         """Wrapper for reboot_cluster_from_complete_outage command."""
-
         rejoin_command = (
             f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
             f"dba.reboot_cluster_from_complete_outage('{self.cluster_name}')",

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1075,17 +1075,12 @@ class MySQLBase(ABC):
         # MEMBER_ROLE is empty if member is not in a group
         return results[0], results[1] if len(results) == 2 else "unknown"
 
-    def reboot_from_complete_outage(self, instance_names: Set[str]) -> None:
-        """Wrapper for reboot_cluster_from_complete_outage command.
-
-        Args:
-            instance_names: set of instance names (e.g. `juju-e3f183-4:3306`)
-        """
-        options = {"rejoinInstances": list(instance_names)}
+    def reboot_from_complete_outage(self) -> None:
+        """Wrapper for reboot_cluster_from_complete_outage command."""
 
         rejoin_command = (
             f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            f"dba.reboot_cluster_from_complete_outage('{self.cluster_name}', {json.dumps(options)} )",
+            f"dba.reboot_cluster_from_complete_outage('{self.cluster_name}')",
         )
 
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cryptography==37.0.4
 jsonschema==4.16.0
 ops >= 1.5.2
 tenacity==8.0.1
+urllib3==1.26.12

--- a/src/charm.py
+++ b/src/charm.py
@@ -305,7 +305,7 @@ class MySQLOperatorCharm(CharmBase):
                 logger.debug("Attempting reboot from complete outage.")
                 # fetch instance names to rejoin allowing non-interactive process
                 rejoin_instances = {
-                    self._peers.data[unit]["instance-hostname"] for unit in self._peers.units
+                    self.peers.data[unit]["instance-hostname"] for unit in self.peers.units
                 }
                 logger.debug(f"Reboot cluster rejoining instances: {rejoin_instances}")
                 try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -303,13 +303,8 @@ class MySQLOperatorCharm(CharmBase):
                 # All instance are off, reboot cluster from outage from the leader unit
 
                 logger.debug("Attempting reboot from complete outage.")
-                # fetch instance names to rejoin allowing non-interactive process
-                rejoin_instances = {
-                    self.peers.data[unit]["instance-hostname"] for unit in self.peers.units
-                }
-                logger.debug(f"Reboot cluster rejoining instances: {rejoin_instances}")
                 try:
-                    self._mysql.reboot_from_complete_outage(rejoin_instances)
+                    self._mysql.reboot_from_complete_outage()
                 except MySQLRebootFromCompleteOutageError:
                     logger.error("Failed to reboot cluster from complete outage.")
                     self.unit.status = BlockedStatus("failed to recover cluster.")

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -9,8 +9,8 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
-import urllib3
 
+import urllib3
 from charms.mysql.v0.mysql import Error, MySQLBase, MySQLClientError
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import snap

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -332,4 +332,7 @@ def alternate_install_mysql_shell():
     ) as out_file:
         shutil.copyfileobj(r, out_file)
 
+    # install package
     subprocess.check_call("sudo dpkg -i mysql-shell.deb".split())
+    # emulate snap directory
+    os.makedirs(MYSQL_SHELL_COMMON_DIRECTORY)

--- a/src/mysqlsh_helpers.py
+++ b/src/mysqlsh_helpers.py
@@ -309,4 +309,3 @@ def write_content_to_file(
 
     shutil.chown(path, owner, group)
     os.chmod(path, mode=permission)
-

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -441,7 +441,9 @@ async def is_unit_in_cluster(ops_test: OpsTest, unit_name: str, action_unit_name
 
     status = yaml.safe_load(raw_status.strip())
 
-    cluster_topology = status[list(status.keys())[0]]["results"]["defaultreplicaset"]["topology"]
+    cluster_topology = status[list(status.keys())[0]]["results"]["status"]["defaultreplicaset"][
+        "topology"
+    ]
 
     for k, v in cluster_topology.items():
         if k.replace("-", "/") == unit_name and v.get("status") == "online":

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -539,7 +539,7 @@ async def start_server(ops_test: OpsTest, unit_name: str) -> None:
 
 
 async def get_primary_unit_wrapper(
-    ops_test: OpsTest, app_name: str, unit_excluded: Optional[Unit]
+    ops_test: OpsTest, app_name: str, unit_excluded: Optional[Unit] = None
 ) -> Unit:
     """Wrapper for getting primary.
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -399,7 +399,10 @@ def cluster_name(unit: Unit, model_name: str) -> str:
     )
     output = json.loads(output.decode("utf-8"))
 
-    return output[unit.name]["relation-info"][0]["application-data"]["cluster-name"]
+    for relation in output[unit.name]["relation-info"]:
+        if relation["endpoint"] == "database-peers":
+            return relation["application-data"]["cluster-name"]
+    raise ValueError("Failed to retrieve cluster name")
 
 
 async def get_process_pid(ops_test: OpsTest, unit_name: str, process: str) -> int:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -538,16 +538,24 @@ async def start_server(ops_test: OpsTest, unit_name: str) -> None:
         raise Exception("Failed to start server.")
 
 
-async def get_primary_unit_wrapper(ops_test: OpsTest, app_name: str) -> Unit:
+async def get_primary_unit_wrapper(
+    ops_test: OpsTest, app_name: str, unit_excluded: Optional[Unit]
+) -> Unit:
     """Wrapper for getting primary.
 
     Args:
         ops_test: The ops test object passed into every test case
         app_name: The name of the application
+        unit_excluded: excluded unit to run command on
     Returns:
         The primary Unit object
     """
-    unit = ops_test.model.applications[app_name].units[0]
+    if unit_excluded:
+        # if defined, exclude unit from available unit to run command on
+        # useful when the workload is stopped on unit
+        unit = ({ops_test.model.applications[app_name].units} - {unit_excluded}).pop()
+    else:
+        unit = ops_test.model.applications[app_name].units[0]
     cluster = cluster_name(unit, ops_test.model.info.name)
 
     server_config_password = await get_system_user_password(unit, SERVER_CONFIG_USERNAME)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
 import itertools
 import json
 import re
@@ -538,9 +537,7 @@ async def start_server(ops_test: OpsTest, unit_name: str) -> None:
         raise Exception("Failed to start server.")
 
 
-async def get_primary_unit_wrapper(
-    ops_test: OpsTest, app_name: str, unit_excluded: Optional[Unit] = None
-) -> Unit:
+async def get_primary_unit_wrapper(ops_test: OpsTest, app_name: str, unit_excluded=None) -> Unit:
     """Wrapper for getting primary.
 
     Args:
@@ -553,7 +550,13 @@ async def get_primary_unit_wrapper(
     if unit_excluded:
         # if defined, exclude unit from available unit to run command on
         # useful when the workload is stopped on unit
-        unit = ({ops_test.model.applications[app_name].units} - {unit_excluded}).pop()
+        unit = (
+            {
+                unit
+                for unit in ops_test.model.applications[app_name].units
+                if unit.name != unit_excluded.name
+            }
+        ).pop()
     else:
         unit = ops_test.model.applications[app_name].units[0]
     cluster = cluster_name(unit, ops_test.model.info.name)

--- a/tests/integration/test_healing.py
+++ b/tests/integration/test_healing.py
@@ -251,7 +251,7 @@ async def test_replicate_data_on_restart(ops_test: OpsTest):
     # get primary to write to it
     server_config_password = await get_system_user_password(primary_unit, SERVER_CONFIG_USERNAME)
     logger.info("Get new primary")
-    new_primary_unit = await get_primary_unit_wrapper(ops_test, app)
+    new_primary_unit = await get_primary_unit_wrapper(ops_test, app, unit_excluded=primary_unit)
 
     logger.info("Write to new primary")
     random_chars = await write_random_chars_to_test_table(ops_test, new_primary_unit)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
-from tenacity import Retrying, stop_after_attempt, wait_fixed
+from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 from constants import CLUSTER_ADMIN_USERNAME, TLS_SSL_CERT_FILE
 from tests.integration.helpers import (
@@ -161,10 +161,13 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         action = await unit.run_action(action_name="set-tls-private-key")
         # action.wait not always await action status to change
         # retry to address finicky CI test
-        for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5)):
-            with attempt:
-                action_run = await action.wait()
-                assert action_run.status == "completed", "❌ setting key failed"
+        try:
+            for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5)):
+                with attempt:
+                    action_run = await action.wait()
+                    assert action_run.status == "completed", "❌ setting key failed"
+        except RetryError:
+            assert False, f"❌ Failed to rotate key in for {unit.name}"
 
     # Wait for hooks start reconfiguring app
     await ops_test.model.block_until(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -4,6 +4,7 @@
 
 import logging
 from pathlib import Path
+from time import sleep
 
 import pytest
 import yaml
@@ -158,6 +159,9 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
     # set key using auto-generated key for each unit
     for unit in ops_test.model.applications[app].units:
         action = await unit.run_action(action_name="set-tls-private-key")
+        # action.wait not always await action status to change
+        # adding some time to address finicky CI test
+        sleep(4)
         action = await action.wait()
         assert action.status == "completed", "❌ setting key failed"
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -161,10 +161,10 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         action = await unit.run_action(action_name="set-tls-private-key")
         # action.wait not always await action status to change
         # retry to address finicky CI test
-        for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(2)):
+        for attempt in Retrying(stop=stop_after_attempt(3), wait=wait_fixed(5)):
             with attempt:
-                action = await action.wait()
-                assert action.status == "completed", "❌ setting key failed"
+                action_run = await action.wait()
+                assert action_run.status == "completed", "❌ setting key failed"
 
     # Wait for hooks start reconfiguring app
     await ops_test.model.block_until(

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
-from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 from constants import CLUSTER_ADMIN_USERNAME, TLS_SSL_CERT_FILE
 from tests.integration.helpers import (


### PR DESCRIPTION
# Issue

~~TLS support is blocked due non updated mysql-shell snap~~ - related to [DPE-722](https://warthogs.atlassian.net/browse/DPE-722)

**EDIT** mysql-shell snap is updated on edge channel.

This PR was repurposed to fix integration tests after TLS refactoring


# Solution

~~Alternate method to install mysql-shell from upstream sources.~~
Using snap from edge channel.
Opportunistic addressed some issues on CI testing.

# Context

Test PR to validate integration testing in CI

