### PR TITLE
Update README to be in sync with K8s version + update relations/edpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,14 @@ this operator.
 - Generally, before developing enhancements to this charm, you should consider [opening an issue
   ](https://github.com/canonical/mysql-operator/issues) explaining your use case.
 - If you would like to chat with us about your use-cases or proposed implementation, you can reach
-  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/charm-dev)
+  us at [Canonical Mattermost public channel](https://chat.charmhub.io/charmhub/channels/data-platform)
   or [Discourse](https://discourse.charmhub.io/).
 - Familiarising yourself with the [Charmed Operator Framework](https://juju.is/docs/sdk) library
   will help you a lot when working on new features or bug fixes.
 - All enhancements require review before being merged. Code review typically examines
   - code quality
   - test coverage
-  - user experience for Juju administrators this charm.
+  - user experience for Juju administrators of this charm.
 - Please help us out in ensuring easy to review branches by rebasing your pull request branch onto
   the `main` branch. This also avoids merge commits and creates a linear Git commit history.
 
@@ -51,10 +51,12 @@ charmcraft pack
 ```bash
 # Create a model
 juju add-model dev
+
 # Enable DEBUG logging
 juju model-config logging-config="<root>=INFO;unit=DEBUG"
+
 # Deploy the charm
-juju deploy ./mysql_ubuntu-20.04-amd64.charm
+juju deploy ./mysql_ubuntu-22.04-amd64.charm
 ```
 
 ## Canonical Contributor Agreement

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This repository contains a [Juju Charm](https://charmhub.io/mysql) for deploying [MySQL](https://www.mysql.com/) on virtual machines ([LXD](https://ubuntu.com/lxd)).
+This repository contains a [Juju Charm](https://charmhub.io/mysql) for deploying [MySQL](https://www.mysql.com/) on [virtual machines](https://ubuntu.com/lxd).
 
 To deploy on [Kubernetes](https://microk8s.io/), please use [Charmed MySQL K8s operator](https://charmhub.io/mysql-k8s).
 
@@ -12,7 +12,7 @@ To deploy this charm using Juju 2.9 or later, run:
 
 ```shell
 juju add-model mysql-vm
-juju deploy mysql --channel edge
+juju deploy mysql
 ```
 
 **Note:** the above model must be created on LXD (virtual machines) environment. Use [another](https://charmhub.io/mysql-k8s) charm for K8s!
@@ -53,7 +53,7 @@ Adding a relation is accomplished with `juju relate` (or `juju integrate` for Ju
 
 ```shell
 # Deploy Charmed MySQL cluster with 3 nodes
-juju deploy mysql -n 3
+juju deploy mysql -n 3 --channel 8.0
 
 # Deploy the relevant charms, e.g. mysql-test-app
 juju deploy mysql-test-app
@@ -81,7 +81,7 @@ This charm supports several legacy interfaces, e.g. `mysql`, `mysql-shared`, `my
 1. `mysql` is a relation that's used from some k8s charms and can be used in cross-model relations.
 
 ```shell
-juju deploy mysql --channel edge
+juju deploy mysql --channel 8.0
 juju deploy mediawiki
 juju relate mysql:mysql mediawiki:db
 ```
@@ -89,7 +89,7 @@ juju relate mysql:mysql mediawiki:db
 2. `mysql-router` interface (`db-router` endpoint) is a relation that one uses with the [mysql router](https://charmhub.io/mysql-router) charm. The following commands can be executed to deploy and relate to the keystone charm:
 
 ```shell
-juju deploy mysql --channel edge
+juju deploy mysql --channel 8.0
 juju deploy mysql-router --series focal
 juju deploy keystone --series focal
 juju relate mysql-router keystone
@@ -103,7 +103,7 @@ It is supported by various legacy charms, e.g. [mysql-innodb-cluster](https://ch
 The following commands can be executed to deploy and relate to the keystone charm:
 
 ```shell
-juju deploy mysql --channel edge
+juju deploy mysql --channel 8.0
 juju deploy keystone --series focal
 juju relate keystone:shared-db mysql:shared-db
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ juju status --relations
 # > mysql:database      mysql-test-app:database  mysql_client  regular
 ```
 
-**Note:** In order to relate with this charm, every table created by the related application must have a primary key. This is required by the [group replication plugin](https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html) enabled in this charm.
+**Note:** In order to relate with this charm, every table created by the related application must have a primary key. This is required by the [group replication plugin](https://dev.mysql.com/doc/refman/8.0/en/group-replication-requirements.html) enabled in this charm.
 
 
 ### Legacy relations

--- a/README.md
+++ b/README.md
@@ -76,17 +76,22 @@ juju status --relations
 
 **Note:** Legacy relations are deprecated and will be discontinued on future releases. Usage should be avoided.
 
-This charm supports several legacy interfaces, e.g. `mysql`, `mysql-shared`, `mysql-router`:
+This charm supports several legacy interfaces, e.g. `mysql`, `mysql-shared`, `mysql-router`. They were used in some legacy charms in [cross-model relations](https://juju.is/docs/olm/cross-model-integration).
 
-1. `mysql` is a relation that's used from some k8s charms and can be used in cross-model relations.
+#### `mysql` interface (`mysql` endpoint)
+
+It was a popular interface used by some legacy charms (e.g. "[MariaDB](https://charmhub.io/mariadb)", "[OSM MariaDB](https://charmhub.io/charmed-osm-mariadb-k8s)", "[Percona Cluster](https://charmhub.io/percona-cluster)" and "[Mysql Innodb Cluster](https://charmhub.io/mysql-innodb-cluster)"), often in [cross-model relations](https://juju.is/docs/olm/cross-model-integration):
 
 ```shell
 juju deploy mysql --channel 8.0
+juju config mysql mysql-interface-database=mediawiki mysql-interface-user=mediawiki
 juju deploy mediawiki
 juju relate mysql:mysql mediawiki:db
 ```
 
-2. `mysql-router` interface (`db-router` endpoint) is a relation that one uses with the [mysql router](https://charmhub.io/mysql-router) charm. The following commands can be executed to deploy and relate to the keystone charm:
+#### `mysql-router` interface (`db-router` endpoint)
+
+It is a relation that one uses with the [mysql router](https://charmhub.io/mysql-router) charm. The following commands can be executed to deploy and relate to the keystone charm:
 
 ```shell
 juju deploy mysql --channel 8.0
@@ -98,7 +103,9 @@ juju relate mysql:db-router mysql-router:db-router
 
 **Note:** pay attention to deploy identical [series](https://juju.is/docs/olm/deploy-an-application-with-a-specific-series) for `keystone` and `mysql-router` applications (due to the [subordinate](https://juju.is/docs/sdk/charm-types#heading--subordinate-charms) charm nature of `mysql-router`).
 
-3. `mysql-shared` interface (`shared-db` endpoint) is a relation that one uses when the application needs to connect directly to the database cluster.
+#### `mysql-shared` interface (`shared-db` endpoint)
+
+It is a relation that one uses when the application needs to connect directly to the database cluster.
 It is supported by various legacy charms, e.g. [mysql-innodb-cluster](https://charmhub.io/mysql-innodb-cluster).
 The following commands can be executed to deploy and relate to the keystone charm:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To deploy this charm using Juju 2.9 or later, run:
 
 ```shell
 juju add-model mysql-vm
-juju deploy mysql
+juju deploy mysql --channel 8.0
 ```
 
 **Note:** the above model must be created on LXD (virtual machines) environment. Use [another](https://charmhub.io/mysql-k8s) charm for K8s!

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ juju status --relations
 # > mysql:database      mysql-test-app:database  mysql_client  regular
 ```
 
-**Note:** In order to relate with this charm, every table created by the related application must have a primary key. This is required by the [group replication plugin](https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html), enable in this charm.
+**Note:** In order to relate with this charm, every table created by the related application must have a primary key. This is required by the [group replication plugin](https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html) enabled in this charm.
 
 
 ### Legacy relations


### PR DESCRIPTION
## Issue
The VM README file was not in sync with K8s one and had no endpoints description, causing issues like https://github.com/canonical/mysql-k8s-operator/issues/198

## Solution
Update README to match the one in mysql K8s repo.

We should consider for the future:
 * name endpoints and interfaces identically/similar
 * sync amount of interfaces supported by VM and K8s
