### PR TITLE
Deprecate series focal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,10 +75,8 @@ jobs:
           - integration-tls
         ubuntu-versions:
           # Update whenever charmcraft.yaml is changed
-          - series: focal
-            bases-index: 0
           - series: jammy
-            bases-index: 1
+            bases-index: 0
     name: ${{ matrix.tox-environments }} | ${{ matrix.ubuntu-versions.series }}
     needs:
       - lib-check

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,12 +8,6 @@ bases:
   # - Update .github/workflow/ci.yaml integration-test matrix
   - build-on:
       - name: "ubuntu"
-        channel: "20.04"
-    run-on:
-      - name: "ubuntu"
-        channel: "20.04"
-  - build-on:
-      - name: "ubuntu"
         channel: "22.04"
     run-on:
       - name: "ubuntu"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,7 @@ def pytest_configure(config):
     if config.option.mysql_charm_series is None:
         config.option.mysql_charm_series = "jammy"
     if config.option.mysql_charm_bases_index is None:
-        config.option.mysql_charm_bases_index = 1
+        config.option.mysql_charm_bases_index = 0
 
 
 @pytest.fixture


### PR DESCRIPTION
## Issue
We would like to stop support for the `focal` series (as we do not publish it).

## Solution
Remove `focal` from supported series in charmcraft.py, and adjust the CI to run tests against `jammy` only