### PR TITLE
Return IP addresses as endpoints instead of hostnames

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -747,10 +747,10 @@ class MySQLBase(ABC):
         def _get_host_ip(host: str) -> str:
             try:
                 if ":" in host:
-                    [host, port] = host.split(":")
+                    host, port = host.split(":")
 
                 host_ip = socket.gethostbyname(host)
-                return host_ip if not port else f"{host_ip}:{port}"
+                return f"{host_ip}:{port}" if port else host_ip
             except socket.gaierror:
                 raise MySQLGetClusterEndpointsError(f"Failed to query IP for host {host}")
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -68,6 +68,7 @@ error handling on the subclass and in the charm code.
 import json
 import logging
 import re
+import socket
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Optional, Tuple
 
@@ -89,7 +90,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -743,8 +744,22 @@ class MySQLBase(ABC):
 
         topology = status["defaultreplicaset"]["topology"]
 
-        ro_endpoints = {v["address"] for v in topology.values() if v["mode"] == "r/o"}
-        rw_endpoints = {v["address"] for v in topology.values() if v["mode"] == "r/w"}
+        def _get_host_ip(host: str) -> str:
+            try:
+                if ":" in host:
+                    [host, port] = host.split(":")
+
+                host_ip = socket.gethostbyname(host)
+                return host_ip if not port else f"{host_ip}:{port}"
+            except socket.gaierror:
+                raise MySQLGetClusterEndpointsError(f"Failed to query IP for host {host}")
+
+        ro_endpoints = {
+            _get_host_ip(v["address"]) for v in topology.values() if v["mode"] == "r/o"
+        }
+        rw_endpoints = {
+            _get_host_ip(v["address"]) for v in topology.values() if v["mode"] == "r/w"
+        }
 
         return ",".join(rw_endpoints), ",".join(ro_endpoints)
 

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -207,19 +207,11 @@ class MySQLProvider(Object):
 
         try:
             db_version = self.charm._mysql.get_mysql_version()
-            primary_endpoint = self.charm._mysql.get_cluster_primary_address()
+            rw_endpoints, ro_endpoints = self.charm._mysql.get_cluster_endpoints()
             self.database.set_credentials(relation_id, db_user, db_pass)
-            self.database.set_endpoints(relation_id, primary_endpoint)
+            self.database.set_endpoints(relation_id, rw_endpoints)
             self.database.set_version(relation_id, db_version)
-            # get read only endpoints by removing primary from all members
-            read_only_endpoints = sorted(
-                self.charm._mysql.get_cluster_members_addresses()
-                - {
-                    primary_endpoint,
-                }
-            )
-
-            self.database.set_read_only_endpoints(relation_id, ",".join(read_only_endpoints))
+            self.database.set_read_only_endpoints(relation_id, ro_endpoints)
             # TODO:
             # add setup of tls, tls_ca and status
             self.charm._mysql.create_application_database_and_scoped_user(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -647,7 +647,7 @@ def get_read_only_endpoints(relation_data: list) -> Set[str]:
     return read_only_endpoints
 
 
-def get_read_only_endpoint_hostnames(relation_data: list) -> List[str]:
+def get_read_only_endpoint_ips(relation_data: list) -> List[str]:
     """Returns the read-only-endpoint hostnames from the relation data.
 
     Args:
@@ -694,7 +694,7 @@ async def remove_leader_unit(ops_test: OpsTest, application_name: str):
         )
 
 
-async def get_unit_hostname(ops_test: OpsTest, app_name: str) -> List[str]:
+async def get_units_ip_addresses(ops_test: OpsTest, app_name: str) -> List[str]:
     """Retrieves hostnames of given application units.
 
     Args:
@@ -703,7 +703,10 @@ async def get_unit_hostname(ops_test: OpsTest, app_name: str) -> List[str]:
     Returns:
         a list that contains the hostnames of a given application
     """
-    units = [app_unit.name for app_unit in ops_test.model.applications[app_name].units]
+    units = [
+        get_unit_ip(ops_test, app_unit.name)
+        for app_unit in ops_test.model.applications[app_name].units
+    ]
 
     return [await unit_hostname(ops_test, unit_name) for unit_name in units]
 
@@ -720,13 +723,13 @@ async def check_read_only_endpoints(ops_test: OpsTest, app_name: str, relation_n
     relation_data = await get_relation_data(
         ops_test=ops_test, application_name=app_name, relation_name=relation_name
     )
-    read_only_endpoints = get_read_only_endpoint_hostnames(relation_data)
+    read_only_endpoints = get_read_only_endpoint_ips(relation_data)
     # check that the number of read-only-endpoints is correct
     assert len(ops_test.model.applications[app_name].units) - 1 == len(read_only_endpoints)
-    app_hostnames = await get_unit_hostname(ops_test=ops_test, app_name=app_name)
+    app_ips = await get_units_ip_addresses(ops_test=ops_test, app_name=app_name)
     # check that endpoints are the one of the application
     for r_endpoint in read_only_endpoints:
-        assert r_endpoint in app_hostnames
+        assert r_endpoint in app_ips
 
 
 async def get_controller_machine(ops_test: OpsTest) -> str:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -703,12 +703,10 @@ async def get_units_ip_addresses(ops_test: OpsTest, app_name: str) -> List[str]:
     Returns:
         a list that contains the hostnames of a given application
     """
-    units = [
-        get_unit_ip(ops_test, app_unit.name)
+    return [
+        await get_unit_ip(ops_test, app_unit.name)
         for app_unit in ops_test.model.applications[app_name].units
     ]
-
-    return [await unit_hostname(ops_test, unit_name) for unit_name in units]
 
 
 async def check_read_only_endpoints(ops_test: OpsTest, app_name: str, relation_name: str):
@@ -723,13 +721,13 @@ async def check_read_only_endpoints(ops_test: OpsTest, app_name: str, relation_n
     relation_data = await get_relation_data(
         ops_test=ops_test, application_name=app_name, relation_name=relation_name
     )
-    read_only_endpoints = get_read_only_endpoint_ips(relation_data)
+    read_only_endpoint_ips = get_read_only_endpoint_ips(relation_data)
     # check that the number of read-only-endpoints is correct
-    assert len(ops_test.model.applications[app_name].units) - 1 == len(read_only_endpoints)
+    assert len(ops_test.model.applications[app_name].units) - 1 == len(read_only_endpoint_ips)
     app_ips = await get_units_ip_addresses(ops_test=ops_test, app_name=app_name)
     # check that endpoints are the one of the application
-    for r_endpoint in read_only_endpoints:
-        assert r_endpoint in app_ips
+    for read_endpoint_ip in read_only_endpoint_ips:
+        assert read_endpoint_ip in app_ips
 
 
 async def get_controller_machine(ops_test: OpsTest) -> str:

--- a/tests/integration/relations/test_database.py
+++ b/tests/integration/relations/test_database.py
@@ -245,7 +245,7 @@ async def test_relation_creation(ops_test: OpsTest):
 
 
 @pytest.mark.abort_on_fail
-async def test_ready_only_endpoints(ops_test: OpsTest):
+async def test_read_only_endpoints(ops_test: OpsTest):
     """Check read-only-endpoints are correctly updated."""
     relation_data = await get_relation_data(
         ops_test=ops_test, application_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -25,7 +25,10 @@ class TestDatase(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
-    @patch("mysql_vm_helpers.MySQL.get_cluster_endpoints", return_value=("2.2.2.2:3306", "2.2.2.1:3306,2.2.2.3:3306"))
+    @patch(
+        "mysql_vm_helpers.MySQL.get_cluster_endpoints",
+        return_value=("2.2.2.2:3306", "2.2.2.1:3306,2.2.2.3:3306"),
+    )
     @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
     @patch(
         "relations.mysql_provider.generate_random_password", return_value="super_secure_password"

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -25,11 +25,7 @@ class TestDatase(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
-    @patch(
-        "mysql_vm_helpers.MySQL.get_cluster_members_addresses",
-        return_value={"2.2.2.1:3306", "2.2.2.3:3306", "2.2.2.2:3306"},
-    )
-    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="2.2.2.2:3306")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_endpoints", return_value=("2.2.2.2:3306", "2.2.2.1:3306,2.2.2.3:3306"))
     @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
     @patch(
         "relations.mysql_provider.generate_random_password", return_value="super_secure_password"
@@ -38,8 +34,7 @@ class TestDatase(unittest.TestCase):
         self,
         _generate_random_password,
         _create_application_database_and_scoped_user,
-        _get_cluster_primary_address,
-        _get_cluster_members_addresses,
+        _get_cluster_endpoints,
         _get_mysql_version,
     ):
         # run start-up events to enable usage of the helper class
@@ -81,8 +76,7 @@ class TestDatase(unittest.TestCase):
 
         _generate_random_password.assert_called_once()
         _create_application_database_and_scoped_user.assert_called_once()
-        _get_cluster_primary_address.assert_called_once()
-        _get_cluster_members_addresses.assert_called_once()
+        _get_cluster_endpoints.assert_called_once()
         _get_mysql_version.assert_called_once()
 
     @patch_network_get(private_address="1.1.1.1")


### PR DESCRIPTION
# Issue
[DPE-1174](https://warthogs.atlassian.net/browse/DPE-1174)

The `endpoint` field of the `mysql_client` relation is expecting IP addresses (so that external consumers can connect to the database). However, MySQL Group Replication is storing hostnames as member addresses.

# Solution
Convert the hostnames to IP addresses for the `endpoint` field.

```
shayan@wellington:~ (07:42:47)  $ juju run-action data-integrator/0 get-credentials --wait --format=y
aml
unit-data-integrator-0:
  UnitId: data-integrator/0
  id: "6"
  results:
    mysql:
      endpoints: 10.201.101.31:3306
      password: uCWa9MCBrMUmZRM8Ua7j1T63
      read-only-endpoints: 10.201.101.7:3306
      username: relation-9
      version: 8.0.32-0ubuntu0.22.04.2
    ok: "True"
  status: completed
  timing:
    completed: 2023-02-04 12:42:58 +0000 UTC
    enqueued: 2023-02-04 12:42:53 +0000 UTC
    started: 2023-02-04 12:42:58 +0000 UTC
```

# Context
We are using the `socket` python lib to convert hostnames to IP addresses. `socket.gethostbyname` handles IP addresses correctly. Since the member addresses are used by Group Replication to communicate with one another, the DNS resolution of the member address (if it is a hostname) is going to work.

```
>>> import socket                                                                                                                                                                                          
>>> socket.gethostbyname('juju-1aa21d-0')                                                                                                                                                                  
'10.201.101.135'                                                                                                                                                                                           
>>> socket.gethostbyname('10.201.101.135')                                                                                                                                                                 
'10.201.101.135'                                                                                                                                                                                           
>>> socket.gethostbyname('blah')                                                                                                                                                                           
Traceback (most recent call last):                                                                                                                                                                         
  File "<stdin>", line 1, in <module>                                                                                                                                                                      
socket.gaierror: [Errno -3] Temporary failure in name resolution                                                                                                                                           
>>> socket.gethostbyname('juju-1aa21d-0:3306')                                                                                                                                                             
Traceback (most recent call last):                                                                                                                                                                         
  File "<stdin>", line 1, in <module>                                                                                                                                                                      
socket.gaierror: [Errno -2] Name or service not known 
>>>
```

# Release Notes
Return IP addresses as endpoints instead of hostnames


[DPE-1174]: https://warthogs.atlassian.net/browse/DPE-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ