### PR TITLE
Bump wait_network_restore timeout from 2 to 5 minutes

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -488,7 +488,7 @@ async def unit_hostname(ops_test: OpsTest, unit_name: str) -> str:
     return raw_hostname.strip()
 
 
-@retry(stop=stop_after_attempt(8), wait=wait_fixed(15))
+@retry(stop=stop_after_attempt(20), wait=wait_fixed(15))
 def wait_network_restore(model_name: str, hostname: str, old_ip: str) -> None:
     """Wait until network is restored.
 


### PR DESCRIPTION
Time-2-time the test is failing on busy GH runners:

> Traceback (most recent call last):
>   File "/home/runner/work/mysql-operator/mysql-operator/.tox/integration/lib/python3.10/site-packages/tenacity/__init__.py", line 407, in __call__
>     result = fn(*args, **kwargs)
>   File "/home/runner/work/mysql-operator/mysql-operator/tests/integration/helpers.py", line 501, in wait_network_restore
>     raise Exception
>   Exception
>
> The above exception was the direct cause of the following exception:
>
> Traceback (most recent call last):
>   File "/home/runner/work/mysql-operator/mysql-operator/tests/integration/high_availability/test_self_healing.py", line 198, in test_network_cut
>     wait_network_restore(model_name, primary_hostname, primary_unit_ip)
>   File "/home/runner/work/mysql-operator/mysql-operator/.tox/integration/lib/python3.10/site-packages/tenacity/__init__.py", line 324, in wrapped_f
>     return self(f, *args, **kw)
>   File "/home/runner/work/mysql-operator/mysql-operator/.tox/integration/lib/python3.10/site-packages/tenacity/__init__.py", line 404, in __call__
>     do = self.iter(retry_state=retry_state)
>   File "/home/runner/work/mysql-operator/mysql-operator/.tox/integration/lib/python3.10/site-packages/tenacity/__init__.py", line 361, in iter
>     raise retry_exc from fut.exception()
> tenacity.RetryError: RetryError[<Future at 0x7fe970508550 state=finished raised Exception>]

## Issue


## Solution
