### PR TITLE
Support `juju expose`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -270,6 +270,7 @@ class MySQLOperatorCharm(CharmBase):
             self.unit_peer_data["unit-initialized"] = "True"
             try:
                 subprocess.check_call(["open-port", "3306/tcp"])
+                subprocess.check_call(["open-port", "33060/tcp"])
             except subprocess.CalledProcessError:
                 logger.exception("failed to open port")
             self.unit.status = ActiveStatus(self.active_status_message)
@@ -537,6 +538,7 @@ class MySQLOperatorCharm(CharmBase):
         self.unit_peer_data["member-role"] = "primary"
         try:
             subprocess.check_call(["open-port", "3306/tcp"])
+            subprocess.check_call(["open-port", "33060/tcp"])
         except subprocess.CalledProcessError:
             logger.exception("failed to open port")
 


### PR DESCRIPTION
## Issue
Support `juju expose` ([DPE-1214](https://warthogs.atlassian.net/browse/DPE-1214))

## Solution
Run `open-port` hook tool with subprocess (copied from https://github.com/jnsgruk/zinc-k8s-operator/commit/2076f30311ce915aae7b982de33b03e0b4bb15ce#diff-b9ed39bbc9c0387bd3e07da31d13373745534a1cd723d3e292c73496b12e307cR78-R82)

[DPE-1214]: https://warthogs.atlassian.net/browse/DPE-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ