### PR TITLE
Add `has_cos_relation` to the MySQLCharmBase class

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -111,7 +111,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 40
+LIBPATCH = 41
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -74,7 +74,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import ops
-from ops.charm import ActionEvent, CharmBase
+from ops.charm import ActionEvent, CharmBase, RelationBrokenEvent
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -111,11 +111,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-<<<<<<< HEAD
 LIBPATCH = 41
-=======
-LIBPATCH = 40
->>>>>>> main
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -111,7 +111,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 39
+LIBPATCH = 40
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -371,6 +371,10 @@ class MySQLCharmBase(CharmBase):
         self.framework.observe(self.on.get_password_action, self._on_get_password)
         self.framework.observe(self.on.set_password_action, self._on_set_password)
 
+        # Set in some event handlers in order to avoid passing event down a chain
+        # of methods
+        self.current_event = None
+
     def _on_get_password(self, event: ActionEvent) -> None:
         """Action used to retrieve the system user's password."""
         username = event.params.get("username") or ROOT_USERNAME
@@ -421,10 +425,7 @@ class MySQLCharmBase(CharmBase):
 
         self.set_secret("app", secret_key, new_password)
 
-        if (
-            username == MONITORING_USERNAME
-            and len(self.model.relations.get(COS_AGENT_RELATION_NAME, [])) > 0
-        ):
+        if username == MONITORING_USERNAME and self.has_cos_relation:
             self._mysql.restart_mysql_exporter()
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
@@ -490,6 +491,22 @@ class MySQLCharmBase(CharmBase):
             and self.get_secret("app", MONITORING_PASSWORD_KEY)
             and self.get_secret("app", BACKUPS_PASSWORD_KEY)
         )
+
+    @property
+    def has_cos_relation(self) -> bool:
+        """Returns a bool indicating whether a relation with COS is present."""
+        cos_relations = self.model.relations.get(COS_AGENT_RELATION_NAME, [])
+        active_cos_relations = list(
+            filter(
+                lambda relation: not (
+                    isinstance(self.current_event, RelationBrokenEvent)
+                    and self.current_event.relation.id == relation.id
+                ),
+                cos_relations,
+            )
+        )
+
+        return len(active_cos_relations) > 0
 
     def _get_secret_from_juju(self, scope: str, key: str) -> Optional[str]:
         """Retrieve and return the secret from the juju secret storage."""

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -88,6 +88,7 @@ from constants import (
     BACKUPS_USERNAME,
     CLUSTER_ADMIN_PASSWORD_KEY,
     CLUSTER_ADMIN_USERNAME,
+    COS_AGENT_RELATION_NAME,
     MONITORING_PASSWORD_KEY,
     MONITORING_USERNAME,
     PASSWORD_LENGTH,
@@ -110,7 +111,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 38
+LIBPATCH = 39
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -403,6 +404,12 @@ class MySQLCharmBase(CharmBase):
         self._mysql.update_user_password(username, new_password)
 
         self.set_secret("app", secret_key, new_password)
+
+        if (
+            username == MONITORING_USERNAME
+            and len(self.model.relations.get(COS_AGENT_RELATION_NAME, [])) > 0
+        ):
+            self._mysql.restart_mysql_exporter()
 
     def _get_cluster_status(self, event: ActionEvent) -> None:
         """Action used  to retrieve the cluster status."""

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -2303,6 +2303,11 @@ Swap:     1027600384  1027600384           0
         raise NotImplementedError
 
     @abstractmethod
+    def restart_mysql_exporter(self) -> None:
+        """Restart the mysqld exporter."""
+        raise NotImplementedError
+
+    @abstractmethod
     def wait_until_mysql_connection(self) -> None:
         """Wait until a connection to MySQL has been obtained.
 

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -566,6 +566,11 @@ class MySQL(MySQLBase):
             logger.exception("An exception occurred when stopping mysqld-exporter")
             raise MySQLExporterConnectError("Error stopping mysqld-exporter")
 
+    def restart_mysql_exporter(self) -> None:
+        """Restart the mysqld exporter."""
+        self._stop_mysql_exporter()
+        self._connect_mysql_exporter()
+
     def _run_mysqlsh_script(self, script: str, timeout=None) -> str:
         """Execute a MySQL shell script.
 


### PR DESCRIPTION
## Issue
- We added a `has_cos_relation` property in a branch in the k8s charm. It seems like this property would be good to have in the vm charm as well as the k8s charm
- Sometimes, we pass the current_event (event of a handler) down a chain of methods before it gets used

## Solution
- Add `has_cos_relation` property to the MySQLBaseCharm class
- Introduce a `self.current_event` field (initialized to `None`) that can be set on the charm class by an event and then used in helper methods