### PR TITLE
DPE-904 Pin flake8 to 5.0.4 as the latest 6.0.0 is broken

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==5.0.4 # https://github.com/savoirfairelinux/flake8-copyright/issues/19
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
# Issue
The latest flake8 version 6.0.0 is broken. Check all details here:
> https://github.com/savoirfairelinux/flake8-copyright/issues/19
We have to pin the old version until the fix is released.

# Solution
Pin the old version

# Testing
GH CI is happy with a fix and failing without it.

# Release Notes
 Pin flake8 to 5.0.4 as the latest 6.0.0 is broken.