### PR TITLE
Alutay/add lib publisher

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,20 @@ jobs:
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
 
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@2.2.2
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   build:
     name: Build charms
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v1
@@ -60,6 +74,7 @@ jobs:
             bases-index: 1
     name: ${{ matrix.tox-environments }} | ${{ matrix.ubuntu-versions.series }}
     needs:
+      - lib-check
       - lint
       - unit-test
       - build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@2.2.2
         with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Release any bumped charm libs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci-tests:
-    name: Run lint, unit, and integration tests
+    name: Tests
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
 
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Release any bumped charm libs
+      - name: Release charm libraries
         uses: canonical/charming-actions/release-libraries@2.2.2
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
@@ -35,4 +35,3 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,29 +6,14 @@ on:
       - main
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.2.2
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   ci-tests:
-    needs:
-      - lib-check
+    name: Run lint, unit, and integration tests
     uses: ./.github/workflows/ci.yaml
+    secrets: inherit
 
   release-to-charmhub:
     name: Release to CharmHub
     needs:
-      - lib-check
       - ci-tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Release any bumped charm libs
+        uses: canonical/charming-actions/release-libraries@2.2.2
+        with:
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.2.2
         id: channel
@@ -45,3 +50,4 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: "${{ steps.channel.outputs.name }}"
+


### PR DESCRIPTION
## Issue
1) we are not publishing our libraries automatically, while mysql-k8s reuse those libraries.
2) we are not shoring outdated libraries warning on PR request. We are labeling outdated libraries after merging, but nobody see them.

## Solution
1) publish libraries automatically on new LIBPATCH bump.
2) label outdated libraries on PR request.