### PR TITLE
DPE-1626 Add timeout kwarg to run_mysqlcli_script, and use timeouts in get_cluster_status

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -91,7 +91,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 31
+LIBPATCH = 32
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -932,7 +932,7 @@ class MySQLBase(ABC):
         )
 
         try:
-            output = self._run_mysqlsh_script("\n".join(status_commands))
+            output = self._run_mysqlsh_script("\n".join(status_commands), timeout=30)
             output_dict = json.loads(output.lower())
             return output_dict
         except MySQLClientError:
@@ -1298,33 +1298,37 @@ class MySQLBase(ABC):
             )
             raise MySQLCheckUserExistenceError(e.message)
 
-    @retry(reraise=True, stop=stop_after_attempt(6), wait=wait_fixed(10))
+    @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(10))
     def get_member_state(self) -> Tuple[str, str]:
         """Get member status in cluster.
 
         Returns:
             A tuple(str) with the MEMBER_STATE and MEMBER_ROLE within the cluster.
         """
-        member_state_commands = (
-            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-            (
-                "raw_result=session.run_sql('SELECT MEMBER_STATE, MEMBER_ROLE FROM"
-                " performance_schema.replication_group_members WHERE MEMBER_ID = @@server_uuid;')"
-            ),
-            "result=raw_result.fetch_one()",
-            "print(result[0],result[1])",
+        member_state_query = (
+            "SELECT MEMBER_STATE, MEMBER_ROLE FROM"
+            " performance_schema.replication_group_members WHERE MEMBER_ID = @@server_uuid"
         )
 
         try:
-            output = self._run_mysqlsh_script("\n".join(member_state_commands), timeout=10)
+            output = self._run_mysqlcli_script(
+                member_state_query,
+                user=self.cluster_admin_user,
+                password=self.cluster_admin_password,
+                timeout=10,
+            )
         except MySQLClientError as e:
             logger.error(
                 "Failed to get member state: mysqld daemon is down",
             )
             raise MySQLGetMemberStateError(e.message)
 
-        results = output.lower().split()
-        # MEMBER_ROLE is empty if member is not in a group/offline
+        lines = output.lower().split("\n")
+        if len(lines) < 2:
+            raise MySQLGetMemberStateError("No member state retrieved")
+
+        results = lines[1].split()
+        # no member role defined when member state is 'offline'
         return results[0], results[1] if len(results) == 2 else "unknown"
 
     def reboot_from_complete_outage(self) -> None:
@@ -1889,7 +1893,9 @@ Swap:     1027600384  1027600384           0
         raise NotImplementedError
 
     @abstractmethod
-    def _run_mysqlcli_script(self, script: str, user: str = "root", password: str = None) -> str:
+    def _run_mysqlcli_script(
+        self, script: str, user: str = "root", password: str = None, timeout: Optional[int] = None
+    ) -> str:
         """Execute a MySQL CLI script.
 
         Execute SQL script as instance with given user.
@@ -1900,5 +1906,6 @@ Swap:     1027600384  1027600384           0
             script: raw SQL script string
             user: (optional) user to invoke the mysql cli script with (default is "root")
             password: (optional) password to invoke the mysql cli script with
+            timeout: (optional) time before the query should timeout
         """
         raise NotImplementedError

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -9,7 +9,7 @@ import pathlib
 import shutil
 import subprocess
 import tempfile
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from charms.mysql.v0.mysql import (
     Error,
@@ -525,7 +525,9 @@ class MySQL(MySQLBase):
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 raise MySQLClientError(e.stderr)
 
-    def _run_mysqlcli_script(self, script: str, user: str = "root", password: str = None) -> str:
+    def _run_mysqlcli_script(
+        self, script: str, user: str = "root", password: str = None, timeout: Optional[int] = None
+    ) -> str:
         """Execute a MySQL CLI script.
 
         Execute SQL script as instance root user.
@@ -535,6 +537,7 @@ class MySQL(MySQLBase):
             script: raw SQL script string
             user: (optional) user to invoke the mysql cli script with (default is "root")
             password: (optional) password to invoke the mysql cli script with
+            timeout: (optional) time before the query should timeout
         """
         command = [
             CHARMED_MYSQL,
@@ -550,7 +553,9 @@ class MySQL(MySQLBase):
             command.append(f"--password={password}")
 
         try:
-            return subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")
+            return subprocess.check_output(
+                command, stderr=subprocess.PIPE, timeout=timeout
+            ).decode("utf-8")
         except subprocess.CalledProcessError as e:
             raise MySQLClientError(e.stderr)
 

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -696,7 +696,7 @@ class TestMySQLBase(unittest.TestCase):
                 "print(cluster.status())",
             )
         )
-        _run_mysqlsh_script.assert_called_once_with(expected_commands)
+        _run_mysqlsh_script.assert_called_once_with(expected_commands, timeout=30)
 
     @patch("json.loads")
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -68,7 +68,7 @@ class TestMySQL(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_run_mysqlcli_script(self, _check_output):
         """Test a successful execution of run_mysqlsh_script."""
-        self.mysql._run_mysqlcli_script("script")
+        self.mysql._run_mysqlcli_script("script", timeout=10)
 
         _check_output.assert_called_once_with(
             [
@@ -81,6 +81,7 @@ class TestMySQL(unittest.TestCase):
                 "script",
             ],
             stderr=subprocess.PIPE,
+            timeout=10,
         )
 
     @patch("subprocess.check_output")


### PR DESCRIPTION
## Issue
[mysql-k8s PR 225](https://github.com/canonical/mysql-k8s-operator/pull/225) requires some changes to the mysql charm lib.
Changes include:
- add timeout to `get_cluster_status` as it is called from update-status and can hang
- use mysql query to `get_member_state` as we've confirmed that the socket file exists before calling it
- add timeout optional kwarg to `_run_mysqlcli_script`

## Solution
Port over changes to the mysql charm lib