### PR TITLE
Add workaround to unblock release CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
     with:
       artifact-name: ${{ needs.build.outputs.artifact-name }}
       cloud: lxd
-      juju-agent-version: 2.9.43
+      juju-agent-version: 2.9.43  # renovate: juju-agent-pin-major
       # TODO: Remove when self-hosted runners support `on: push`. Also, replace `@release-workaround` with latest version
       _enable-on-push-continue-on-error-workaround-for-release-ci: true
     secrets:


### PR DESCRIPTION
Self-hosted runners do not currently support `on: push`

Currently, this blocks the release CI

Enable a workaround using `continue-on-error` that allows the ci.yaml workflow to pass if the self-hosted integration test job fails
