### PR TITLE
Use exactly match on 'pgrep mysqld' due to mysqld_exporter availability

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -417,7 +417,7 @@ async def get_process_pid(ops_test: OpsTest, unit_name: str, process: str) -> in
         A integer for the process id
     """
     try:
-        _, raw_pid, _ = await ops_test.juju("ssh", unit_name, "pgrep", process)
+        _, raw_pid, _ = await ops_test.juju("ssh", unit_name, "pgrep", "-x", process)
         pid = int(raw_pid.strip())
 
         return pid


### PR DESCRIPTION
## Issue
The test is getting wrong pid due to wide match:
```
> ubuntu@juju-82de18-16:~$ pgrep -a mysqld
> 3774 /snap/charmed-mysql/24/bin/mysqld_exporter ...
> 3996 /bin/sh /snap/charmed-mysql/24/usr/bin/mysqld_safe ...
> 4866 /snap/charmed-mysql/24/usr/sbin/mysqld ...
> ubuntu@juju-82de18-16:~$

> ubuntu@juju-82de18-16:~$ pgrep -a -x mysqld
> 4866 /snap/charmed-mysql/24/usr/sbin/mysqld ...
> ubuntu@juju-82de18-16:~$
```
## Solution
Use "pgrep -x" for exact match.