### PR TITLE
Add assumes=juju to avoid starting VM operator on K8s

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,7 +6,7 @@ display-name: MySQL
 description: |
   MySQL charm for machines
 summary: |
-  MySQL is  a widely used, open-source relational database management system
+  MySQL is a widely used, open-source relational database management system
   (RDBMS). MySQL InnoDB cluster provides a complete high availability solution
   for MySQL via Group Replication.
 source: https://github.com/canonical/mysql-operator
@@ -39,3 +39,5 @@ storage:
     type: filesystem
     description: Persistent storage for MySQL data
     location: /var/lib/mysql
+assumes:
+  - juju


### PR DESCRIPTION
It should avoid human mistakes and negative feedback. Also fix a typo in the Charm summary.

# Issue
It will prevent starting VM operator in K8s env.


# Solution
Using Juju function 'assume'.

# Release Notes
Add protection to avoid starting VM operator on K8s.