### PR TITLE
Fix TLS setting for single unit deployment

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -35,14 +35,8 @@ async def run_command_on_unit(unit, command: str) -> Optional[str]:
         command execution output or none if
         the command produces no output.
     """
-    # workaround for https://github.com/juju/python-libjuju/issues/707
     action = await unit.run(command)
-    result = await action.wait()
-    code = str(result.results.get("Code") or result.results.get("return-code"))
-    stdout = result.results.get("Stdout") or result.results.get("stdout")
-    stderr = result.results.get("Stderr") or result.results.get("stderr")
-    assert code == "0", f"{command} failed ({code}): {stderr or stdout}"
-    return stdout
+    return action.results.get("Stdout", None)
 
 
 def generate_random_string(length: int) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -80,7 +80,7 @@ commands =
 [testenv:integration-ha]
 description = Run HA integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -92,7 +92,7 @@ commands =
 [testenv:integration-db-router]
 description = Run legacy db-router relation integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -104,7 +104,7 @@ commands =
 [testenv:integration-shared-db]
 description = Run legacy shared-db relation integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -116,7 +116,7 @@ commands =
 [testenv:integration-database]
 description = Run integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -128,7 +128,7 @@ commands =
 [testenv:integration-mysql-interface]
 description = Run integration tests for legacy mysql interface
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -140,7 +140,7 @@ commands =
 [testenv:integration-healing]
 description = Run self-healing tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -152,7 +152,7 @@ commands =
 [testenv:integration-tls]
 description = Run TLS tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -164,7 +164,7 @@ commands =
 [testenv:dev]
 description = Run in development test
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pdbpp


### PR DESCRIPTION
# Issue

Fixed primary restart when setting TLS for a single node cluster.
Replicates k8s [PR#110](https://github.com/canonical/mysql-k8s-operator/pull/110) and addresses issue #59 


# Solution

When rebooting a single node cluster, use `reboot_from_outage` to restore node as primary;

# Testing
Testing to come in bundle repo.
