### PR TITLE
Update peer interface name to follow naming conventions

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ maintainers:
   - Shayan Patel <shayan.patel@canonical.com>
 peers:
   database-peers:
-    interface: mysql-peers
+    interface: mysql_peers
   restart:
     interface: rolling_op
 provides:


### PR DESCRIPTION
## Issue
The interface name is using `-`, but naming convention says `_`.
https://juju.is/docs/sdk/styleguide

## Solution
The endpoint name should use `-`, but interface name `_`.
