### PR TITLE
update endpoints retrival to report offline nodes

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -90,7 +90,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -731,11 +731,14 @@ class MySQLBase(ABC):
         except MySQLClientError as e:
             logger.exception(f"Failed to get cluster status for {self.cluster_name}", exc_info=e)
 
-    def get_cluster_endpoints(self) -> Tuple[str, str]:
+    def get_cluster_endpoints(self, get_ips: bool = True) -> Tuple[str, str, str]:
         """Use get_cluster_status to return endpoints tuple.
 
+        Args:
+            get_ips: Whether to return IP addresses or hostnames, default to IP
+
         Returns:
-            A tuple with endpoints and read-only-endpoints strings.
+            A tuple of strings with endpoints, read-only-endpoints and offline endpoints
         """
         status = self.get_cluster_status()
 
@@ -755,13 +758,19 @@ class MySQLBase(ABC):
                 raise MySQLGetClusterEndpointsError(f"Failed to query IP for host {host}")
 
         ro_endpoints = {
-            _get_host_ip(v["address"]) for v in topology.values() if v["mode"] == "r/o"
+            _get_host_ip(v["address"]) if get_ips else v["address"]
+            for v in topology.values()
+            if v["memberrole"] == "secondary" and v["status"] == "online"
         }
         rw_endpoints = {
-            _get_host_ip(v["address"]) for v in topology.values() if v["mode"] == "r/w"
+            _get_host_ip(v["address"]) if get_ips else v["address"]
+            for v in topology.values()
+            if v["memberrole"] == "primary" and v["status"] == "online"
         }
+        # won't get offline endpoints to IP as they maybe unreachable
+        no_endpoints = {v["address"] for v in topology.values() if v["status"] != "online"}
 
-        return ",".join(rw_endpoints), ",".join(ro_endpoints)
+        return ",".join(rw_endpoints), ",".join(ro_endpoints), ",".join(no_endpoints)
 
     @retry(
         retry=retry_if_exception_type(MySQLRemoveInstanceRetryError),

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -149,7 +149,7 @@ class MySQLProvider(Object):
             remote_app (str): The name of the remote application
         """
         try:
-            rw_endpoints, ro_endpoints = self.charm._mysql.get_cluster_endpoints()
+            rw_endpoints, ro_endpoints, _ = self.charm._mysql.get_cluster_endpoints()
 
             # check if endpoints need update
             relation = self.model.get_relation(DB_RELATION_NAME, relation_id)
@@ -207,7 +207,7 @@ class MySQLProvider(Object):
 
         try:
             db_version = self.charm._mysql.get_mysql_version()
-            rw_endpoints, ro_endpoints = self.charm._mysql.get_cluster_endpoints()
+            rw_endpoints, ro_endpoints, _ = self.charm._mysql.get_cluster_endpoints()
             self.database.set_credentials(relation_id, db_user, db_pass)
             self.database.set_endpoints(relation_id, rw_endpoints)
             self.database.set_version(relation_id, db_version)

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -28,7 +28,7 @@ class TestDatase(unittest.TestCase):
     @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
     @patch(
         "mysql_vm_helpers.MySQL.get_cluster_endpoints",
-        return_value=("2.2.2.2:3306", "2.2.2.1:3306,2.2.2.3:3306"),
+        return_value=("2.2.2.2:3306", "2.2.2.1:3306,2.2.2.3:3306", ""),
     )
     @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
     @patch(

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -868,6 +868,43 @@ class TestMySQLBase(unittest.TestCase):
 
         _run_mysqlsh_script.assert_called_with(expected_commands)
 
+    @patch(
+        "charms.mysql.v0.mysql.MySQLBase.get_cluster_status",
+        return_value={
+            "defaultreplicaset": {
+                "topology": {
+                    "mysql-k8s-0": {
+                        "address": "mysql-k8s-0.mysql-k8s-endpoints:3306",
+                        "memberrole": "secondary",
+                        "status": "online",
+                    },
+                    "mysql-k8s-1": {
+                        "address": "mysql-k8s-1.mysql-k8s-endpoints:3306",
+                        "memberrole": "primary",
+                        "status": "online",
+                    },
+                    "mysql-k8s-2": {
+                        "address": "mysql-k8s-2.mysql-k8s-endpoints:3306",
+                        "memberrole": "",
+                        "status": "offline",
+                    },
+                }
+            }
+        },
+    )
+    def test_get_cluster_endpoints(self, _):
+        """Test get_cluster_endpoints() method."""
+        endpoints = self.mysql.get_cluster_endpoints(get_ips=False)
+
+        self.assertEqual(
+            endpoints,
+            (
+                "mysql-k8s-1.mysql-k8s-endpoints:3306",
+                "mysql-k8s-0.mysql-k8s-endpoints:3306",
+                "mysql-k8s-2.mysql-k8s-endpoints:3306",
+            ),
+        )
+
     def test_abstract_methods(self):
         """Test abstract methods."""
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
## Issue

k8s charm need to patch offline pods labels to avoid then be picked up by kubernetes services selector rule.
k8s uses hostnames by default.

## Solution

* include `offline` endpoints output
* parametrized IP conversion
