### PR TITLE
Add juju agent version requirement to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -56,4 +56,10 @@ storage:
     location: /var/snap/charmed-mysql/common
 
 assumes:
-  - juju
+  - any-of:
+      - all-of:
+          - juju >= 2.9.44
+          - juju < 3
+      - all-of:
+          - juju >= 3.1.6
+          - juju < 4


### PR DESCRIPTION
Ported from https://github.com/canonical/mysql-k8s-operator/pull/277