### PR TITLE
Fix early legacy relations handling

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -975,10 +975,9 @@ class MySQLBase(ABC):
         Returns:
             The address of the cluster's primary
         """
-        logger.debug(f"Getting cluster primary member's address from {connect_instance_address}")
-
         if not connect_instance_address:
             connect_instance_address = self.instance_address
+        logger.debug(f"Getting cluster primary member's address from {connect_instance_address}")
 
         get_cluster_primary_commands = (
             f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{connect_instance_address}')",

--- a/src/relations/db_router.py
+++ b/src/relations/db_router.py
@@ -208,6 +208,11 @@ class DBRouterRelation(Object):
         if not self.charm.unit.is_leader():
             return
 
+        # wait until the unit is initialized
+        if not self.charm.unit_peer_data.get("unit-initialized"):
+            event.defer()
+            return
+
         logger.warning("DEPRECATION WARNING - `db-router` is a legacy interface")
 
         changed_unit_databag = event.relation.data.get(event.unit)

--- a/src/relations/db_router.py
+++ b/src/relations/db_router.py
@@ -180,7 +180,7 @@ class DBRouterRelation(Object):
             return
 
         try:
-            primary_address = self._charm._mysql.get_cluster_primary_address().split(":")[0]
+            primary_address = self.charm._mysql.get_cluster_primary_address().split(":")[0]
         except MySQLGetClusterPrimaryAddressError:
             logger.error("Can't get primary address. Deferring")
             event.defer()

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -106,6 +106,12 @@ class MySQLRelation(Object):
         database = self.charm.config.get("mysql-interface-database")
 
         if not username or not database:
+            logger.debug("`mysql` legacy interface user or database not defined.")
+            event.defer()
+            return
+
+        # wait until the unit is initialized
+        if not self.charm.unit_peer_data.get("unit-initialized"):
             event.defer()
             return
 
@@ -131,7 +137,7 @@ class MySQLRelation(Object):
             MySQLCreateApplicationDatabaseAndScopedUserError,
             MySQLGetClusterPrimaryAddressError,
         ):
-            self._charm.unit.status = BlockedStatus("Failed to initialize mysql relation")
+            self.charm.unit.status = BlockedStatus("Failed to initialize mysql relation")
             return
 
         updates = {
@@ -167,4 +173,4 @@ class MySQLRelation(Object):
             self.charm._mysql.delete_users_for_unit("mysql-legacy-relation")
         except MySQLDeleteUsersForUnitError:
             logger.error("Failed to delete mysql users")
-            self._charm.unit.status = BlockedStatus("Failed to remove relation user")
+            self.charm.unit.status = BlockedStatus("Failed to remove relation user")

--- a/src/relations/shared_db.py
+++ b/src/relations/shared_db.py
@@ -104,6 +104,11 @@ class SharedDBRelation(Object):
         if not self._charm.unit.is_leader():
             return
 
+        # wait until the unit is initialized
+        if not self._charm.unit_peer_data.get("unit-initialized"):
+            event.defer()
+            return
+
         logger.warning("DEPRECATION WARNING - `shared-db` is a legacy interface")
 
         # get relation data

--- a/tests/unit/test_db_router.py
+++ b/tests/unit/test_db_router.py
@@ -45,6 +45,7 @@ class TestDBRouter(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
+        self.charm.unit_peer_data["unit-initialized"] = "True"
 
         # confirm that the relation databag is empty
         db_router_relation_databag = self.harness.get_relation_data(
@@ -127,6 +128,7 @@ class TestDBRouter(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
+        self.charm.unit_peer_data["unit-initialized"] = "True"
 
         # confirm that the relation databag is empty
         db_router_relation_databag = self.harness.get_relation_data(

--- a/tests/unit/test_relation_mysql_legacy.py
+++ b/tests/unit/test_relation_mysql_legacy.py
@@ -39,6 +39,7 @@ class TestMariaDBRelation(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
+        self.charm.unit_peer_data["unit-initialized"] = "True"
         self.harness.update_config(
             {"mysql-interface-user": "mysql", "mysql-interface-database": "default_database"}
         )

--- a/tests/unit/test_shared_db.py
+++ b/tests/unit/test_shared_db.py
@@ -38,6 +38,7 @@ class TestSharedDBRelation(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
+        self.charm.unit_peer_data["unit-initialized"] = "True"
 
         # confirm that the relation databag is empty
         shared_db_relation_databag = self.harness.get_relation_data(
@@ -89,6 +90,7 @@ class TestSharedDBRelation(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
+        self.charm.unit_peer_data["unit-initialized"] = "True"
 
         _create_application_database_and_scoped_user.side_effect = (
             MySQLCreateApplicationDatabaseAndScopedUserError("Can't create user")


### PR DESCRIPTION
## Issue

Legacy relations are trying to access database (user checking/creation, etc) as soon as the relation starts.
The problem arises when in bundle deployment, the database is still initializing.
Ref. issue is [DPE-1312](https://warthogs.atlassian.net/browse/DPE-1312)

## Solution

Defer relations {created/changed} handlers execution until database is initialized.



[DPE-1312]: https://warthogs.atlassian.net/browse/DPE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ