### PR TITLE
Use output from build workflow for artifact name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Download packed charm(s)
         uses: actions/download-artifact@v3
         with:
-          name: charms-packed-with-cache
+          name: ${{ needs.build.outputs.artifact-name }}
       - name: Select tests
         id: select-tests
         run: |


### PR DESCRIPTION
## Issue
Artifact name is hard-coded and needs to match with artifact name used during build

## Solution
Use output from build workflow added in https://github.com/canonical/data-platform-workflows/pull/6