### PR TITLE
Bump wait for read only endpoints timeout 5 sec -> 5 min in test_database.py::test_read_only_endpoints 

### DIFF
--- a/tests/integration/relations/test_database.py
+++ b/tests/integration/relations/test_database.py
@@ -275,7 +275,7 @@ async def test_read_only_endpoints(ops_test: OpsTest):
 
     # wait for the update of the endpoints
     try:
-        for attempt in AsyncRetrying(stop=stop_after_delay(5), wait=wait_fixed(20)):
+        for attempt in AsyncRetrying(stop=stop_after_delay(5 * 60), wait=wait_fixed(20)):
             with attempt:
                 # check update for read-only-endpoints
                 await check_read_only_endpoints(
@@ -293,7 +293,7 @@ async def test_read_only_endpoints(ops_test: OpsTest):
 
     # wait for the update of the endpoints
     try:
-        for attempt in AsyncRetrying(stop=stop_after_delay(5), wait=wait_fixed(20)):
+        for attempt in AsyncRetrying(stop=stop_after_delay(5 * 60), wait=wait_fixed(20)):
             with attempt:
                 # check update for read-only-endpoints
                 await check_read_only_endpoints(


### PR DESCRIPTION
## Issue
The test was waiting not enough for read-only endpoints appearing (5 seconds):

```    
> Traceback (most recent call last):
>   File "/home/runner/work/mysql-operator/mysql-operator/tests/integration/relations/test_database.py", line 278, in test_read_only_endpoints
>     for attempt in AsyncRetrying(stop=stop_after_delay(5), wait=wait_fixed(20)):
>   File "/home/runner/work/mysql-operator/mysql-operator/.tox/integration/lib/python3.10/site-packages/tenacity/_asyncio.py", line 62, in __iter__
>     raise TypeError("AsyncRetrying object is not iterable")
> TypeError: AsyncRetrying object is not iterable
``` 

## Solution

Waiting for 5 minutes due to slow GH runners.