### PR TITLE
Update metadata.yaml to be up-2-date

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,48 +1,59 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: mysql
-display-name: MySQL
+display-name: Charmed MySQL
+summary: Charmed MySQL VM operator
 description: |
-  MySQL charm for machines
-docs: https://discourse.charmhub.io/t/charmed-mysql-documentation/9925
-summary: |
   MySQL is a widely used, open-source relational database management system
   (RDBMS). MySQL InnoDB cluster provides a complete high availability solution
   for MySQL via Group Replication.
+
+  This charm supports MySQL 8.0 in bare-metal/virtual-machines.
+docs: https://discourse.charmhub.io/t/charmed-mysql-documentation/9925
 source: https://github.com/canonical/mysql-operator
 issues: https://github.com/canonical/mysql-operator/issues
-
-  This charm supports MySQL 8 on machines.
+website:
+  - https://ubuntu.com/data/mysql
+  - https://charmhub.io/mysql
+  - https://github.com/canonical/mysql-operator
+  - https://chat.charmhub.io/charmhub/channels/data-platform
 maintainers:
   - Paulo Machado <paulo.machado@canonical.com>
   - Shayan Patel <shayan.patel@canonical.com>
+
 peers:
   database-peers:
     interface: mysql_peers
+
 provides:
-  db-router:
-    interface: mysql-router
-  shared-db:
-    interface: mysql-shared
   database:
     interface: mysql_client
   mysql:
     interface: mysql
+  db-router:
+    interface: mysql-router
+  shared-db:
+    interface: mysql-shared
   cos-agent:
     interface: cos_agent
     limit: 1
+
 requires:
   certificates:
     interface: tls-certificates
     limit: 1
+    optional: true
   s3-parameters:
     interface: s3
     limit: 1
+    optional: true
+
 storage:
   database:
     type: filesystem
-    description: Persistent storage for MySQL data
+    description: Persistent storage for data
     location: /var/snap/charmed-mysql/common
+
 assumes:
   - juju


### PR DESCRIPTION
## Issue

The charm has old link to bugreport on charmhub: https://github.com/canonical/mysql-operator/issues/54

## Solution

Updating metada.yaml to use use "summary" and "description" properly.

Also changing style to be in sync with mysql-k8s (and modern formats):
* Reorder relations to show modern one first.
* indicate tls and s3 interfaces as optional.
* add website links

Closes: https://github.com/canonical/mysql-operator/issues/54
see: https://discourse.charmhub.io/t/question-why-charm-mysql-ignores-issues-attribute-in-metadata-yaml/10029
