### PR TITLE
Switch ops 1.5.2 to released 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==38.0.4
 jsonschema==4.16.0
-ops >= 1.5.2
+ops >= 2.0.0
 tenacity==8.0.1
 urllib3==1.26.12

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,8 +1,0 @@
-# Copyright 2022 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-import ops.testing
-
-# Since ops>=1.4 this enables better connection tracking.
-# See: More at https://juju.is/docs/sdk/testing#heading--simulate-can-connect
-ops.testing.SIMULATE_CAN_CONNECT = True


### PR DESCRIPTION
It is a try to increase tests stability. 