### PR TITLE
DPE-2352 Restart mysql exporter upon monitoring password change

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -88,6 +88,7 @@ from constants import (
     BACKUPS_USERNAME,
     CLUSTER_ADMIN_PASSWORD_KEY,
     CLUSTER_ADMIN_USERNAME,
+    COS_AGENT_RELATION_NAME,
     MONITORING_PASSWORD_KEY,
     MONITORING_USERNAME,
     PASSWORD_LENGTH,
@@ -110,7 +111,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 38
+LIBPATCH = 39
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -403,6 +404,12 @@ class MySQLCharmBase(CharmBase):
         self._mysql.update_user_password(username, new_password)
 
         self.set_secret("app", secret_key, new_password)
+
+        if (
+            username == MONITORING_USERNAME
+            and len(self.model.relations.get(COS_AGENT_RELATION_NAME, [])) > 0
+        ):
+            self._mysql.restart_mysql_exporter()
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
         """Action used  to retrieve the cluster status."""

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -2303,6 +2303,11 @@ Swap:     1027600384  1027600384           0
         raise NotImplementedError
 
     @abstractmethod
+    def restart_mysql_exporter(self) -> None:
+        """Restart the mysqld exporter."""
+        raise NotImplementedError
+
+    @abstractmethod
     def wait_until_mysql_connection(self) -> None:
         """Wait until a connection to MySQL has been obtained.
 

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -566,6 +566,11 @@ class MySQL(MySQLBase):
             logger.exception("An exception occurred when stopping mysqld-exporter")
             raise MySQLExporterConnectError("Error stopping mysqld-exporter")
 
+    def restart_mysql_exporter(self) -> None:
+        """Restart the mysqld exporter."""
+        self._stop_mysql_exporter()
+        self._connect_mysql_exporter()
+
     def _run_mysqlsh_script(self, script: str, timeout=None) -> str:
         """Execute a MySQL shell script.
 


### PR DESCRIPTION
## Issue
We are currently not restarting the mysqld exporter when the monitoring user password changes. 

## Solution
Restart the mysqld exporter (stop and connect again with the new password) when the password changes