### PR TITLE
Use v1 of build workflow instead of main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@main
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v1
 
   integration-test:
     strategy:


### PR DESCRIPTION
## Issue
Breaking changes to build workflow will be automatically used

## Solution
Pin major version of build workflow
