### PR TITLE
Add base of jammy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -24,7 +25,11 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
+
   integration-test-lxd-ha:
+    strategy:
+      matrix:
+        series: [focal, jammy]
     name: Integration tests for HA (lxd)
     needs:
       - lint
@@ -39,8 +44,12 @@ jobs:
           provider: lxd
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration HA tests
-        run: tox -e integration-ha
+        run: tox -e integration-ha -- --series=${{ matrix.series }}
+
   integration-test-lxd-db-router:
+    strategy:
+      matrix:
+        series: [focal, jammy]
     name: Integration tests for db-router relation (lxd)
     needs:
       - lint
@@ -55,8 +64,12 @@ jobs:
           provider: lxd
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration db-router tests
-        run: tox -e integration-db-router
+        run: tox -e integration-db-router -- --series=${{ matrix.series }}
+
   integration-test-lxd-shared-db:
+    strategy:
+      matrix:
+        series: [focal, jammy]
     name: Integration tests for shared-db relation (lxd)
     needs:
       - lint
@@ -71,8 +84,12 @@ jobs:
           provider: lxd
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration shared-db tests
-        run: tox -e integration-shared-db
+        run: tox -e integration-shared-db -- --series=${{ matrix.series }}
+
   integration-test-lxd-database:
+    strategy:
+      matrix:
+        series: [focal, jammy]
     name: Integration tests for database relation (lxd)
     needs:
       - lint
@@ -87,8 +104,12 @@ jobs:
           provider: lxd
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
-        run: tox -e integration-database
+        run: tox -e integration-database -- --series=${{ matrix.series }}
+
   integration-test-lxd-mysql:
+    strategy:
+      matrix:
+        series: [focal, jammy]
     name: Integration tests for mysql interface (lxd)
     needs:
       - lint
@@ -103,8 +124,12 @@ jobs:
           provider: lxd
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
-        run: tox -e integration-mysql-interface
+        run: tox -e integration-mysql-interface -- --series=${{ matrix.series }}
+
   integration-test-self-healing:
+    strategy:
+      matrix:
+        series: [focal, jammy]
     name: Integration tests for self healing scenarios
     needs:
       - lint
@@ -119,8 +144,12 @@ jobs:
           provider: lxd
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
-        run: tox -e integration-healing
+        run: tox -e integration-healing -- --series=${{ matrix.series }}
+
   integration-test-tls:
+    strategy:
+      matrix:
+        series: [focal, jammy]
     name: Integration tests for tls support
     needs:
       - lint
@@ -135,4 +164,4 @@ jobs:
           provider: lxd
           bootstrap-options: "--agent-version 2.9.29"
       - name: Run integration database tests
-        run: tox -e integration-tls
+        run: tox -e integration-tls -- --series=${{ matrix.series }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,10 +5,10 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
     run-on:
       - name: "ubuntu"
-        channel: "20.04"
+        channel: "22.04"
 parts:
   charm:
     build-packages:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,3 +22,5 @@ parts:
       - libssl-dev
       - rustc
       - cargo
+    charm-binary-python-packages:
+      - setuptools

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,6 +5,12 @@ type: charm
 bases:
   - build-on:
       - name: "ubuntu"
+        channel: "20.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "20.04"
+  - build-on:
+      - name: "ubuntu"
         channel: "22.04"
     run-on:
       - name: "ubuntu"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+def pytest_addoption(parser):
+    parser.addoption("--series", action="store", type=str, default="jammy")
+
+
+def pytest_generate_tests(metafunc):
+    series = metafunc.config.option.series
+    # Only set "series" if it exists as a fixture for a test
+    if "series" in metafunc.fixturenames:
+        metafunc.parametrize("series", [series])

--- a/tests/integration/integration_constants.py
+++ b/tests/integration/integration_constants.py
@@ -1,0 +1,9 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""File containing constants to be used in the integration tests."""
+
+SERIES_TO_VERSION = {
+    "focal": "20.04",
+    "jammy": "22.04",
+}

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -60,7 +60,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["charmcraft", "pack"]
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
     subprocess.check_output(charmcraft_pack_commands)
     db_charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -60,7 +60,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    charmcraft_pack_commands = ["charmcraft", "pack"]
     subprocess.check_output(charmcraft_pack_commands)
     db_charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+
 import asyncio
 import logging
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -30,6 +32,7 @@ from tests.integration.helpers import (
     get_primary_unit,
     rotate_credentials,
 )
+from tests.integration.integration_constants import SERIES_TO_VERSION
 from utils import generate_random_password
 
 logger = logging.getLogger(__name__)
@@ -55,14 +58,19 @@ ENDPOINT = "database"
 async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     # Build and deploy charm from local source folder
-    db_charm = await ops_test.build_charm(".")
+    # Manually call charmcraft pack because ops_test.build_charm() does not support
+    # multiple bases in the charmcraft file
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    subprocess.check_output(charmcraft_pack_commands)
+    db_charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
+
     app_charm = await ops_test.build_charm("./tests/integration/application-charm/")
 
     config = {"cluster-name": CLUSTER_NAME}
 
     await asyncio.gather(
         ops_test.model.deploy(
-            db_charm,
+            db_charm_url,
             application_name=DATABASE_APP_NAME,
             config=config,
             num_units=3,

--- a/tests/integration/test_database.py
+++ b/tests/integration/test_database.py
@@ -52,7 +52,7 @@ ENDPOINT = "database"
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 @pytest.mark.database_tests
-async def test_build_and_deploy(ops_test: OpsTest):
+async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     # Build and deploy charm from local source folder
     db_charm = await ops_test.build_charm(".")
@@ -62,7 +62,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            db_charm, application_name=DATABASE_APP_NAME, config=config, num_units=3
+            db_charm,
+            application_name=DATABASE_APP_NAME,
+            config=config,
+            num_units=3,
+            series=series,
         ),
         ops_test.model.deploy(app_charm, application_name=APPLICATION_APP_NAME, num_units=2),
     )

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import subprocess
 from pathlib import Path
 from typing import Dict, List
 
@@ -16,6 +17,7 @@ from tests.integration.helpers import (
     get_server_config_credentials,
     scale_application,
 )
+from tests.integration.integration_constants import SERIES_TO_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -119,11 +121,17 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest, series: str) -> None
         ops_test: The ops test framework
         series: The series for the database machine
     """
-    charm = await ops_test.build_charm(".")
+    # Build and deploy charm from local source folder
+    # Manually call charmcraft pack because ops_test.build_charm() does not support
+    # multiple bases in the charmcraft file
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    subprocess.check_output(charmcraft_pack_commands)
+    charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
+
     config = {"cluster-name": CLUSTER_NAME}
 
     mysql_app = await ops_test.model.deploy(
-        charm, application_name=APP_NAME, config=config, num_units=1, series=series
+        charm_url, application_name=APP_NAME, config=config, num_units=1, series=series
     )
 
     # Deploy keystone

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -117,6 +117,7 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest, series: str) -> None
 
     Args:
         ops_test: The ops test framework
+        series: The series for the database machine
     """
     charm = await ops_test.build_charm(".")
     config = {"cluster-name": CLUSTER_NAME}

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -112,7 +112,7 @@ async def check_keystone_users_existence(
 @pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.db_router_tests
-async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
+async def test_keystone_bundle_db_router(ops_test: OpsTest, series: str) -> None:
     """Deploy the keystone bundle to test the 'db-router' relation.
 
     Args:
@@ -122,7 +122,7 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest) -> None:
     config = {"cluster-name": CLUSTER_NAME}
 
     mysql_app = await ops_test.model.deploy(
-        charm, application_name=APP_NAME, config=config, num_units=1
+        charm, application_name=APP_NAME, config=config, num_units=1, series=series
     )
 
     # Deploy keystone

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -124,7 +124,7 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest, series: str) -> None
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["charmcraft", "pack"]
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_db_router.py
+++ b/tests/integration/test_db_router.py
@@ -124,7 +124,7 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest, series: str) -> None
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    charmcraft_pack_commands = ["charmcraft", "pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -31,7 +31,7 @@ ANOTHER_APP_NAME = f"second{APP_NAME}"
 @pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.ha_tests
-async def test_build_and_deploy(ops_test: OpsTest) -> None:
+async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     if app := await app_name(ops_test):
         if len(ops_test.model.applications[app].units) == 3:
@@ -43,7 +43,12 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    await ops_test.model.deploy(
+        charm,
+        application_name=APP_NAME,
+        num_units=3,
+        series=series,
+    )
     # variable used to avoid rebuilding the charm
     global another_charm
     another_charm = charm
@@ -264,7 +269,7 @@ async def test_cluster_preserves_data_on_delete(ops_test: OpsTest) -> None:
 
 @pytest.mark.order(5)
 @pytest.mark.ha_tests
-async def test_cluster_isolation(ops_test: OpsTest) -> None:
+async def test_cluster_isolation(ops_test: OpsTest, series: str) -> None:
     """Test for cluster data isolation.
 
     This test creates a new cluster, create a new table on both cluster, write a single record with
@@ -276,7 +281,12 @@ async def test_cluster_isolation(ops_test: OpsTest) -> None:
 
     # Build and deploy secondary charm
     charm = another_charm or await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=ANOTHER_APP_NAME, num_units=1)
+    await ops_test.model.deploy(
+        charm,
+        application_name=ANOTHER_APP_NAME,
+        num_units=1,
+        series=series,
+    )
     async with ops_test.fast_forward():
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[ANOTHER_APP_NAME].units) == 1

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -46,7 +46,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    charmcraft_pack_commands = ["charmcraft", "pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 
@@ -291,7 +291,7 @@ async def test_cluster_isolation(ops_test: OpsTest, series: str) -> None:
     if not charm_url:
         # Manually call charmcraft pack because ops_test.build_charm() does not support
         # multiple bases in the charmcraft file
-        charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+        charmcraft_pack_commands = ["charmcraft", "pack"]
         subprocess.check_output(charmcraft_pack_commands)
         charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_ha.py
+++ b/tests/integration/test_ha.py
@@ -46,7 +46,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["charmcraft", "pack"]
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 
@@ -291,7 +291,7 @@ async def test_cluster_isolation(ops_test: OpsTest, series: str) -> None:
     if not charm_url:
         # Manually call charmcraft pack because ops_test.build_charm() does not support
         # multiple bases in the charmcraft file
-        charmcraft_pack_commands = ["charmcraft", "pack"]
+        charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
         subprocess.check_output(charmcraft_pack_commands)
         charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_healing.py
+++ b/tests/integration/test_healing.py
@@ -53,7 +53,7 @@ async def build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["charmcraft", "pack"]
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_healing.py
+++ b/tests/integration/test_healing.py
@@ -40,7 +40,7 @@ APP_NAME = METADATA["name"]
 MYSQL_DAEMON = "mysqld"
 
 
-async def build_and_deploy(ops_test: OpsTest) -> None:
+async def build_and_deploy(ops_test: OpsTest, series: str) -> None:
     """Build and deploy."""
     if app := await app_name(ops_test):
         async with ops_test.fast_forward():
@@ -52,7 +52,12 @@ async def build_and_deploy(ops_test: OpsTest) -> None:
 
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
-        await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+        await ops_test.model.deploy(
+            charm,
+            application_name=APP_NAME,
+            num_units=3,
+            series=series,
+        )
 
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[APP_NAME].units) == 3

--- a/tests/integration/test_healing.py
+++ b/tests/integration/test_healing.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -33,6 +34,7 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
 from src.constants import CLUSTER_ADMIN_USERNAME, SERVER_CONFIG_USERNAME
+from tests.integration.integration_constants import SERIES_TO_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +51,16 @@ async def build_and_deploy(ops_test: OpsTest, series: str) -> None:
             return
 
     # Build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
+    # Manually call charmcraft pack because ops_test.build_charm() does not support
+    # multiple bases in the charmcraft file
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    subprocess.check_output(charmcraft_pack_commands)
+    charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
         await ops_test.model.deploy(
-            charm,
+            charm_url,
             application_name=APP_NAME,
             num_units=3,
             series=series,

--- a/tests/integration/test_healing.py
+++ b/tests/integration/test_healing.py
@@ -73,9 +73,9 @@ async def build_and_deploy(ops_test: OpsTest, series: str) -> None:
 @pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
-async def test_kill_db_process(ops_test: OpsTest) -> None:
+async def test_kill_db_process(ops_test: OpsTest, series: str) -> None:
     """Kill mysqld process and check for auto cluster recovery."""
-    await build_and_deploy(ops_test)
+    await build_and_deploy(ops_test, series)
 
     app = await app_name(ops_test)
 

--- a/tests/integration/test_healing.py
+++ b/tests/integration/test_healing.py
@@ -53,7 +53,7 @@ async def build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    charmcraft_pack_commands = ["charmcraft", "pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_relation_mysql_legacy.py
+++ b/tests/integration/test_relation_mysql_legacy.py
@@ -48,7 +48,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
 
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["charmcraft", "pack"]
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
     subprocess.check_output(charmcraft_pack_commands)
     db_charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_relation_mysql_legacy.py
+++ b/tests/integration/test_relation_mysql_legacy.py
@@ -48,7 +48,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
 
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    charmcraft_pack_commands = ["charmcraft", "pack"]
     subprocess.check_output(charmcraft_pack_commands)
     db_charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_relation_mysql_legacy.py
+++ b/tests/integration/test_relation_mysql_legacy.py
@@ -38,7 +38,7 @@ TEST_DATABASE = "testdb"
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 @pytest.mark.mysql_interface_tests
-async def test_build_and_deploy(ops_test: OpsTest):
+async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     # Build and deploy charms from local source folders
 
@@ -49,7 +49,11 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            db_charm, application_name=DATABASE_APP_NAME, config=config, num_units=3
+            db_charm,
+            application_name=DATABASE_APP_NAME,
+            config=config,
+            num_units=3,
+            series=series,
         ),
         ops_test.model.deploy(app_charm, application_name=APPLICATION_APP_NAME, num_units=2),
     )

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -159,7 +159,7 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest, series: str) -> None
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    charmcraft_pack_commands = ["charmcraft", "pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -152,6 +152,7 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest, series: str) -> None
 
     Args:
         ops_test: The ops test framework
+        series: The series for the database machine
     """
     # Build and deploy the mysql charm
     charm = await ops_test.build_charm(".")

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -147,7 +147,7 @@ async def check_keystone_users_existence(
 @pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.shared_db_tests
-async def test_keystone_bundle_shared_db(ops_test: OpsTest) -> None:
+async def test_keystone_bundle_shared_db(ops_test: OpsTest, series: str) -> None:
     """Deploy the keystone bundle to test the 'shared-db' relation.
 
     Args:
@@ -156,7 +156,13 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest) -> None:
     # Build and deploy the mysql charm
     charm = await ops_test.build_charm(".")
     config = {"cluster-name": CLUSTER_NAME}
-    await ops_test.model.deploy(charm, application_name=APP_NAME, config=config, num_units=3)
+    await ops_test.model.deploy(
+        charm,
+        application_name=APP_NAME,
+        config=config,
+        num_units=3,
+        series=series,
+    )
 
     # Reduce the update_status frequency for the duration of the test
     async with ops_test.fast_forward():

--- a/tests/integration/test_shared_db.py
+++ b/tests/integration/test_shared_db.py
@@ -159,7 +159,7 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest, series: str) -> None
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["charmcraft", "pack"]
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -47,7 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    charmcraft_pack_commands = ["charmcraft", "pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -32,7 +32,7 @@ TLS_APP_NAME = "tls-certificates-operator"
 @pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.tls_tests
-async def test_build_and_deploy(ops_test: OpsTest) -> None:
+async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     """Build the charm and deploy 3 units to ensure a cluster is formed."""
     if app := await app_name(ops_test):
         if len(ops_test.model.applications[app].units) == 3:
@@ -44,7 +44,12 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     # Build and deploy charm from local source folder
     charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(charm, application_name=APP_NAME, num_units=3)
+    await ops_test.model.deploy(
+        charm,
+        application_name=APP_NAME,
+        num_units=3,
+        series=series,
+    )
 
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -3,6 +3,7 @@
 
 
 import logging
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,7 @@ from tests.integration.helpers import (
     scale_application,
     unit_file_md5,
 )
+from tests.integration.integration_constants import SERIES_TO_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +45,14 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
             return
 
     # Build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
+    # Manually call charmcraft pack because ops_test.build_charm() does not support
+    # multiple bases in the charmcraft file
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
+    subprocess.check_output(charmcraft_pack_commands)
+    charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
+
     await ops_test.model.deploy(
-        charm,
+        charm_url,
         application_name=APP_NAME,
         num_units=3,
         series=series,

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -47,7 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     # Build and deploy charm from local source folder
     # Manually call charmcraft pack because ops_test.build_charm() does not support
     # multiple bases in the charmcraft file
-    charmcraft_pack_commands = ["charmcraft", "pack"]
+    charmcraft_pack_commands = ["sg", "lxd", "-c", "charmcraft pack"]
     subprocess.check_output(charmcraft_pack_commands)
     charm_url = f"local:mysql_ubuntu-{SERIES_TO_VERSION[series]}-amd64.charm"
 

--- a/tox.ini
+++ b/tox.ini
@@ -161,6 +161,7 @@ deps =
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "tls_tests"
 
+# Used to mark tests run locally (in order to target specific tests to run)
 [testenv:dev]
 description = Run in development test
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -80,7 +80,7 @@ commands =
 [testenv:integration-ha]
 description = Run HA integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -92,7 +92,7 @@ commands =
 [testenv:integration-db-router]
 description = Run legacy db-router relation integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -104,7 +104,7 @@ commands =
 [testenv:integration-shared-db]
 description = Run legacy shared-db relation integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -116,7 +116,7 @@ commands =
 [testenv:integration-database]
 description = Run integration tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -128,7 +128,7 @@ commands =
 [testenv:integration-mysql-interface]
 description = Run integration tests for legacy mysql interface
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -140,7 +140,7 @@ commands =
 [testenv:integration-healing]
 description = Run self-healing tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -152,7 +152,7 @@ commands =
 [testenv:integration-tls]
 description = Run TLS tests
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pytest-operator
@@ -165,7 +165,7 @@ commands =
 [testenv:dev]
 description = Run in development test
 deps =
-    juju
+    juju==2.9.11
     mysql-connector-python
     pytest
     pdbpp


### PR DESCRIPTION
# Issue
1. We have no way of running our suite of integration tests against multiple releases of ubuntu
2. We are not currently supporting `jammy`
3. `ops_test.build_charm` does not support building multiple charm bases

# Solution
1. Use Github CI matrix to run each integration test against a list of `series`. Additonally, use `pytest_generate_test` to add the `series` passed from `tox` to into each test.
2. Add support for `jammy`
3. Manually run `charmcraft pack` in a subprocess to pack charms and then pick the correct archive file to deploy based on the series

# Release Notes
Add base for jammy
