### PR TITLE
Add `poetry lock` commands to lint and format

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ description = Apply coding style standards to code
 commands_pre =
     poetry install --only format
 commands =
+    poetry lock --no-update
     poetry run isort {[vars]all_path}
     poetry run black {[vars]all_path}
 
@@ -47,6 +48,7 @@ allowlist_externals =
 commands_pre =
     poetry install --only lint
 commands =
+    poetry lock --check
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
     poetry run codespell {[vars]all_path}


### PR DESCRIPTION
Lint: `poetry lock --check` verifies that `poetry.lock` is valid for `pyproject.toml`
Format: `poetry lock --no-update` adds any changes in `pyproject.toml` to `poetry.lock` without updating locked versions
