### PR TITLE
Add memory constraints in conftest and change unit logging to debug in test models

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,8 +3,8 @@
 import dataclasses
 import json
 import os
-from pathlib import Path
 import subprocess
+from pathlib import Path
 from typing import Optional
 
 import pytest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ import dataclasses
 import json
 import os
 from pathlib import Path
+import subprocess
 from typing import Optional
 
 import pytest
@@ -108,6 +109,15 @@ def ops_test(ops_test: OpsTest, pytestconfig) -> OpsTest:
             )
         else:
             return await _build_charm(charm_path)
+
+    subprocess.run(
+        ["juju", "set-model-constraints", "--model", ops_test.model.info.name, "mem=1G"],
+        check=True,
+    )
+    subprocess.run(
+        'juju model-config logging-config="<root>=INFO;unit=DEBUG"'.split(),
+        check=True,
+    )
 
     ops_test.build_charm = build_charm
     return ops_test

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -115,7 +115,7 @@ def ops_test(ops_test: OpsTest, pytestconfig) -> OpsTest:
         check=True,
     )
     subprocess.run(
-        'juju model-config logging-config="<root>=INFO;unit=DEBUG"'.split(),
+        "juju model-config logging-config=<root>=INFO;unit=DEBUG".split(),
         check=True,
     )
 


### PR DESCRIPTION
## Issue
1. We are not setting any constraints on the mysql units (which results in mysql setting `innodb_buffer_pool_size` from calculations of the entire host machine). This may lead to some failures (OOM) in integration tests
2. We are not printing out debug log in the integration tests, making it very difficult to see what was happening when a test failed

## Solution
1. Set a memory constraint of 1G
2. Print unit debug logs in the output
