### PR TITLE
add auto-tuning for max_connections

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1458,12 +1458,11 @@ class MySQLBase(ABC):
             raise MySQLGetAutoTunningParametersError("Error computing buffer pool parameters")
 
     def get_max_connections(self) -> int:
-        """Calculate max_connections parameter for the instance.
-        """
+        """Calculate max_connections parameter for the instance."""
         # Reference: based off xtradb-cluster-operator
         # https://github.com/percona/percona-xtradb-cluster-operator/blob/main/pkg/pxc/app/config/autotune.go#L61-L70
 
-        bytes_per_connection = 12582912 # 12 Megabytes
+        bytes_per_connection = 12582912  # 12 Megabytes
         total_memory = None
 
         try:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -231,7 +231,7 @@ class MySQLOfflineModeAndHiddenInstanceExistsError(Error):
     """
 
 
-class MySQLGetInnoDBBufferPoolParametersError(Error):
+class MySQLGetAutoTunningParametersError(Error):
     """Exception raised when there is an error computing the innodb buffer pool parameters."""
 
 
@@ -956,6 +956,7 @@ class MySQLBase(ABC):
 
         def _get_host_ip(host: str) -> str:
             try:
+                port = None
                 if ":" in host:
                     host, port = host.split(":")
 
@@ -1454,7 +1455,28 @@ class MySQLBase(ABC):
             return (pool_size, innodb_buffer_pool_chunk_size)
         except Exception as e:
             logger.exception("Failed to compute innodb buffer pool parameters", exc_info=e)
-            raise MySQLGetInnoDBBufferPoolParametersError("Error retrieving total free memory")
+            raise MySQLGetAutoTunningParametersError("Error computing buffer pool parameters")
+
+    def get_max_connections(self) -> int:
+        """Calculate max_connections parameter for the instance.
+        """
+        # Reference: based off xtradb-cluster-operator
+        # https://github.com/percona/percona-xtradb-cluster-operator/blob/main/pkg/pxc/app/config/autotune.go#L61-L70
+
+        bytes_per_connection = 12582912 # 12 Megabytes
+        total_memory = None
+
+        try:
+            total_memory = self._get_total_memory()
+        except Exception as e:
+            logger.exception("Failed to retrieve total memory", exc_info=e)
+            raise MySQLGetAutoTunningParametersError("Error retrieving total memory")
+
+        if not total_memory or total_memory < bytes_per_connection:
+            logger.exception("Not enough memory for running MySQL: %i", total_memory)
+            raise MySQLGetAutoTunningParametersError("Not enough memory for running MySQL")
+
+        return total_memory // bytes_per_connection
 
     def _get_total_memory(self) -> int:
         """Retrieves the total memory of the server where mysql is running."""
@@ -1671,7 +1693,7 @@ Swap:     1027600384  1027600384           0
         """Prepare the backup in the provided dir for restore."""
         try:
             innodb_buffer_pool_size, _ = self.get_innodb_buffer_pool_parameters()
-        except MySQLGetInnoDBBufferPoolParametersError as e:
+        except MySQLGetAutoTunningParametersError as e:
             raise MySQLPrepareBackupForRestoreError(e)
 
         prepare_backup_command = f"""

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -16,7 +16,7 @@ from charms.mysql.v0.mysql import (
     MySQLBase,
     MySQLClientError,
     MySQLExecError,
-    MySQLGetInnoDBBufferPoolParametersError,
+    MySQLGetAutoTunningParametersError,
     MySQLRestoreBackupError,
     MySQLServiceNotRunningError,
     MySQLStartMySQLDError,
@@ -172,14 +172,16 @@ class MySQL(MySQLBase):
                 innodb_buffer_pool_size,
                 innodb_buffer_pool_chunk_size,
             ) = self.get_innodb_buffer_pool_parameters()
-        except MySQLGetInnoDBBufferPoolParametersError:
-            raise MySQLCreateCustomMySQLDConfigError("Failed to compute innodb buffer pool size")
+        max_connections = self.get_max_connections()
+        except MySQLGetAutoTunningParametersError:
+            raise MySQLCreateCustomMySQLDConfigError("Failed to compute mysql parameters automatically")
 
         content = [
             "[mysqld]",
             "bind-address = 0.0.0.0",
             "mysqlx-bind-address = 0.0.0.0",
             f"innodb_buffer_pool_size = {innodb_buffer_pool_size}",
+            f"max_connections = {max_connections}",
         ]
 
         if innodb_buffer_pool_chunk_size:

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -172,9 +172,11 @@ class MySQL(MySQLBase):
                 innodb_buffer_pool_size,
                 innodb_buffer_pool_chunk_size,
             ) = self.get_innodb_buffer_pool_parameters()
-        max_connections = self.get_max_connections()
+            max_connections = self.get_max_connections()
         except MySQLGetAutoTunningParametersError:
-            raise MySQLCreateCustomMySQLDConfigError("Failed to compute mysql parameters automatically")
+            raise MySQLCreateCustomMySQLDConfigError(
+                "Failed to compute mysql parameters automatically"
+            )
 
         content = [
             "[mysqld]",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -797,6 +797,29 @@ async def write_random_chars_to_test_table(ops_test: OpsTest, primary_unit: Unit
     return random_chars
 
 
+async def retrieve_database_variable_value(
+    ops_test: OpsTest, unit: Unit, variable_name: str
+) -> str:
+    """Retrieve a database variable value as a string.
+
+    Args:
+        ops_test: The ops test framework instance
+        unit: The unit to retrieve the variable
+        variable_name: The name of the variable to retrieve
+    Returns:
+        The variable value (str)
+    """
+    unit_ip = await get_unit_ip(ops_test, unit.name)
+    server_config_password = await get_system_user_password(unit, SERVER_CONFIG_USERNAME)
+    queries = [f"SELECT @@{variable_name};"]
+
+    output = await execute_queries_on_unit(
+        unit_ip, SERVER_CONFIG_USERNAME, server_config_password, queries
+    )
+
+    return output[0]
+
+
 async def get_tls_ca(
     ops_test: OpsTest,
     unit_name: str,

--- a/tests/integration/high_availability/test_replication.py
+++ b/tests/integration/high_availability/test_replication.py
@@ -64,7 +64,6 @@ async def test_exporter_endpoints(ops_test: OpsTest, mysql_charm_series: str) ->
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@pytest.mark.dev
 async def test_custom_variables(ops_test: OpsTest, mysql_charm_series) -> None:
     """Query database for custom variables."""
     mysql_application_name, _ = await high_availability_test_setup(ops_test, mysql_charm_series)

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -923,6 +923,21 @@ class TestMySQLBase(unittest.TestCase):
         with self.assertRaises(MySQLExecError):
             self.mysql._get_total_memory()
 
+    @patch("charms.mysql.v0.mysql.MySQLBase._get_total_memory")
+    def test_get_max_connections(self, _get_total_memory):
+        _get_total_memory.return_value = 16484458496
+
+        self.assertEqual(1310, self.mysql.get_max_connections())
+
+        _get_total_memory.return_value = 12582910
+
+        with self.assertRaises(MySQLGetAutoTunningParametersError):
+            self.mysql.get_max_connections()
+
+        with self.assertRaises(MySQLGetAutoTunningParametersError):
+            _get_total_memory.side_effect = MySQLExecError
+            self.mysql.get_max_connections()
+
     @patch("charms.mysql.v0.mysql.MySQLBase._execute_commands")
     def test_execute_backup_commands(self, _execute_commands):
         """Test successful execution of execute_backup_commands()."""

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -24,7 +24,7 @@ from charms.mysql.v0.mysql import (
     MySQLEmptyDataDirectoryError,
     MySQLExecError,
     MySQLExecuteBackupCommandsError,
-    MySQLGetInnoDBBufferPoolParametersError,
+    MySQLGetAutoTunningParametersError,
     MySQLInitializeJujuOperationsTableError,
     MySQLOfflineModeAndHiddenInstanceExistsError,
     MySQLPrepareBackupForRestoreError,
@@ -914,7 +914,7 @@ class TestMySQLBase(unittest.TestCase):
         """Test a failure in execution of get_innodb_buffer_pool_parameters()."""
         _get_total_memory.side_effect = MySQLExecError
 
-        with self.assertRaises(MySQLGetInnoDBBufferPoolParametersError):
+        with self.assertRaises(MySQLGetAutoTunningParametersError):
             self.mysql.get_innodb_buffer_pool_parameters()
 
     @patch("charms.mysql.v0.mysql.MySQLBase._execute_commands")
@@ -1319,7 +1319,7 @@ xtrabackup/location --prepare
                 group="test-group",
             )
 
-        _get_innodb_buffer_pool_parameters.side_effect = MySQLGetInnoDBBufferPoolParametersError()
+        _get_innodb_buffer_pool_parameters.side_effect = MySQLGetAutoTunningParametersError()
         with self.assertRaises(MySQLPrepareBackupForRestoreError):
             self.mysql.prepare_backup_for_restore(
                 "backup/location",

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, call, patch
 from charms.mysql.v0.mysql import (
     MySQLClientError,
     MySQLExecError,
-    MySQLGetInnoDBBufferPoolParametersError,
+    MySQLGetAutoTunningParametersError,
     MySQLStartMySQLDError,
     MySQLStopMySQLDError,
 )
@@ -280,7 +280,7 @@ report_host = 127.0.0.1
         self, _open, _path, _get_innodb_buffer_pool_parameters
     ):
         """Test failure in execution of create_custom_mysqld_config."""
-        _get_innodb_buffer_pool_parameters.side_effect = MySQLGetInnoDBBufferPoolParametersError
+        _get_innodb_buffer_pool_parameters.side_effect = MySQLGetAutoTunningParametersError
 
         _path_mock = MagicMock()
         _path.return_value = _path_mock


### PR DESCRIPTION
## Issue

MySQL `max_connections` is neither being tunned nor being exposed to configuration, staying at the default 151 connections.

## Solution

Add sane auto-tune strategy while proper configuration management is not implemented.

