### PR TITLE
Remove pytest-order

### DIFF
--- a/tests/integration/high_availability/test_replication.py
+++ b/tests/integration/high_availability/test_replication.py
@@ -39,7 +39,6 @@ ANOTHER_APP_NAME = f"second{APP_NAME}"
 TIMEOUT = 17 * 60
 
 
-@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.ha_tests
 async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
@@ -47,7 +46,6 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     await high_availability_test_setup(ops_test, series)
 
 
-@pytest.mark.order(2)
 @pytest.mark.abort_on_fail
 @pytest.mark.ha_tests
 async def test_consistent_data_replication_across_cluster(
@@ -66,7 +64,6 @@ async def test_consistent_data_replication_across_cluster(
     await ensure_all_units_continuous_writes_incrementing(ops_test)
 
 
-@pytest.mark.order(3)
 @pytest.mark.abort_on_fail
 @pytest.mark.ha_tests
 async def test_kill_primary_check_reelection(ops_test: OpsTest) -> None:
@@ -115,7 +112,6 @@ async def test_kill_primary_check_reelection(ops_test: OpsTest) -> None:
     await clean_up_database_and_table(ops_test, database_name, table_name)
 
 
-@pytest.mark.order(4)
 @pytest.mark.abort_on_fail
 @pytest.mark.ha_tests
 async def test_scaling_without_data_loss(ops_test: OpsTest) -> None:
@@ -194,7 +190,6 @@ async def test_scaling_without_data_loss(ops_test: OpsTest) -> None:
         assert random_chars in output
 
 
-@pytest.mark.order(5)
 @pytest.mark.ha_tests
 async def test_cluster_isolation(ops_test: OpsTest, series: str) -> None:
     """Test for cluster data isolation.

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -46,7 +46,6 @@ APP_NAME = METADATA["name"]
 MYSQL_DAEMON = "mysqld"
 
 
-@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
 async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
@@ -54,7 +53,6 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     await high_availability_test_setup(ops_test, series)
 
 
-@pytest.mark.order(2)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
 async def test_kill_db_process(ops_test: OpsTest, continuous_writes) -> None:
@@ -94,7 +92,6 @@ async def test_kill_db_process(ops_test: OpsTest, continuous_writes) -> None:
     await clean_up_database_and_table(ops_test, database_name, table_name)
 
 
-@pytest.mark.order(3)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
 async def test_freeze_db_process(ops_test: OpsTest, continuous_writes):
@@ -139,7 +136,6 @@ async def test_freeze_db_process(ops_test: OpsTest, continuous_writes):
     await clean_up_database_and_table(ops_test, database_name, table_name)
 
 
-@pytest.mark.order(4)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
 async def test_network_cut(ops_test: OpsTest, continuous_writes):
@@ -221,7 +217,6 @@ async def test_network_cut(ops_test: OpsTest, continuous_writes):
     await clean_up_database_and_table(ops_test, database_name, table_name)
 
 
-@pytest.mark.order(5)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
 async def test_replicate_data_on_restart(ops_test: OpsTest, continuous_writes):
@@ -305,7 +300,6 @@ async def test_replicate_data_on_restart(ops_test: OpsTest, continuous_writes):
     await clean_up_database_and_table(ops_test, database_name, table_name)
 
 
-@pytest.mark.order(6)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
 async def test_cluster_pause(ops_test: OpsTest, continuous_writes):
@@ -371,7 +365,6 @@ async def test_cluster_pause(ops_test: OpsTest, continuous_writes):
     await ops_test.model.set_config({"update-status-hook-interval": "5m"})
 
 
-@pytest.mark.order(7)
 @pytest.mark.abort_on_fail
 @pytest.mark.healing_tests
 async def test_sst_test(ops_test: OpsTest, continuous_writes):

--- a/tests/integration/relations/test_database.py
+++ b/tests/integration/relations/test_database.py
@@ -55,7 +55,6 @@ ENDPOINT = "database"
 TIMEOUT = 15 * 60
 
 
-@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 @pytest.mark.database_tests
@@ -122,7 +121,6 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     assert len(ops_test.model.applications[APPLICATION_APP_NAME].units) == 2
 
 
-@pytest.mark.order(2)
 @pytest.mark.abort_on_fail
 @pytest.mark.database_tests
 async def test_password_rotation(ops_test: OpsTest):
@@ -168,7 +166,6 @@ async def test_password_rotation(ops_test: OpsTest):
     assert len(output) > 0, "query with new password failed, no databases found"
 
 
-@pytest.mark.order(3)
 @pytest.mark.abort_on_fail
 @pytest.mark.database_tests
 async def test_password_rotation_silent(ops_test: OpsTest):
@@ -209,7 +206,6 @@ async def test_password_rotation_silent(ops_test: OpsTest):
     assert len(output) > 0, "query with new password failed, no databases found"
 
 
-@pytest.mark.order(4)
 @pytest.mark.abort_on_fail
 @pytest.mark.database_tests
 async def test_password_rotation_root_user_implicit(ops_test: OpsTest):
@@ -257,7 +253,6 @@ async def test_password_rotation_root_user_implicit(ops_test: OpsTest):
     assert len(output) > 0, "query with new password failed, no databases found"
 
 
-@pytest.mark.order(5)
 @pytest.mark.abort_on_fail
 @pytest.mark.database_tests
 async def test_relation_creation(ops_test: OpsTest):
@@ -272,7 +267,6 @@ async def test_relation_creation(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(apps=APPS, status="active")
 
 
-@pytest.mark.order(6)
 @pytest.mark.abort_on_fail
 @pytest.mark.database_tests
 async def test_ready_only_endpoints(ops_test: OpsTest):
@@ -326,7 +320,6 @@ async def test_ready_only_endpoints(ops_test: OpsTest):
         assert False
 
 
-@pytest.mark.order(7)
 @pytest.mark.abort_on_fail
 @pytest.mark.database_tests
 async def test_relation_broken(ops_test: OpsTest):

--- a/tests/integration/relations/test_db_router.py
+++ b/tests/integration/relations/test_db_router.py
@@ -114,7 +114,6 @@ async def check_keystone_users_existence(
         assert user not in output, "User(s) that should not exist are in the database"
 
 
-@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.db_router_tests
 async def test_keystone_bundle_db_router(ops_test: OpsTest, series: str) -> None:

--- a/tests/integration/relations/test_relation_mysql_legacy.py
+++ b/tests/integration/relations/test_relation_mysql_legacy.py
@@ -42,7 +42,6 @@ TEST_DATABASE = "testdb"
 TIMEOUT = 15 * 60
 
 
-@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 @pytest.mark.mysql_interface_tests
@@ -111,7 +110,6 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
     assert len(ops_test.model.applications[APPLICATION_APP_NAME].units) == 2
 
 
-@pytest.mark.order(2)
 @pytest.mark.abort_on_fail
 @pytest.mark.mysql_interface_tests
 async def test_relation_creation(ops_test: OpsTest):
@@ -133,7 +131,6 @@ async def test_relation_creation(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(apps=APPS, status="active")
 
 
-@pytest.mark.order(3)
 @pytest.mark.abort_on_fail
 @pytest.mark.mysql_interface_tests
 async def test_relation_broken(ops_test: OpsTest):

--- a/tests/integration/relations/test_shared_db.py
+++ b/tests/integration/relations/test_shared_db.py
@@ -149,7 +149,6 @@ async def check_keystone_users_existence(
         assert user not in output
 
 
-@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.shared_db_tests
 async def test_keystone_bundle_shared_db(ops_test: OpsTest, series: str) -> None:

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -34,7 +34,6 @@ APP_NAME = METADATA["name"]
 TLS_APP_NAME = "tls-certificates-operator"
 
 
-@pytest.mark.order(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.tls_tests
 async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
@@ -80,7 +79,6 @@ async def test_build_and_deploy(ops_test: OpsTest, series: str) -> None:
         )
 
 
-@pytest.mark.order(2)
 @pytest.mark.abort_on_fail
 @pytest.mark.tls_tests
 async def test_connection_before_tls(ops_test: OpsTest) -> None:
@@ -110,7 +108,6 @@ async def test_connection_before_tls(ops_test: OpsTest) -> None:
         ), f"❌ Unencrypted connection not possible to unit {unit.name} with disabled TLS"
 
 
-@pytest.mark.order(3)
 @pytest.mark.abort_on_fail
 @pytest.mark.tls_tests
 async def test_enable_tls(ops_test: OpsTest) -> None:
@@ -154,7 +151,6 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
     assert await get_tls_ca(ops_test, all_units[0].name), "❌ No CA found after TLS relation"
 
 
-@pytest.mark.order(4)
 @pytest.mark.abort_on_fail
 @pytest.mark.tls_tests
 async def test_rotate_tls_key(ops_test: OpsTest) -> None:
@@ -213,7 +209,6 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         ), f"❌ Unencrypted connection possible to unit {unit.name} with enabled TLS"
 
 
-@pytest.mark.order(5)
 @pytest.mark.abort_on_fail
 @pytest.mark.tls_tests
 async def test_disable_tls(ops_test: OpsTest) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ deps =
     mysql-connector-python
     pytest
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "ha_tests"
@@ -84,7 +83,6 @@ deps =
     mysql-connector-python
     pytest
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "db_router_tests"
@@ -96,7 +94,6 @@ deps =
     mysql-connector-python
     pytest
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "shared_db_tests"
@@ -108,7 +105,6 @@ deps =
     mysql-connector-python
     pytest
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "database_tests"
@@ -120,7 +116,6 @@ deps =
     mysql-connector-python
     pytest
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "mysql_interface_tests"
@@ -132,7 +127,6 @@ deps =
     mysql-connector-python
     pytest
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "healing_tests"
@@ -144,7 +138,6 @@ deps =
     mysql-connector-python
     pytest
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "tls_tests"
@@ -158,7 +151,6 @@ deps =
     pytest
     pdbpp
     pytest-operator
-    pytest-order
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m "dev"


### PR DESCRIPTION
By default, pytest runs tests sequentially in order of definition. pytest-order (as currently used) has no effect