### PR TITLE
Refactor configure_instance method to always restart the instance

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -91,7 +91,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 18
+LIBPATCH = 19
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -561,14 +561,14 @@ class MySQLBase(ABC):
             logger.exception(f"Failed to delete users for relation {relation_id}", exc_info=e)
             raise MySQLDeleteUserForRelationError(e.message)
 
-    def configure_instance(self, restart: bool = True, create_cluster_admin: bool = True) -> None:
+    def configure_instance(self, create_cluster_admin: bool = True) -> None:
         """Configure the instance to be used in an InnoDB cluster.
 
         Raises MySQLConfigureInstanceError
             if the was an error configuring the instance for use in an InnoDB cluster.
         """
         options = {
-            "restart": "true" if restart else "false",
+            "restart": "true",
         }
 
         if create_cluster_admin:
@@ -586,7 +586,7 @@ class MySQLBase(ABC):
         try:
             logger.debug(f"Configuring instance for InnoDB on {self.instance_address}")
             self._run_mysqlsh_script("\n".join(configure_instance_command))
-
+            self.wait_until_mysql_connection()
         except MySQLClientError as e:
             logger.exception(
                 f"Failed to configure instance: {self.instance_address} with error {e.message}",


### PR DESCRIPTION
## Issue
As part of [k8s PR 179](https://github.com/canonical/mysql-k8s-operator/pull/179/files), the `configure_instance` method no longer needs the ability to avoid restart of the instance. The lib file was updated in the k8s charm, but not in the vm charm.

## Solution
Propagate the changes from the k8s charm to the vm charm, and bump the lib version.
