### PR TITLE
Do not fail on unhappy CodeCov

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 30%
+        threshold: 100%

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,8 +35,6 @@ jobs:
         run: tox run -e unit
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: false
 
   lib-check:
     name: Check libraries

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
         run: tox run -e unit
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          if_ci_failed: false
 
   lib-check:
     name: Check libraries

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          if_ci_failed: false
+          fail_ci_if_error: false
 
   lib-check:
     name: Check libraries


### PR DESCRIPTION
## Issue

We have enabled CodeCov to see the tests coverage statistic, but it makes CI/CD [unhappy](https://github.com/canonical/mysql-operator/pull/126).

## Solution
Do not fail CI/CD for now. At the moment we are running CodeCov for statistic only, we are not enforcing committers to make CodeCov happy. One day in the future, we will re-consider this.


