### PR TITLE
Handle IP address changes of units

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -488,7 +488,7 @@ async def unit_hostname(ops_test: OpsTest, unit_name: str) -> str:
     return raw_hostname.strip()
 
 
-@retry(stop=stop_after_attempt(20), wait=wait_fixed(15))
+@retry(stop=stop_after_attempt(60), wait=wait_fixed(15))
 def wait_network_restore(model_name: str, hostname: str, old_ip: str) -> None:
     """Wait until network is restored.
 

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -208,7 +208,7 @@ async def test_network_cut(ops_test: OpsTest, continuous_writes, mysql_charm_ser
         # wait for the unit to be ready
         logger.info(f"Waiting for {primary_unit.name} to enter maintenance")
         await ops_test.model.block_until(
-            lambda: primary_unit.workload_status == "maintenance", timeout=10 * 60
+            lambda: primary_unit.workload_status == "maintenance", timeout=30 * 60
         )
         logger.info(f"Waiting for {primary_unit.name} to enter active")
         await ops_test.model.block_until(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -363,11 +363,12 @@ class TestCharm(unittest.TestCase):
         _get_member_state.return_value = ("unreachable", "primary")
 
         self.charm.on.update_status.emit()
+
         _get_member_state.assert_called_once()
         __reboot_from_complete_outage.assert_not_called()
         _snap_service_operation.assert_called_once()
         _workload_reset.assert_called_once()
-        _get_cluster_primary_address.assert_called_once()
+        _get_cluster_primary_address.assert_called()
         _rescan_cluster.assert_called_once()
 
-        self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
+        self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))


### PR DESCRIPTION
## Issue
We are currently not handling the IP address change of a unit in the cluster.

## Solution
Handle the IP address change of a unit (whether in a cluster or a single node).

Steps to recover involve:
1. Remove plugin `group_replication`
2. Update `report_host` in the custom mysqld config file and restart mysqld
3. Add node back to cluster (or recreate cluster if there is only 1 unit in the cluster)

If the transaction set in the unit is a subset of the transaction set in the cluster, then upon addition into the cluster, distributed recovery will be in effect. Else, the data will be cloned from one of the units in the cluster.

## Considerations
- How will scaling down to 1 unit (preserving the data volume), recovering from IP address change, and then scaling up effect SST (because the GTID may be different after re-creating a cluster in the recovery process)?