### PR TITLE
Disable check libs label

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,7 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           use-labels: false
+          fail-build: true
 
   build:
     name: Build charms


### PR DESCRIPTION
PRs already have a status check for the `Check libraries` job; no need to also add labels