### PR TITLE
Remove top-level directory from PYTHONPATH

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
 
 [testenv]
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+  PYTHONPATH = {toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
 passenv =


### PR DESCRIPTION
# Issue
<!-- What issue is this PR trying to solve? -->
Python code should be in a subdirectory (`src`, `lib`, or `tests`)

Python code should not be importable from the top-level directory


# Solution
<!-- A summary of the solution addressing the above issue -->
Remove top-level directory from PYTHONPATH


# Context
<!-- What is some specialized knowledge relevant to this project/technology -->


# Testing
<!-- What steps need to be taken to test this PR? -->


# Release Notes
<!-- A digestable summary of the change in this PR -->
Remove top-level directory from PYTHONPATH
