### PR TITLE
DPE-2061 Fail action to set or get incorrect user password

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -409,7 +409,9 @@ class MySQLOperatorCharm(CharmBase):
         username = event.params.get("username") or ROOT_USERNAME
 
         if username not in REQUIRED_USERNAMES:
-            event.fail(f"The action can be run only for users used by the charm: {', '.join(REQUIRED_USERNAMES)} not {username}")
+            event.fail(
+                f"The action can be run only for users used by the charm: {', '.join(REQUIRED_USERNAMES)} not {username}"
+            )
             return
 
         if username == ROOT_USERNAME:
@@ -436,7 +438,9 @@ class MySQLOperatorCharm(CharmBase):
         username = event.params.get("username") or ROOT_USERNAME
 
         if username not in REQUIRED_USERNAMES:
-            event.fail(f"The action can be run only for users used by the charm: {', '.join(REQUIRED_USERNAMES)} not {username}")
+            event.fail(
+                f"The action can be run only for users used by the charm: {', '.join(REQUIRED_USERNAMES)} not {username}"
+            )
             return
 
         if username == ROOT_USERNAME:

--- a/src/charm.py
+++ b/src/charm.py
@@ -409,7 +409,8 @@ class MySQLOperatorCharm(CharmBase):
         username = event.params.get("username") or ROOT_USERNAME
 
         if username not in REQUIRED_USERNAMES:
-            raise RuntimeError("Invalid username.")
+            event.fail(f"The action can be run only for users used by the charm: {', '.join(REQUIRED_USERNAMES)} not {username}")
+            return
 
         if username == ROOT_USERNAME:
             secret_key = ROOT_PASSWORD_KEY
@@ -429,12 +430,14 @@ class MySQLOperatorCharm(CharmBase):
     def _on_set_password(self, event: ActionEvent) -> None:
         """Action used to update/rotate the system user's password."""
         if not self.unit.is_leader():
-            raise RuntimeError("set-password action can only be run on the leader unit.")
+            event.fail("set-password action can only be run on the leader unit.")
+            return
 
         username = event.params.get("username") or ROOT_USERNAME
 
         if username not in REQUIRED_USERNAMES:
-            raise RuntimeError("Invalid username.")
+            event.fail(f"The action can be run only for users used by the charm: {', '.join(REQUIRED_USERNAMES)} not {username}")
+            return
 
         if username == ROOT_USERNAME:
             secret_key = ROOT_PASSWORD_KEY


### PR DESCRIPTION
## Issue
We are raising an exception when an invalid username is passed to the `get-password` or `set-password` action.

## Solution
Use `event.fail` to return a more meaningful message (instead of raising an exception).