### PR TITLE
DPE-2061 Update default username for set/get password in the description

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -10,7 +10,7 @@ get-password:
   params:
     username:
       type: string
-      description: The username, the default value 'operator'.
+      description: The username, the default value 'root'.
         Possible values - root, serverconfig, clusteradmin.
 
 set-password:
@@ -19,7 +19,7 @@ set-password:
   params:
     username:
       type: string
-      description: The username, the default value 'operator'.
+      description: The username, the default value 'root'.
         Possible values - root, serverconfig, clusteradmin.
     password:
       type: string


### PR DESCRIPTION
## Issue
The default username is `operation` in the `set-password` and `get-password` action descriptions

## Solution
Update description to set the default username to `root`
