### PR TITLE
DPE-1688 DPE-1913 Add alert logs for success/failure of backups + change temp backup dir

### DIFF
--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -50,7 +50,6 @@ import logging
 import pathlib
 from typing import Dict, List, Optional, Tuple
 
-from constants import MYSQL_DATA_DIR
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.mysql.v0.mysql import (
     MySQLConfigureInstanceError,
@@ -81,6 +80,8 @@ from ops.charm import ActionEvent, CharmBase
 from ops.framework import Object
 from ops.jujuversion import JujuVersion
 from ops.model import ActiveStatus, BlockedStatus
+
+from constants import MYSQL_DATA_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +232,9 @@ Stderr:
             return
 
         if not self.charm._mysql.is_mysqld_running():
-            logger.warning(f"Backup failed: process mysqld is not running on {self.charm.unit.name}")
+            logger.warning(
+                f"Backup failed: process mysqld is not running on {self.charm.unit.name}"
+            )
             event.fail("Process mysqld not running")
             return
 

--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -93,7 +93,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class MySQLBackups(Object):
@@ -225,10 +225,12 @@ Stderr:
         logger.info("A backup has been requested on unit")
 
         if not self.charm.s3_integrator_relation_exists:
+            logger.warning("Backup failed: missing relation with S3 integrator charm")
             event.fail("Missing relation with S3 integrator charm")
             return
 
         if not self.charm._mysql.is_mysqld_running():
+            logger.warning(f"Backup failed: process mysqld is not running on {self.charm.unit.name}")
             event.fail("Process mysqld not running")
             return
 
@@ -237,6 +239,7 @@ Stderr:
         # Retrieve and validate missing S3 parameters
         s3_parameters, missing_parameters = self._retrieve_s3_parameters()
         if missing_parameters:
+            logger.warning(f"Backup failed: missing S3 parameters {missing_parameters}")
             event.fail(f"Missing S3 parameters: {missing_parameters}")
             return
 
@@ -245,7 +248,7 @@ Stderr:
         # Check if this unit can perform backup
         can_unit_perform_backup, validation_message = self._can_unit_perform_backup()
         if not can_unit_perform_backup:
-            logger.warning(validation_message)
+            logger.warning(f"Backup failed: {validation_message}")
             event.fail(validation_message)
             return
 
@@ -259,25 +262,26 @@ Juju Version: {str(juju_version)}
 """
 
         if not upload_content_to_s3(metadata, f"{backup_path}.metadata", s3_parameters):
+            logger.warning("Backup failed: Failed to upload metadata to provided S3")
             event.fail("Failed to upload metadata to provided S3")
             return
 
         # Run operations to prepare for the backup
         success, error_message = self._pre_backup()
         if not success:
-            logger.warning(error_message)
+            logger.warning(f"Backup failed: {error_message}")
             event.fail(error_message)
             return
 
         # Perform the backup
         success, error_message = self._backup(backup_path, s3_parameters)
         if not success:
-            logger.warning(error_message)
+            logger.warning(f"Backup failed: {error_message}")
             event.fail(error_message)
 
             success, error_message = self._post_backup()
             if not success:
-                logger.error(error_message)
+                logger.warning(f"Backup failed: {error_message}")
                 self.charm.unit.status = BlockedStatus(
                     "Failed to create backup; instance in bad state"
                 )
@@ -287,13 +291,14 @@ Juju Version: {str(juju_version)}
         # Run operations to clean up after the backup
         success, error_message = self._post_backup()
         if not success:
-            logger.error(error_message)
+            logger.warning(f"Backup failed: {error_message}")
             self.charm.unit.status = BlockedStatus(
                 "Failed to create backup; instance in bad state"
             )
             event.fail(error_message)
             return
 
+        logger.info(f"Backup succeeded: with backup-id {datetime_backup_requested}")
         event.set_results(
             {
                 "backup-id": datetime_backup_requested,
@@ -424,26 +429,26 @@ Juju Version: {str(juju_version)}
         """
         if not self.charm.s3_integrator_relation_exists:
             error_message = "Missing relation with S3 integrator charm"
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             event.fail(error_message)
             return False
 
         if not event.params.get("backup-id"):
             error_message = "Missing backup-id to restore"
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             event.fail(error_message)
             return False
 
         if not self.charm._mysql.is_server_connectable():
             error_message = "Server running mysqld is not connectable"
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             event.fail(error_message)
             return False
 
         logger.info("Checking if the unit is waiting to start or restart")
         if self.charm.is_unit_busy():
             error_message = "Unit is waiting to start or restart"
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             event.fail(error_message)
             return False
 
@@ -452,7 +457,7 @@ Juju Version: {str(juju_version)}
             error_message = (
                 "Unit cannot restore backup as there are more than one units in the cluster"
             )
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             event.fail(error_message)
             return False
 
@@ -473,6 +478,7 @@ Juju Version: {str(juju_version)}
         # Retrieve and validate missing S3 parameters
         s3_parameters, missing_parameters = self._retrieve_s3_parameters()
         if missing_parameters:
+            logger.warning(f"Restore failed: missing S3 parameters {missing_parameters}")
             event.fail(f"Missing S3 parameters: {missing_parameters}")
             return
 
@@ -480,20 +486,21 @@ Juju Version: {str(juju_version)}
         logger.info("Validating provided backup-id in the specified s3 path")
         s3_backup_md5 = str(pathlib.Path(s3_parameters["path"]) / f"{backup_id}.md5")
         if not fetch_and_check_existence_of_s3_path(s3_backup_md5, s3_parameters):
+            logger.warning(f"Restore failed: invalid backup-id {backup_id}")
             event.fail(f"Invalid backup-id: {backup_id}")
             return
 
         # Run operations to prepare for the restore
         success, error_message = self._pre_restore()
         if not success:
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             event.fail(error_message)
             return
 
         # Perform the restore
         success, recoverable, error_message = self._restore(backup_id, s3_parameters)
         if not success:
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             event.fail(error_message)
 
             if recoverable:
@@ -506,11 +513,12 @@ Juju Version: {str(juju_version)}
         # Run post-restore operations
         success, error_message = self._post_restore()
         if not success:
-            logger.warning(error_message)
+            logger.warning(f"Restore failed: {error_message}")
             self.charm.unit.status = BlockedStatus(error_message)
             event.fail(error_message)
             return
 
+        logger.info("Restore succeeded")
         event.set_results(
             {
                 "completed": "ok",
@@ -583,6 +591,9 @@ Juju Version: {str(juju_version)}
         try:
             self.charm._mysql.delete_temp_restore_directory()
             self.charm._mysql.delete_temp_backup_directory()
+            # Old backups may contain the temp backup directory (as previously, the temp
+            # backup directory was created in the mysql data directory to reduce IOPS latency)
+            self.charm._mysql.delete_temp_backup_directory(from_directory=MYSQL_DATA_DIR)
         except MySQLDeleteTempRestoreDirectoryError:
             return False, "Failed to delete the temp restore directory"
         except MySQLDeleteTempBackupDirectoryError:

--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -232,9 +232,7 @@ Stderr:
             return
 
         if not self.charm._mysql.is_mysqld_running():
-            logger.error(
-                f"Backup failed: process mysqld is not running on {self.charm.unit.name}"
-            )
+            logger.error(f"Backup failed: process mysqld is not running on {self.charm.unit.name}")
             event.fail("Process mysqld not running")
             return
 

--- a/lib/charms/mysql/v0/backups.py
+++ b/lib/charms/mysql/v0/backups.py
@@ -50,6 +50,7 @@ import logging
 import pathlib
 from typing import Dict, List, Optional, Tuple
 
+from constants import MYSQL_DATA_DIR
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.mysql.v0.mysql import (
     MySQLConfigureInstanceError,

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -91,7 +91,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 32
+LIBPATCH = 33
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 
@@ -1592,7 +1592,7 @@ Swap:     1027600384  1027600384           0
         self,
         backup_id: str,
         s3_parameters: Dict[str, str],
-        mysql_data_directory: str,
+        temp_restore_directory: str,
         xbcloud_location: str,
         xbstream_location: str,
         user=None,
@@ -1601,11 +1601,12 @@ Swap:     1027600384  1027600384           0
         """Retrieve the specified backup from S3.
 
         The backup is retrieved using xbcloud and stored in a temp dir in the
-        mysql container.
+        mysql container. This temp dir is supposed to be on the same volume as
+        the mysql data directory to reduce latency for IOPS.
         """
         nproc_command = "nproc".split()
         make_temp_dir_command = (
-            f"mktemp --directory {mysql_data_directory}/#mysql_sst_XXXX".split()
+            f"mktemp --directory {temp_restore_directory}/#mysql_sst_XXXX".split()
         )
 
         try:
@@ -1762,13 +1763,13 @@ Swap:     1027600384  1027600384           0
 
     def delete_temp_restore_directory(
         self,
-        mysql_data_directory: str,
+        temp_restore_directory: str,
         user=None,
         group=None,
     ) -> None:
         """Delete the temp restore directory from the mysql data directory."""
-        logger.info(f"Deleting temp restore directory in {mysql_data_directory}")
-        delete_temp_restore_directory_command = f"find {mysql_data_directory} -wholename {mysql_data_directory}/#mysql_sst_* -delete".split()
+        logger.info(f"Deleting temp restore directory in {temp_restore_directory}")
+        delete_temp_restore_directory_command = f"find {temp_restore_directory} -wholename {temp_restore_directory}/#mysql_sst_* -delete".split()
 
         try:
             logger.debug(

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -281,16 +281,16 @@ class MySQL(MySQLBase):
             CHARMED_MYSQL_XBCLOUD_LOCATION,
             XTRABACKUP_PLUGIN_DIR,
             MYSQLD_SOCK_FILE,
-            MYSQL_DATA_DIR,
+            CHARMED_MYSQL_COMMON_DIRECTORY,
             MYSQLD_DEFAULTS_CONFIG_FILE,
             user=ROOT_SYSTEM_USER,
             group=ROOT_SYSTEM_USER,
         )
 
-    def delete_temp_backup_directory(self) -> None:
+    def delete_temp_backup_directory(self, from_directory: str = CHARMED_MYSQL_COMMON_DIRECTORY) -> None:
         """Delete the temp backup directory."""
         super().delete_temp_backup_directory(
-            MYSQL_DATA_DIR,
+            from_directory,
             user=ROOT_SYSTEM_USER,
             group=ROOT_SYSTEM_USER,
         )
@@ -304,7 +304,7 @@ class MySQL(MySQLBase):
         return super().retrieve_backup_with_xbcloud(
             backup_id,
             s3_parameters,
-            MYSQL_DATA_DIR,
+            CHARMED_MYSQL_COMMON_DIRECTORY,
             CHARMED_MYSQL_XBCLOUD_LOCATION,
             CHARMED_MYSQL_XBSTREAM_LOCATION,
             user=ROOT_SYSTEM_USER,
@@ -393,7 +393,7 @@ class MySQL(MySQLBase):
     def delete_temp_restore_directory(self) -> None:
         """Delete the temp restore directory from the mysql data directory."""
         super().delete_temp_restore_directory(
-            MYSQL_DATA_DIR,
+            CHARMED_MYSQL_COMMON_DIRECTORY,
             user=ROOT_SYSTEM_USER,
             group=ROOT_SYSTEM_USER,
         )

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -287,7 +287,9 @@ class MySQL(MySQLBase):
             group=ROOT_SYSTEM_USER,
         )
 
-    def delete_temp_backup_directory(self, from_directory: str = CHARMED_MYSQL_COMMON_DIRECTORY) -> None:
+    def delete_temp_backup_directory(
+        self, from_directory: str = CHARMED_MYSQL_COMMON_DIRECTORY
+    ) -> None:
         """Delete the temp backup directory."""
         super().delete_temp_backup_directory(
             from_directory,


### PR DESCRIPTION
## Issue
1. We are not logging the success or failure of both the `create-backup` and `restore` actions
2. We are currently creating a temp backup and restore directories in the mysql data directory (to ensure that the temp backup directory is on the same volume as the data directory to reduce IOPS latency). However, we expanded the volume to include the snap common directory, so the temp directories no longer need to be in the data directory.
 
## Solution
1. Log failures (as warnings) and successes (as info) to the debug log. The failures have prefix `Backup failed`/`Restore failed`, the successes have prefix `Backup successful`/`Restore successful`
2. Move the temp directories out of the data directory, but within the snap common directory (where the volume is mounted). Additionally, make sure that the backups are backwards compatible (by still removing any temp directories in the data directory from old backups)
