### PR TITLE
Undo temporary fix that downloaded setuptools as a binary

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,5 +22,3 @@ parts:
       - libssl-dev
       - rustc
       - cargo
-    charm-binary-python-packages:
-      - setuptools


### PR DESCRIPTION
# Issue
We added a temporary fix to be able to pack a charm (that involved installing `setuptools` as a binary package). This fix is not needed

# Solution
Remove fix


# Release Notes
Undo temporary fix that downloaded setuptools as a binary
