### PR TITLE
Use charmcraft 2.3.0 to fix release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,8 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v4.1.0
+    with:
+      charmcraft-snap-revision: 1349  # version 2.3.0
 
   release:
     name: Release charm


### PR DESCRIPTION
charmcraft 2.3.0 was pinned in the integration test build but not in the release build
