### PR TITLE
Rename "flaky" mark to "unstable"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,11 +82,11 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "schedule" ]
           then
-            echo Running flaky and non-flaky tests
+            echo Running unstable and stable tests
             echo "mark_expression=" >> $GITHUB_OUTPUT
           else
-            echo Skipping flaky tests
-            echo "mark_expression=not flaky" >> $GITHUB_OUTPUT
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
           fi
       - name: Run integration tests
         run: tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' --mysql-charm-series=${{ matrix.ubuntu-versions.series }} --mysql-charm-bases-index=${{ matrix.ubuntu-versions.bases-index }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ log_cli_level = "INFO"
 asyncio_mode = "auto"
 markers = [
     "dev: mark to test in development tests",
-    "flaky"
+    "unstable"
 ]
 
 # Formatting tools configuration

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -54,7 +54,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> N
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.flaky
+@pytest.mark.unstable
 async def test_kill_db_process(
     ops_test: OpsTest, continuous_writes, mysql_charm_series: str
 ) -> None:
@@ -95,7 +95,7 @@ async def test_kill_db_process(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.flaky
+@pytest.mark.unstable
 async def test_freeze_db_process(ops_test: OpsTest, continuous_writes, mysql_charm_series: str):
     """Freeze and unfreeze process and check for auto cluster recovery."""
     mysql_application_name, _ = await high_availability_test_setup(ops_test, mysql_charm_series)
@@ -139,7 +139,7 @@ async def test_freeze_db_process(ops_test: OpsTest, continuous_writes, mysql_cha
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.flaky
+@pytest.mark.unstable
 async def test_network_cut(ops_test: OpsTest, continuous_writes, mysql_charm_series: str):
     """Completely cut and restore network."""
     mysql_application_name, _ = await high_availability_test_setup(ops_test, mysql_charm_series)
@@ -220,7 +220,7 @@ async def test_network_cut(ops_test: OpsTest, continuous_writes, mysql_charm_ser
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.flaky
+@pytest.mark.unstable
 async def test_replicate_data_on_restart(
     ops_test: OpsTest, continuous_writes, mysql_charm_series: str
 ):
@@ -305,7 +305,7 @@ async def test_replicate_data_on_restart(
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.flaky
+@pytest.mark.unstable
 async def test_cluster_pause(ops_test: OpsTest, continuous_writes, mysql_charm_series: str):
     """Pause test.
 
@@ -370,7 +370,7 @@ async def test_cluster_pause(ops_test: OpsTest, continuous_writes, mysql_charm_s
 
 
 @pytest.mark.abort_on_fail
-@pytest.mark.flaky
+@pytest.mark.unstable
 async def test_sst_test(ops_test: OpsTest, continuous_writes, mysql_charm_series: str):
     """The SST test.
 


### PR DESCRIPTION
## Issue
When new integration tests are added, they will be given this mark until they are shown to be stable. "flaky" implies that they have been discovered to be inconsistent

## Solution
