### PR TITLE
Remove tox `integration` environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,11 @@ source .tox/unit/bin/activate
 ### Testing
 
 ```shell
-tox -e fmt           # update your code according to linting rules
-tox -e lint          # code style
-tox -e unit          # unit tests
-tox -e integration   # integration tests
-tox                  # runs 'lint' and 'unit' environments
+tox -e fmt             # update your code according to linting rules
+tox -e lint            # code style
+tox -e unit            # unit tests
+tox -e integration-*   # integration tests
+tox                    # runs 'lint' and 'unit' environments
 ```
 
 ## Build charm

--- a/tox.ini
+++ b/tox.ini
@@ -65,18 +65,6 @@ commands =
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 
-[testenv:integration]
-description = Run integration tests
-deps =
-    juju==2.9.11
-    mysql-connector-python
-    pytest
-    pytest-operator
-    pytest-order
-    -r{toxinidir}/requirements.txt
-commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
-
 [testenv:integration-ha]
 description = Run HA integration tests
 deps =


### PR DESCRIPTION
Ported from https://github.com/canonical/mysql-k8s-operator/pull/118

Due to `pytest-order`, integration tests run out of order when run together