### PR TITLE
Add workflow_call

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: Tests
 on:
   pull_request:
+  workflow_call:
 
 jobs:
   lint:


### PR DESCRIPTION
Just add workflow_call to allow usage of referenced `ci.yaml` on `release.yaml`
