### PR TITLE
Remove unused tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,14 +72,6 @@ commands =
         -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
     coverage report
 
-[testenv:create-build-matrix]
-description = Create build matrix for integration tests
-deps =
-    pyyaml
-pass_env = GITHUB_OUTPUT
-commands =
-    python -c "from tests.integration.read_charm_yaml import create_build_matrix; create_build_matrix()"
-
 [testenv:integration-ha]
 description = Run HA integration tests
 pass_env =


### PR DESCRIPTION
## Issue
`create-build-matrix` environment no longer needed as of #106

## Solution
Remove environment