### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @canonical/data-platform-mysql


### PR DESCRIPTION
Required for self-hosted runners (per spec ISD029)
