### PR TITLE
Use data dir for temp backup dir + format list-backups output as table

### DIFF
--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -46,7 +46,6 @@ class MySQL(MySQLBase):
 """
 
 import datetime
-import json
 import logging
 import pathlib
 from typing import Dict, List, Tuple
@@ -93,7 +92,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class MySQLBackups(Object):
@@ -170,6 +169,16 @@ Stderr:
 
     # ------------------ List Backups ------------------
 
+    def _format_backups_list(self, backup_list: Tuple[str, bool]) -> str:
+        """Formats the provided list of backups as a table."""
+        backups = ["{:<21s} | {:<12s} | {:s}".format("backup-id", "backup-type", "backup-status")]
+
+        backups.append("-" * len(backups[0]))
+        for backup_id, backup_status in backup_list:
+            backups.append("{:<21s} | {:<12s} | {:s}".format(backup_id, "physical", backup_status))
+
+        return "\n".join(backups)
+
     def _on_list_backups(self, event: ActionEvent) -> None:
         """Handle the list backups action.
 
@@ -187,8 +196,8 @@ Stderr:
                 return
 
             logger.info("Listing backups in the specified s3 path")
-            backup_ids = list_backups_in_s3_path(s3_parameters)
-            event.set_results({"backup-ids": json.dumps(backup_ids)})
+            backups = sorted(list_backups_in_s3_path(s3_parameters), key=lambda pair: pair[0])
+            event.set_results({"backups": self._format_backups_list(backups)})
         except Exception:
             event.fail("Failed to retrieve backup ids from S3")
 
@@ -561,8 +570,11 @@ Juju Version: {str(juju_version)}
         """
         try:
             self.charm._mysql.delete_temp_restore_directory()
+            self.charm._mysql.delete_temp_backup_directory()
         except MySQLDeleteTempRestoreDirectoryError:
             return False, "Failed to delete the temp restore directory"
+        except MySQLDeleteTempBackupDirectoryError:
+            return False, "Failed to delete the temp backup directory"
 
         try:
             self.charm._mysql.start_mysqld()

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -91,7 +91,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 20
+LIBPATCH = 21
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -1398,7 +1398,9 @@ Swap:     1027600384  1027600384           0
     ) -> Tuple[str, str]:
         """Executes commands to create a backup with the given args."""
         nproc_command = "nproc".split()
-        make_temp_dir_command = f"mktemp --directory {tmp_base_directory}/xtra_backup_XXXX".split()
+        make_temp_dir_command = (
+            f"mktemp --directory {tmp_base_directory}/#xtra_backup_XXXX".split()
+        )
 
         try:
             nproc, _ = self._execute_commands(nproc_command)
@@ -1467,7 +1469,7 @@ Swap:     1027600384  1027600384           0
         group: str = None,
     ) -> None:
         """Delete the temp backup directory."""
-        delete_temp_dir_command = f"find {tmp_base_directory} -wholename {tmp_base_directory}/xtra_backup_* -delete".split()
+        delete_temp_dir_command = f"find {tmp_base_directory} -wholename {tmp_base_directory}/#xtra_backup_* -delete".split()
 
         try:
             self._execute_commands(
@@ -1502,7 +1504,9 @@ Swap:     1027600384  1027600384           0
         mysql container.
         """
         nproc_command = "nproc".split()
-        make_temp_dir_command = f"mktemp --directory {mysql_data_directory}/mysql_sst_XXXX".split()
+        make_temp_dir_command = (
+            f"mktemp --directory {mysql_data_directory}/#mysql_sst_XXXX".split()
+        )
 
         try:
             nproc, _ = self._execute_commands(nproc_command)
@@ -1594,7 +1598,7 @@ Swap:     1027600384  1027600384           0
         group=None,
     ) -> None:
         """Empty the mysql data directory in preparation of backup restore."""
-        empty_data_files_command = f"find {mysql_data_directory} -not -path {mysql_data_directory}/mysql_sst_* -not -path {mysql_data_directory} -delete".split()
+        empty_data_files_command = f"find {mysql_data_directory} -not -path {mysql_data_directory}/#mysql_sst_* -not -path {mysql_data_directory} -delete".split()
 
         try:
             self._execute_commands(
@@ -1652,7 +1656,7 @@ Swap:     1027600384  1027600384           0
     ) -> None:
         """Delete the temp restore directory from the mysql data directory."""
         logger.info(f"Deleting temp restore directory in {mysql_data_directory}")
-        delete_temp_restore_directory_command = f"find {mysql_data_directory} -wholename {mysql_data_directory}/mysql_sst_* -delete".split()
+        delete_temp_restore_directory_command = f"find {mysql_data_directory} -wholename {mysql_data_directory}/#mysql_sst_* -delete".split()
 
         try:
             self._execute_commands(

--- a/lib/charms/mysql/v0/s3_helpers.py
+++ b/lib/charms/mysql/v0/s3_helpers.py
@@ -16,7 +16,8 @@
 
 import logging
 import tempfile
-from typing import Dict, List
+import time
+from typing import Dict, List, Tuple
 
 import boto3
 
@@ -30,7 +31,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 def upload_content_to_s3(content: str, content_path: str, s3_parameters: Dict) -> bool:
@@ -71,6 +72,23 @@ def upload_content_to_s3(content: str, content_path: str, s3_parameters: Dict) -
     return True
 
 
+def _compile_backups_from_file_ids(
+    metadata_ids: List[str], md5_ids: List[str], log_ids: List[str]
+) -> Tuple[str, str]:
+    """Helper function that compiles tuples of (backup_id, status) from file ids."""
+    backups = []
+    for backup_id in metadata_ids:
+        backup_status = "in progress"
+        if backup_id in md5_ids:
+            backup_status = "finished"
+        elif backup_id in log_ids:
+            backup_status = "failed"
+
+        backups.append((backup_id, backup_status))
+
+    return backups
+
+
 def list_backups_in_s3_path(s3_parameters: Dict) -> List[str]:
     """Retrieve subdirectories in an S3 path.
 
@@ -101,7 +119,10 @@ def list_backups_in_s3_path(s3_parameters: Dict) -> List[str]:
             else f"{s3_parameters['path']}/"
         )
 
-        directories = []
+        metadata_ids = []
+        md5_ids = []
+        log_ids = []
+
         for page in list_objects_v2_paginator.paginate(
             Bucket=s3_parameters["bucket"],
             Prefix=s3_path_directory,
@@ -109,12 +130,22 @@ def list_backups_in_s3_path(s3_parameters: Dict) -> List[str]:
         ):
             for content in page.get("Contents", []):
                 key = content["Key"]
-                if ".md5" in key:
-                    directories.append(
-                        key.lstrip(s3_path_directory).split("/")[0].split(".md5")[0]
-                    )
 
-        return directories
+                filename = key.lstrip(s3_path_directory).split("/")[0]
+
+                if ".metadata" in filename:
+                    try:
+                        backup_id = filename.split(".metadata")[0]
+                        time.strptime(backup_id, "%Y-%m-%dT%H:%M:%SZ")
+                        metadata_ids.append(backup_id)
+                    except ValueError:
+                        pass
+                elif ".md5" in key:
+                    md5_ids.append(filename.split(".md5")[0])
+                elif ".backup.log" in key:
+                    log_ids.append(filename.split(".backup.log")[0])
+
+        return _compile_backups_from_file_ids(metadata_ids, md5_ids, log_ids)
     except Exception as e:
         logger.exception(
             f"Failed to list subdirectories in S3 bucket={s3_parameters['bucket']}, path={s3_parameters['path']}",

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -287,7 +287,7 @@ class MySQL(MySQLBase):
             CHARMED_MYSQL_XBCLOUD_LOCATION,
             XTRABACKUP_PLUGIN_DIR,
             MYSQLD_SOCK_FILE,
-            CHARMED_MYSQL_COMMON_DIRECTORY,
+            MYSQL_DATA_DIR,
             MYSQLD_DEFAULTS_CONFIG_FILE,
             user=ROOT_SYSTEM_USER,
             group=ROOT_SYSTEM_USER,
@@ -296,7 +296,7 @@ class MySQL(MySQLBase):
     def delete_temp_backup_directory(self) -> None:
         """Delete the temp backup directory."""
         super().delete_temp_backup_directory(
-            CHARMED_MYSQL_COMMON_DIRECTORY,
+            MYSQL_DATA_DIR,
             user=ROOT_SYSTEM_USER,
             group=ROOT_SYSTEM_USER,
         )

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -173,7 +173,8 @@ async def test_backup(ops_test: OpsTest, mysql_charm_series: str, cloud_credenti
 
         action = await zeroth_unit.run_action(action_name="list-backups")
         result = await action.wait()
-        backup_ids = json.loads(result.results["backup-ids"])
+        output = result.results["backups"]
+        backup_ids = [line.split("|")[0].strip() for line in output.split("\n")[2:]]
 
         # create backup
         logger.info("Creating backup")
@@ -187,7 +188,8 @@ async def test_backup(ops_test: OpsTest, mysql_charm_series: str, cloud_credenti
 
         action = await zeroth_unit.run_action(action_name="list-backups")
         result = await action.wait()
-        new_backup_ids = json.loads(result.results["backup-ids"])
+        output = result.results["backups"]
+        new_backup_ids = [line.split("|")[0].strip() for line in output.split("\n")[2:]]
 
         assert sorted(new_backup_ids) == sorted(backup_ids + [backup_id])
 

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -1009,7 +1009,7 @@ class TestMySQLBase(unittest.TestCase):
         """Test successful execution of execute_backup_commands()."""
         _execute_commands.side_effect = [
             ("16", None),
-            ("/tmp/base/directory/xtra_backup_ABCD", None),
+            ("/tmp/base/directory/#xtra_backup_ABCD", None),
             ("stdout", "stderr"),
         ]
 
@@ -1036,7 +1036,7 @@ class TestMySQLBase(unittest.TestCase):
 
         _expected_nproc_commands = ["nproc"]
         _expected_tmp_dir_commands = (
-            "mktemp --directory /tmp/base/directory/xtra_backup_XXXX".split()
+            "mktemp --directory /tmp/base/directory/#xtra_backup_XXXX".split()
         )
         _expected_xtrabackup_commands = """
 /xtrabackup/location --defaults-file=/defaults/file.cnf
@@ -1050,7 +1050,7 @@ class TestMySQLBase(unittest.TestCase):
             --backup
             --stream=xbstream
             --xtrabackup-plugin-dir=/xtrabackup/plugin/dir
-            --target-dir=/tmp/base/directory/xtra_backup_ABCD
+            --target-dir=/tmp/base/directory/#xtra_backup_ABCD
             --no-server-version-check
     | /xbcloud/location put
             --curl-retriable-errors=7
@@ -1140,7 +1140,7 @@ class TestMySQLBase(unittest.TestCase):
         )
 
         _execute_commands.assert_called_once_with(
-            "find /temp/base/directory -wholename /temp/base/directory/xtra_backup_* -delete".split(),
+            "find /temp/base/directory -wholename /temp/base/directory/#xtra_backup_* -delete".split(),
             user="test_user",
             group="test_group",
         )
@@ -1166,7 +1166,7 @@ class TestMySQLBase(unittest.TestCase):
         """Test a successful execution of retrieve_backup_with_xbcloud()."""
         _execute_commands.side_effect = [
             ("16", None),
-            ("mysql/data/directory/mysql_sst_ABCD", None),
+            ("mysql/data/directory/#mysql_sst_ABCD", None),
             ("", None),
         ]
 
@@ -1186,7 +1186,7 @@ class TestMySQLBase(unittest.TestCase):
 
         _expected_nproc_commands = ["nproc"]
         _expected_temp_dir_commands = (
-            "mktemp --directory mysql/data/directory/mysql_sst_XXXX".split()
+            "mktemp --directory mysql/data/directory/#mysql_sst_XXXX".split()
         )
         _expected_retrieve_backup_commands = """
 xbcloud/location get
@@ -1197,7 +1197,7 @@ xbcloud/location get
     | xbstream/location
         --decompress
         -x
-        -C mysql/data/directory/mysql_sst_ABCD
+        -C mysql/data/directory/#mysql_sst_ABCD
         --parallel=16
 """.split()
 
@@ -1366,7 +1366,7 @@ xtrabackup/location --prepare
             group="test-group",
         )
 
-        _expected_commands = "find mysql/data/directory -not -path mysql/data/directory/mysql_sst_* -not -path mysql/data/directory -delete".split()
+        _expected_commands = "find mysql/data/directory -not -path mysql/data/directory/#mysql_sst_* -not -path mysql/data/directory -delete".split()
 
         _execute_commands.assert_called_once_with(
             _expected_commands,
@@ -1454,7 +1454,7 @@ xtrabackup/location --defaults-file=defaults/config/file
         )
 
         _expected_commands = (
-            "find mysql/data/directory -wholename mysql/data/directory/mysql_sst_* -delete".split()
+            "find mysql/data/directory -wholename mysql/data/directory/#mysql_sst_* -delete".split()
         )
 
         _execute_commands.assert_called_once_with(


### PR DESCRIPTION
[dpe-1597](https://warthogs.atlassian.net/browse/DPE-1597)

## Issue
1. We are not correctly formatting the output of the `list-backups` action
2. We are currently only displaying the successfully "finished" backup ids in the `list-backups` output
3. We are not using `#` to being temp backup/restore directories while performing backups/restores. Additionally, the temp backup directory is not in the MySQL data directory (thus we could run out of disk space)

## Solution
1. Correctly format the output of `list-backups` (in the form of a table) -> parted from MongoDB operator
2. Display "finished", "failed" and "in progress" backup ids in the output of `list-backups`
In progress = metadata file exists, but neither the md5 nor the log files exist
Failed = metadata and log files exist, but no md5 file
Finished = metadata and md5 files exist
3. Use `#` for the temp backup/restore directories. Point both the temp backup and temp restore directories to the data directory, and appropriately clean up these directories after a restore (as the backup with contain the temp backup directory)