### PR TITLE
DPE-2215 Fix wait timeout for shared-db

### DIFF
--- a/src/relations/shared_db.py
+++ b/src/relations/shared_db.py
@@ -165,9 +165,11 @@ class SharedDBRelation(Object):
 
             # Database port is static in legacy charm
             local_app_data["db_port"] = local_unit_data["db_port"] = "3306"
+
             # Wait timeout is a config option in legacy charm
-            # defaulted to 3600 seconds
-            local_app_data["wait_timeout"] = local_unit_data["wait_timeout"] = "3600"
+            # here defaulted to mysql sysvar value:
+            # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_wait_timeout
+            local_app_data["wait_timeout"] = local_unit_data["wait_timeout"] = "28800"
 
             # password already cached
             local_app_data["password"] = local_unit_data["password"] = password

--- a/tests/unit/test_shared_db.py
+++ b/tests/unit/test_shared_db.py
@@ -79,7 +79,7 @@ class TestSharedDBRelation(unittest.TestCase):
             {
                 "db_host": "1.1.1.1",
                 "db_port": "3306",
-                "wait_timeout": "3600",
+                "wait_timeout": "28800",
                 "password": "super_secure_password",
                 "allowed_units": "other-app/0",
             },


### PR DESCRIPTION
## Issue

Mismatch between relation data and server sysvar `wait_timeout`

## Solution

Use mysqld default `wait_timeout` value.