### PR TITLE
Run router bootstrap operations against cluster primary rather than leader unit

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1008,9 +1008,13 @@ class MySQLBase(ABC):
         Raises:
             MySQLUpgradeUserForMySQLRouterError if there is an issue upgrading user for mysqlrouter
         """
+        cluster_primary = self.get_cluster_primary_address()
+        if not cluster_primary:
+            raise MySQLUpgradeUserForMySQLRouterError("Failed to retrieve cluster primary")
+
         options = {"update": "true"}
         upgrade_user_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{cluster_primary}')",
             f"cluster = dba.get_cluster('{self.cluster_name}')",
             f"cluster.setup_router_account('{username}@{hostname}', {json.dumps(options)})",
         )
@@ -1037,8 +1041,12 @@ class MySQLBase(ABC):
         Raises:
             MySQLGrantPrivilegesToUserError if there is an issue granting privileges to a user
         """
+        cluster_primary = self.get_cluster_primary_address()
+        if not cluster_primary:
+            raise MySQLGrantPrivilegesToUserError("Failed to get cluster primary address")
+
         grant_privileges_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{cluster_primary}')",
             f"session.run_sql(\"GRANT {', '.join(privileges)} ON *.* TO '{username}'@'{hostname}'{' WITH GRANT OPTION' if with_grant_option else ''}\")",
         )
 

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -795,12 +795,15 @@ class TestMySQLBase(unittest.TestCase):
 
         self.assertEqual(version, "8.0.29-0ubuntu0.20.04.3")
 
+    @patch(
+        "charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address", return_value="1.1.1.1:3306"
+    )
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
-    def test_upgrade_user_for_mysqlrouter(self, _run_mysqlsh_script):
+    def test_upgrade_user_for_mysqlrouter(self, _run_mysqlsh_script, _get_cluster_primary_address):
         """Test the successful execution of upgrade_user_for_mysqlrouter."""
         expected_commands = "\n".join(
             (
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "shell.connect('clusteradmin:clusteradminpassword@1.1.1.1:3306')",
                 "cluster = dba.get_cluster('test_cluster')",
                 'cluster.setup_router_account(\'test_user@%\', {"update": "true"})',
             )
@@ -810,20 +813,34 @@ class TestMySQLBase(unittest.TestCase):
 
         _run_mysqlsh_script.assert_called_once_with(expected_commands)
 
+    @patch(
+        "charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address", return_value="1.1.1.1:3306"
+    )
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
-    def test_upgrade_user_for_mysqlrouter_exception(self, _run_mysqlsh_script):
+    def test_upgrade_user_for_mysqlrouter_exception(
+        self, _run_mysqlsh_script, _get_cluster_primary_address
+    ):
         """Test an exception during the execution of upgrade_user_for_mysqlrouter."""
         _run_mysqlsh_script.side_effect = MySQLClientError("Error upgrading user")
 
         with self.assertRaises(MySQLUpgradeUserForMySQLRouterError):
             self.mysql.upgrade_user_for_mysqlrouter("test_user", "%")
 
+        _run_mysqlsh_script.side_effect = None
+        _get_cluster_primary_address.return_value = None
+
+        with self.assertRaises(MySQLUpgradeUserForMySQLRouterError):
+            self.mysql.upgrade_user_for_mysqlrouter("test_user", "%")
+
+    @patch(
+        "charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address", return_value="1.1.1.1:3306"
+    )
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
-    def test_grant_privileges_to_user(self, _run_mysqlsh_script):
+    def test_grant_privileges_to_user(self, _run_mysqlsh_script, _get_cluster_primary_address):
         """Test the successful execution of grant_privileges_to_user."""
         expected_commands = "\n".join(
             (
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "shell.connect('clusteradmin:clusteradminpassword@1.1.1.1:3306')",
                 "session.run_sql(\"GRANT CREATE USER ON *.* TO 'test_user'@'%' WITH GRANT OPTION\")",
             )
         )
@@ -838,7 +855,7 @@ class TestMySQLBase(unittest.TestCase):
 
         expected_commands = "\n".join(
             (
-                "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+                "shell.connect('clusteradmin:clusteradminpassword@1.1.1.1:3306')",
                 "session.run_sql(\"GRANT SELECT, UPDATE ON *.* TO 'test_user'@'%'\")",
             )
         )


### PR DESCRIPTION
# Issue
[jira ticket](https://warthogs.atlassian.net/browse/DPE-917)
When running operations against the database while bootstrapping mysqlrouter, the operations are run against the juju leader unit. However, these operations contain writes and the leader unit is not guaranteed to be the cluster primary.

# Solution
Run the operations against the cluster primary unit.

# Release Notes
Run router bootstrap operations against cluster primary rather than leader unit

# Context
The below screenshot demonstrates that the fix in this PR resolves the error.
![bootstrap_bugfix](https://user-images.githubusercontent.com/99665202/209614351-927e2357-4beb-4fc9-b6ac-04e2ff33af61.png)

