### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-** @canonical/data-platform-mysql


### PR DESCRIPTION
No longer a requirement for self-hosted runners
