### PR TITLE
Upload Coverage report to Codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,8 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox run -e unit
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v3
 
   build:
     name: Build charms

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.charm
 *.py[cod]
 .coverage
+coverage.xml
 .tox/
 .vscode/
 __pycache__/

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ commands =
     coverage run --source={[vars]src_path},{[vars]lib_path} \
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     coverage report
+    coverage xml
 
 [testenv:create-build-matrix]
 description = Create build matrix for integration tests


### PR DESCRIPTION
# Issue
1) sometime tests are lost silently which is hard to detect due to missing visibility.
2) it is nice to show test coverage inside PR to show "achievements" of writing tests.

# Solution
Show the current test coverage inside the PR to prevent loosing some tests.

# Testing
GH PR visibility only.

# Release Notes
Not necessary to mention.