### PR TITLE
Add method to lib that checks if instances exist in backing up state

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -214,6 +214,14 @@ class MySQLSetInstanceOptionError(Error):
     """Exception raised when there is an issue setting instance option."""
 
 
+class MySQLOfflineModeAndHiddenInstanceExistsError(Error):
+    """Exception raised when there is an error checking if an instance is backing up.
+
+    We check if an instance is in offline_mode and hidden from mysql-router to determine
+    this.
+    """
+
+
 class MySQLBase(ABC):
     """Abstract class to encapsulate all operations related to the MySQL instance and cluster.
 
@@ -491,17 +499,23 @@ class MySQLBase(ABC):
             logger.exception(f"Failed to delete users for relation {relation_id}", exc_info=e)
             raise MySQLDeleteUserForRelationError(e.message)
 
-    def configure_instance(self, restart: bool = True) -> None:
+    def configure_instance(self, restart: bool = True, create_cluster_admin: bool = True) -> None:
         """Configure the instance to be used in an InnoDB cluster.
 
         Raises MySQLConfigureInstanceError
             if the was an error configuring the instance for use in an InnoDB cluster.
         """
         options = {
-            "clusterAdmin": self.cluster_admin_user,
-            "clusterAdminPassword": self.cluster_admin_password,
             "restart": "true" if restart else "false",
         }
+
+        if create_cluster_admin:
+            options.update(
+                {
+                    "clusterAdmin": self.cluster_admin_user,
+                    "clusterAdminPassword": self.cluster_admin_password,
+                }
+            )
 
         configure_instance_command = (
             f"dba.configure_instance('{self.server_config_user}:{self.server_config_password}@{self.instance_address}', {json.dumps(options)})",
@@ -1209,6 +1223,33 @@ class MySQLBase(ABC):
         except MySQLClientError as e:
             logger.exception(f"Failed to set option {option} with value {value}", exc_info=e)
             raise MySQLSetInstanceOptionError(e.message)
+
+    def offline_mode_and_hidden_instance_exists(self) -> bool:
+        """Indicates whether an instance exists in offline_mode and hidden from router.
+
+        The pre_backup operations switch an instance to offline_mode and hide it
+        from the mysql-router.
+        """
+        offline_mode_message = "Instance has offline_mode enabled"
+        commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
+            f"cluster_topology = dba.get_cluster('{self.cluster_name}').status()['defaultReplicaSet']['topology']",
+            f"selected_instances = [label for label, member in cluster_topology.items() if '{offline_mode_message}' in member.get('instanceErrors', '') and member.get('hiddenFromRouter')]",
+            "print(f'<OFFLINE_MODE_INSTANCES>{len(selected_instances)}</OFFLINE_MODE_INSTANCES>')",
+        )
+
+        try:
+            output = self._run_mysqlsh_script("\n".join(commands))
+        except MySQLClientError as e:
+            logger.exception("Failed to query offline mode instances", exc_info=e)
+            raise MySQLOfflineModeAndHiddenInstanceExistsError(e)
+
+        matches = re.search(r"<OFFLINE_MODE_INSTANCES>(.*)</OFFLINE_MODE_INSTANCES>", output)
+
+        if not matches:
+            raise MySQLOfflineModeAndHiddenInstanceExistsError("Failed to parse command output")
+
+        return matches.group(1) != "0"
 
     @abstractmethod
     def wait_until_mysql_connection(self) -> None:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -90,7 +90,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -21,6 +21,7 @@ from charms.mysql.v0.mysql import (
     MySQLDeleteUserForRelationError,
     MySQLDeleteUsersForUnitError,
     MySQLInitializeJujuOperationsTableError,
+    MySQLOfflineModeAndHiddenInstanceExistsError,
     MySQLRemoveInstanceError,
     MySQLRemoveInstanceRetryError,
     MySQLUpgradeUserForMySQLRouterError,
@@ -904,6 +905,41 @@ class TestMySQLBase(unittest.TestCase):
                 "mysql-k8s-2.mysql-k8s-endpoints:3306",
             ),
         )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_offline_mode_and_hidden_instance_exists(self, _run_mysqlsh_script):
+        """Test the offline_mode_and_hidden_instance_exists() method."""
+        commands = (
+            "shell.connect('clusteradmin:clusteradminpassword@127.0.0.1')",
+            "cluster_topology = dba.get_cluster('test_cluster').status()['defaultReplicaSet']['topology']",
+            "selected_instances = [label for label, member in cluster_topology.items() if 'Instance has offline_mode enabled' in member.get('instanceErrors', '') and member.get('hiddenFromRouter')]",
+            "print(f'<OFFLINE_MODE_INSTANCES>{len(selected_instances)}</OFFLINE_MODE_INSTANCES>')",
+        )
+
+        _run_mysqlsh_script.return_value = "<OFFLINE_MODE_INSTANCES>1</OFFLINE_MODE_INSTANCES>"
+
+        exists = self.mysql.offline_mode_and_hidden_instance_exists()
+        self.assertTrue(exists)
+        _run_mysqlsh_script.assert_called_once_with("\n".join(commands))
+
+        _run_mysqlsh_script.reset_mock()
+        _run_mysqlsh_script.return_value = "<OFFLINE_MODE_INSTANCES>0</OFFLINE_MODE_INSTANCES>"
+
+        exists = self.mysql.offline_mode_and_hidden_instance_exists()
+        self.assertFalse(exists)
+        _run_mysqlsh_script.assert_called_once_with("\n".join(commands))
+
+        _run_mysqlsh_script.reset_mock()
+        _run_mysqlsh_script.side_effect = MySQLClientError()
+
+        with self.assertRaises(MySQLOfflineModeAndHiddenInstanceExistsError):
+            self.mysql.offline_mode_and_hidden_instance_exists()
+
+        _run_mysqlsh_script.reset_mock()
+        _run_mysqlsh_script.return_value = "garbage"
+
+        with self.assertRaises(MySQLOfflineModeAndHiddenInstanceExistsError):
+            self.mysql.offline_mode_and_hidden_instance_exists()
 
     def test_abstract_methods(self):
         """Test abstract methods."""

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -277,7 +277,7 @@ class TestMySQLBase(unittest.TestCase):
     def test_configure_instance(self, _wait_until_mysql_connection, _run_mysqlsh_script):
         """Test a successful execution of configure_instance."""
         configure_instance_commands = (
-            'dba.configure_instance(\'serverconfig:serverconfigpassword@127.0.0.1\', {"clusterAdmin": "clusteradmin", "clusterAdminPassword": "clusteradminpassword", "restart": "true"})',
+            'dba.configure_instance(\'serverconfig:serverconfigpassword@127.0.0.1\', {"restart": "true", "clusterAdmin": "clusteradmin", "clusterAdminPassword": "clusteradminpassword"})',
         )
 
         self.mysql.configure_instance()


### PR DESCRIPTION
## Issue
The k8s operator introduces a method that checks if an instance is in a "backing up" state (by checking if the instance is in offline_mode and is hidden from mysql-router). This method can also be used in the mysql vm operator.

## Solution
Move the method into the shared mysql lib