### PR TITLE
Only show ActiveStatus message on primary

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -523,10 +523,11 @@ class MySQLOperatorCharm(CharmBase):
             raise RuntimeError("Unknown secret scope.")
 
     @property
-    def active_status_message(self) -> Optional[str]:
+    def active_status_message(self) -> str:
         """Active status message."""
         if self.unit_peer_data.get("member-role") == "primary":
             return "Primary"
+        return ""
 
     def _workload_initialise(self) -> None:
         """Workload initialisation commands.


### PR DESCRIPTION
## Issue
[DPE-1258](https://warthogs.atlassian.net/browse/DPE-1258) ("Print nothing to messages IF user attention is not necessary")

## Solution
Set message to "Primary" for primary unit, do not set message for other units


[DPE-1258]: https://warthogs.atlassian.net/browse/DPE-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ