### PR TITLE
DPE-1800 in place upgrades

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -49,3 +49,7 @@ restore:
     backup-id:
       type: string
       description: A backup-id to identify the backup to restore (format = %Y-%m-%dT%H:%M:%SZ)
+
+pre-upgrade-check:
+  description: Run necessary pre-upgrade checks and preparations before executing a charm refresh.
+

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -1,0 +1,1245 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Library to manage in-place upgrades for charms running on VMs and K8s.
+
+This library contains handlers for `upgrade` relation events used to coordinate
+between units in an application during a `juju refresh`, as well as `Pydantic` models
+for instantiating, validating and comparing dependencies.
+
+An upgrade on VMs is initiated with the command `juju refresh`. Once executed, the following
+events are emitted to each unit at random:
+    - `upgrade-charm`
+    - `config-changed`
+    - `leader-settings-changed` - Non-leader only
+
+Charm authors can implement the classes defined in this library to streamline the process of
+coordinating which unit updates when, achieved through updating of unit-data `state` throughout.
+
+At a high-level, the upgrade steps are as follows:
+    - Run pre-checks on the cluster to confirm it is safe to upgrade
+    - Create stack of unit.ids, to serve as the upgrade order (generally workload leader is last)
+    - Start the upgrade by issuing a Juju CLI command
+    - The unit at the top of the stack gets permission to upgrade
+    - The unit handles the upgrade and restarts their service
+    - Repeat, until all units have restarted
+
+### Usage by charm authors
+
+#### `upgrade` relation
+
+Charm authors must implement an additional peer-relation.
+
+As this library uses relation data exchanged between units to coordinate, charm authors
+need to add a new relation interface. The relation name does not matter.
+
+`metadata.yaml`
+```yaml
+peers:
+  upgrade:
+    interface: upgrade
+```
+
+#### Dependencies JSON/Dict
+
+Charm authors must implement a dict object tracking current charm versions, requirements + upgradability.
+
+Many workload versions may be incompatible with older/newer versions. This same idea also can apply to
+charm or snap versions. Workloads with required related applications (e.g Kafka + ZooKeeper) also need to
+ensure their versions are compatible during an upgrade, to avoid cluster failure.
+
+As such, it is necessasry to freeze any dependencies within each published charm. An example of this could
+be creating a `DEPENDENCIES` dict within the charm code, with the following structure:
+
+`src/literals.py`
+```python
+DEPENDENCIES = {
+    "kafka_charm": {
+        "dependencies": {"zookeeper": ">50"},
+        "name": "kafka",
+        "upgrade_supported": ">90",
+        "version": "100",
+    },
+    "kafka_service": {
+        "dependencies": {"zookeeper": "^3"},
+        "name": "kafka",
+        "upgrade_supported": ">=0.8",
+        "version": "3.3.2",
+    },
+}
+```
+
+The first-level key names are arbitrary labels for tracking what those versions+dependencies are for.
+The `dependencies` second-level values are a key-value map of any required external applications,
+    and the versions this packaged charm can support.
+The `upgrade_suppported` second-level values are requirements from which an in-place upgrade can be
+    supported by the charm.
+The `version` second-level values correspond to the current version of this packaged charm.
+
+Any requirements comply with [`poetry`'s dependency specifications](https://python-poetry.org/docs/dependency-specification/#caret-requirements).
+
+### Dependency Model
+
+Charm authors must implement their own class inheriting from `DependencyModel`.
+
+Using a `Pydantic` model to instantiate the aforementioned `DEPENDENCIES` dict gives stronger type safety and additional
+layers of validation.
+
+Implementation just needs to ensure that the top-level key names from `DEPENDENCIES` are defined as attributed in the model.
+
+`src/upgrade.py`
+```python
+from pydantic import BaseModel
+
+class KafkaDependenciesModel(BaseModel):
+    kafka_charm: DependencyModel
+    kafka_service: DependencyModel
+```
+
+### Overrides for `DataUpgrade`
+
+Charm authors must define their own class, inheriting from `DataUpgrade`, overriding all required `abstractmethod`s.
+
+```python
+class ZooKeeperUpgrade(DataUpgrade):
+    def __init__(self, charm: "ZooKeeperUpgrade", **kwargs):
+        super().__init__(charm, **kwargs)
+        self.charm = charm
+```
+
+#### Implementation of `pre_upgrade_check()`
+
+Before upgrading a cluster, it's a good idea to check that it is stable and healthy before permitting it.
+Here, charm authors can validate upgrade safety through API calls, relation-data checks, etc.
+If any of these checks fail, raise `ClusterNotReadyError`.
+
+```python
+    @override
+    def pre_upgrade_check(self) -> None:
+        default_message = "Pre-upgrade check failed and cannot safely upgrade"
+        try:
+            if not self.client.members_broadcasting or not len(self.client.server_members) == len(
+                self.charm.cluster.peer_units
+            ):
+                raise ClusterNotReadyError(
+                    message=default_message,
+                    cause="Not all application units are connected and broadcasting in the quorum",
+                )
+
+            if self.client.members_syncing:
+                raise ClusterNotReadyError(
+                    message=default_message, cause="Some quorum members are syncing data"
+                )
+
+            if not self.charm.cluster.stable:
+                raise ClusterNotReadyError(
+                    message=default_message, cause="Charm has not finished initialising"
+                )
+
+        except QuorumLeaderNotFoundError:
+            raise ClusterNotReadyError(message=default_message, cause="Quorum leader not found")
+        except ConnectionClosedError:
+            raise ClusterNotReadyError(
+                message=default_message, cause="Unable to connect to the cluster"
+            )
+```
+
+#### Implementation of `build_upgrade_stack()` - VM ONLY
+
+Oftentimes, it is necessary to ensure that the workload leader is the last unit to upgrade,
+to ensure high-availability during the upgrade process.
+Here, charm authors can create a LIFO stack of unit.ids, represented as a list of unit.id strings,
+with the leader unit being at i[0].
+
+```python
+@override
+def build_upgrade_stack(self) -> list[int]:
+    upgrade_stack = []
+    for unit in self.charm.cluster.peer_units:
+        config = self.charm.cluster.unit_config(unit=unit)
+
+        # upgrade quorum leader last
+        if config["host"] == self.client.leader:
+            upgrade_stack.insert(0, int(config["unit_id"]))
+        else:
+            upgrade_stack.append(int(config["unit_id"]))
+
+    return upgrade_stack
+```
+
+#### Implementation of `_on_upgrade_granted()`
+
+On relation-changed events, each unit will check the current upgrade-stack persisted to relation data.
+If that unit is at the top of the stack, it will emit an `upgrade-granted` event, which must be handled.
+Here, workloads can be re-installed with new versions, checks can be made, data synced etc.
+If the new unit successfully rejoined the cluster, call `set_unit_completed()`.
+If the new unit failed to rejoin the cluster, call `set_unit_failed()`.
+
+NOTE - It is essential here to manually call `on_upgrade_changed` if the unit is the current leader.
+This ensures that the leader gets it's own relation-changed event, and updates the upgrade-stack for
+other units to follow suit.
+
+```python
+@override
+def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
+    self.charm.snap.stop_snap_service()
+
+    if not self.charm.snap.install():
+        logger.error("Unable to install ZooKeeper Snap")
+        self.set_unit_failed()
+        return None
+
+    logger.info(f"{self.charm.unit.name} upgrading service...")
+    self.charm.snap.restart_snap_service()
+
+    try:
+        logger.debug("Running post-upgrade check...")
+        self.pre_upgrade_check()
+
+        logger.debug("Marking unit completed...")
+        self.set_unit_completed()
+
+        # ensures leader gets it's own relation-changed when it upgrades
+        if self.charm.unit.is_leader():
+            logger.debug("Re-emitting upgrade-changed on leader...")
+            self.on_upgrade_changed(event)
+
+    except ClusterNotReadyError as e:
+        logger.error(e.cause)
+        self.set_unit_failed()
+```
+
+#### Implementation of `log_rollback_instructions()`
+
+If the upgrade fails, manual intervention may be required for cluster recovery.
+Here, charm authors can log out any necessary steps to take to recover from a failed upgrade.
+When a unit fails, this library will automatically log out this message.
+
+```python
+@override
+def log_rollback_instructions(self) -> None:
+    logger.error("Upgrade failed. Please run `juju refresh` to previous version.")
+```
+
+### Instantiating in the charm and deferring events
+
+Charm authors must add a class attribute for the child class of `DataUpgrade` in the main charm.
+They must also ensure that any non-upgrade related events that may be unsafe to handle during
+an upgrade, are deferred if the unit is not in the `idle` state - i.e not currently upgrading.
+
+```python
+class ZooKeeperCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.upgrade = ZooKeeperUpgrade(
+            self,
+            relation_name = "upgrade",
+            substrate = "vm",
+            dependency_model=ZooKeeperDependencyModel(
+                **DEPENDENCIES
+            ),
+        )
+
+    def restart(self, event) -> None:
+        if not self.upgrade.state == "idle":
+            event.defer()
+            return None
+
+        self.restart_snap_service()
+```
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import List, Literal, Optional, Set, Tuple
+
+from ops.charm import (
+    ActionEvent,
+    CharmBase,
+    CharmEvents,
+    RelationCreatedEvent,
+    UpgradeCharmEvent,
+)
+from ops.framework import EventBase, EventSource, Object
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation, Unit, WaitingStatus
+from pydantic import BaseModel, root_validator, validator
+
+# The unique Charmhub library identifier, never change it
+LIBID = "156258aefb79435a93d933409a8c8684"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 8
+
+PYDEPS = ["pydantic>=1.10,<2"]
+
+logger = logging.getLogger(__name__)
+
+# --- DEPENDENCY RESOLUTION FUNCTIONS ---
+
+
+def build_complete_sem_ver(version: str) -> list[int]:
+    """Builds complete major.minor.patch version from version string.
+
+    Returns:
+        List of major.minor.patch version integers
+    """
+    versions = [int(ver) if ver != "*" else 0 for ver in str(version).split(".")]
+
+    # padding with 0s until complete major.minor.patch
+    return (versions + 3 * [0])[:3]
+
+
+def verify_caret_requirements(version: str, requirement: str) -> bool:
+    """Verifies version requirements using carats.
+
+    Args:
+        version: the version currently in use
+        requirement: the requirement version
+
+    Returns:
+        True if `version` meets defined `requirement`. Otherwise False
+    """
+    if not requirement.startswith("^"):
+        return True
+
+    requirement = requirement[1:]
+
+    sem_version = build_complete_sem_ver(version)
+    sem_requirement = build_complete_sem_ver(requirement)
+
+    # caret uses first non-zero character, not enough to just count '.
+    max_version_index = requirement.count(".")
+    for i, semver in enumerate(sem_requirement):
+        if semver != 0:
+            max_version_index = i
+            break
+
+    for i in range(3):
+        # version higher than first non-zero
+        if (i < max_version_index) and (sem_version[i] > sem_requirement[i]):
+            return False
+
+        # version either higher or lower than first non-zero
+        if (i == max_version_index) and (sem_version[i] != sem_requirement[i]):
+            return False
+
+        # valid
+        if (i > max_version_index) and (sem_version[i] > sem_requirement[i]):
+            return True
+
+    return False
+
+
+def verify_tilde_requirements(version: str, requirement: str) -> bool:
+    """Verifies version requirements using tildes.
+
+    Args:
+        version: the version currently in use
+        requirement: the requirement version
+
+    Returns:
+        True if `version` meets defined `requirement`. Otherwise False
+    """
+    if not requirement.startswith("~"):
+        return True
+
+    requirement = requirement[1:]
+
+    sem_version = build_complete_sem_ver(version)
+    sem_requirement = build_complete_sem_ver(requirement)
+
+    max_version_index = min(1, requirement.count("."))
+
+    for i in range(3):
+        # version higher before requirement level
+        if (i < max_version_index) and (sem_version[i] > sem_requirement[i]):
+            return False
+
+        # version either higher or lower at requirement level
+        if (i == max_version_index) and (sem_version[i] != sem_requirement[i]):
+            return False
+
+        # version lower after requirement level
+        if (i > max_version_index) and (sem_version[i] < sem_requirement[i]):
+            return False
+
+    # must be valid
+    return True
+
+
+def verify_wildcard_requirements(version: str, requirement: str) -> bool:
+    """Verifies version requirements using wildcards.
+
+    Args:
+        version: the version currently in use
+        requirement: the requirement version
+
+    Returns:
+        True if `version` meets defined `requirement`. Otherwise False
+    """
+    if "*" not in requirement:
+        return True
+
+    sem_version = build_complete_sem_ver(version)
+    sem_requirement = build_complete_sem_ver(requirement)
+
+    max_version_index = requirement.count(".")
+
+    for i in range(3):
+        # version not the same before wildcard
+        if (i < max_version_index) and (sem_version[i] != sem_requirement[i]):
+            return False
+
+        # version not higher after wildcard
+        if (i == max_version_index) and (sem_version[i] < sem_requirement[i]):
+            return False
+
+    # must be valid
+    return True
+
+
+def verify_inequality_requirements(version: str, requirement: str) -> bool:
+    """Verifies version requirements using inequalities.
+
+    Args:
+        version: the version currently in use
+        requirement: the requirement version
+
+    Returns:
+        True if `version` meets defined `requirement`. Otherwise False
+    """
+    if not any(char for char in [">", ">="] if requirement.startswith(char)):
+        return True
+
+    raw_requirement = requirement.replace(">", "").replace("=", "")
+
+    sem_version = build_complete_sem_ver(version)
+    sem_requirement = build_complete_sem_ver(raw_requirement)
+
+    max_version_index = raw_requirement.count(".") or 0
+
+    for i in range(3):
+        # valid at same requirement level
+        if (
+            (i == max_version_index)
+            and ("=" in requirement)
+            and (sem_version[i] == sem_requirement[i])
+        ):
+            return True
+
+        # version not increased at any point
+        if sem_version[i] < sem_requirement[i]:
+            return False
+
+        # valid
+        if sem_version[i] > sem_requirement[i]:
+            return True
+
+    # must not be valid
+    return False
+
+
+def verify_requirements(version: str, requirement: str) -> bool:
+    """Verifies a specified version against defined requirements.
+
+    Supports caret (`^`), tilde (`~`), wildcard (`*`) and greater-than inequalities (`>`, `>=`)
+
+    Args:
+        version: the version currently in use
+        requirement: the requirement version
+
+    Returns:
+        True if `version` meets defined `requirement`. Otherwise False
+    """
+    if not all(
+        [
+            verify_inequality_requirements(version=version, requirement=requirement),
+            verify_caret_requirements(version=version, requirement=requirement),
+            verify_tilde_requirements(version=version, requirement=requirement),
+            verify_wildcard_requirements(version=version, requirement=requirement),
+        ]
+    ):
+        return False
+
+    return True
+
+
+# --- DEPENDENCY MODEL TYPES ---
+
+
+class DependencyModel(BaseModel):
+    """Manager for a single dependency.
+
+    To be used as part of another model representing a collection of arbitrary dependencies.
+
+    Example::
+
+        class KafkaDependenciesModel(BaseModel):
+            kafka_charm: DependencyModel
+            kafka_service: DependencyModel
+
+        deps = {
+            "kafka_charm": {
+                "dependencies": {"zookeeper": ">5"},
+                "name": "kafka",
+                "upgrade_supported": ">5",
+                "version": "10",
+            },
+            "kafka_service": {
+                "dependencies": {"zookeeper": "^3.6"},
+                "name": "kafka",
+                "upgrade_supported": "~3.3",
+                "version": "3.3.2",
+            },
+        }
+
+        model = KafkaDependenciesModel(**deps)  # loading dict in to model
+
+        print(model.dict())  # exporting back validated deps
+    """
+
+    dependencies: dict[str, str]
+    name: str
+    upgrade_supported: str
+    version: str
+
+    @validator("dependencies", "upgrade_supported", each_item=True)
+    @classmethod
+    def dependencies_validator(cls, value):
+        """Validates values with dependencies for multiple special characters."""
+        if isinstance(value, dict):
+            deps = value.values()
+        else:
+            deps = [value]
+
+        chars = ["~", "^", ">", "*"]
+
+        for dep in deps:
+            if (count := sum([dep.count(char) for char in chars])) != 1:
+                raise ValueError(
+                    f"Value uses greater than 1 special character (^ ~ > *). Found {count}."
+                )
+
+        return value
+
+    @root_validator(skip_on_failure=True)
+    @classmethod
+    def version_upgrade_supported_validator(cls, values):
+        """Validates specified `version` meets `upgrade_supported` requirement."""
+        if not verify_requirements(
+            version=values.get("version"), requirement=values.get("upgrade_supported")
+        ):
+            raise ValueError(
+                f"upgrade_supported value {values.get('upgrade_supported')} greater than version value {values.get('version')} for {values.get('name')}."
+            )
+
+        return values
+
+    def can_upgrade(self, dependency: "DependencyModel") -> bool:
+        """Compares two instances of :class:`DependencyModel` for upgradability.
+
+        Args:
+            dependency: a dependency model to compare this model against
+
+        Returns:
+            True if current model can upgrade from dependent model. Otherwise False
+        """
+        return verify_requirements(version=self.version, requirement=dependency.upgrade_supported)
+
+
+# --- CUSTOM EXCEPTIONS ---
+
+
+class UpgradeError(Exception):
+    """Base class for upgrade related exceptions in the module."""
+
+    def __init__(self, message: str, cause: Optional[str], resolution: Optional[str]):
+        super().__init__(message)
+        self.message = message
+        self.cause = cause or ""
+        self.resolution = resolution or ""
+
+    def __repr__(self):
+        """Representation of the UpgradeError class."""
+        return f"{type(self).__module__}.{type(self).__name__} - {str(vars(self))}"
+
+    def __str__(self):
+        """String representation of the UpgradeError class."""
+        return repr(self)
+
+
+class ClusterNotReadyError(UpgradeError):
+    """Exception flagging that the cluster is not ready to start upgrading.
+
+    For example, if the cluster fails :class:`DataUpgrade._on_pre_upgrade_check_action`
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual error resolution (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+class KubernetesClientError(UpgradeError):
+    """Exception flagging that a call to Kubernetes API failed.
+
+    For example, if the cluster fails :class:`DataUpgrade._set_rolling_update_partition`
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual error resolution (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+class VersionError(UpgradeError):
+    """Exception flagging that the old `version` fails to meet the new `upgrade_supported`s.
+
+    For example, upgrades from version `2.x` --> `4.x`,
+        but `4.x` only supports upgrading from `3.x` onwards
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual solutions to the error (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+class DependencyError(UpgradeError):
+    """Exception flagging that some new `dependency` is not being met.
+
+    For example, new version requires related App version `2.x`, but currently is `1.x`
+
+    Args:
+        message: string message to be logged out
+        cause: short human-readable description of the cause of the error
+        resolution: short human-readable instructions for manual solutions to the error (optional)
+    """
+
+    def __init__(self, message: str, cause: str, resolution: Optional[str] = None):
+        super().__init__(message, cause=cause, resolution=resolution)
+
+
+# --- CUSTOM EVENTS ---
+
+
+class UpgradeGrantedEvent(EventBase):
+    """Used to tell units that they can process an upgrade."""
+
+
+class UpgradeFinishedEvent(EventBase):
+    """Used to tell units that they finished the upgrade."""
+
+
+class UpgradeEvents(CharmEvents):
+    """Upgrade events.
+
+    This class defines the events that the lib can emit.
+    """
+
+    upgrade_granted = EventSource(UpgradeGrantedEvent)
+    upgrade_finished = EventSource(UpgradeFinishedEvent)
+
+
+# --- EVENT HANDLER ---
+
+
+class DataUpgrade(Object, ABC):
+    """Manages `upgrade` relation operations for in-place upgrades."""
+
+    STATES = ["recovery", "failed", "idle", "ready", "upgrading", "completed"]
+
+    on = UpgradeEvents()  # pyright: ignore [reportGeneralTypeIssues]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        dependency_model: BaseModel,
+        relation_name: str = "upgrade",
+        substrate: Literal["vm", "k8s"] = "vm",
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.dependency_model = dependency_model
+        self.relation_name = relation_name
+        self.substrate = substrate
+        self._upgrade_stack = None
+
+        # events
+        self.framework.observe(
+            self.charm.on[relation_name].relation_created, self._on_upgrade_created
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self.on_upgrade_changed
+        )
+        self.framework.observe(self.charm.on.upgrade_charm, self._on_upgrade_charm)
+        self.framework.observe(getattr(self.on, "upgrade_granted"), self._on_upgrade_granted)
+        self.framework.observe(getattr(self.on, "upgrade_finished"), self._on_upgrade_finished)
+
+        # actions
+        self.framework.observe(
+            getattr(self.charm.on, "pre_upgrade_check_action"), self._on_pre_upgrade_check_action
+        )
+        if self.substrate == "k8s":
+            self.framework.observe(
+                getattr(self.charm.on, "resume_upgrade_action"), self._on_resume_upgrade_action
+            )
+
+    @property
+    def peer_relation(self) -> Optional[Relation]:
+        """The upgrade peer relation."""
+        return self.charm.model.get_relation(self.relation_name)
+
+    @property
+    def app_units(self) -> Set[Unit]:
+        """The peer-related units in the application."""
+        if not self.peer_relation:
+            return set()
+
+        return set([self.charm.unit] + list(self.peer_relation.units))
+
+    @property
+    def state(self) -> Optional[str]:
+        """The unit state from the upgrade peer relation."""
+        if not self.peer_relation:
+            return None
+
+        return self.peer_relation.data[self.charm.unit].get("state", None)
+
+    @property
+    def stored_dependencies(self) -> Optional[BaseModel]:
+        """The application dependencies from the upgrade peer relation."""
+        if not self.peer_relation:
+            return None
+
+        if not (deps := self.peer_relation.data[self.charm.app].get("dependencies", "")):
+            return None
+
+        return type(self.dependency_model)(**json.loads(deps))
+
+    @property
+    def upgrade_stack(self) -> Optional[List[int]]:
+        """Gets the upgrade stack from the upgrade peer relation.
+
+        Unit.ids are ordered Last-In-First-Out (LIFO).
+            i.e unit.id at index `-1` is the first unit to upgrade.
+            unit.id at index `0` is the last unit to upgrade.
+
+        Returns:
+            List of integer unit.ids, ordered in upgrade order in a stack
+        """
+        if not self.peer_relation:
+            return None
+
+        # lazy-load
+        if self._upgrade_stack is None:
+            self._upgrade_stack = (
+                json.loads(self.peer_relation.data[self.charm.app].get("upgrade-stack", "[]"))
+                or None
+            )
+
+        return self._upgrade_stack
+
+    @upgrade_stack.setter
+    def upgrade_stack(self, stack: List[int]) -> None:
+        """Sets the upgrade stack to the upgrade peer relation.
+
+        Unit.ids are ordered Last-In-First-Out (LIFO).
+            i.e unit.id at index `-1` is the first unit to upgrade.
+            unit.id at index `0` is the last unit to upgrade.
+        """
+        if not self.peer_relation:
+            return
+
+        self.peer_relation.data[self.charm.app].update({"upgrade-stack": json.dumps(stack)})
+        self._upgrade_stack = stack
+
+    @property
+    def unit_states(self) -> list:
+        """Current upgrade state for all units.
+
+        Returns:
+            Unsorted list of upgrade states for all units.
+        """
+        if not self.peer_relation:
+            return []
+
+        return [self.peer_relation.data[unit].get("state", "") for unit in self.app_units]
+
+    @property
+    def cluster_state(self) -> Optional[str]:
+        """Current upgrade state for cluster units.
+
+        Determined from :class:`DataUpgrade.STATE`, taking the lowest ordinal unit state.
+
+        For example, if units in have states: `["ready", "upgrading", "completed"]`,
+            the overall state for the cluster is `ready`.
+
+        Returns:
+            String of upgrade state from the furthest behind unit.
+        """
+        if not self.unit_states:
+            return None
+
+        try:
+            return sorted(self.unit_states, key=self.STATES.index)[0]
+        except (ValueError, KeyError):
+            return None
+
+    @property
+    def idle(self) -> Optional[bool]:
+        """Flag for whether the cluster is in an idle upgrade state.
+
+        Returns:
+            True if all application units in idle state. Otherwise False
+        """
+        return self.cluster_state == "idle"
+
+    @abstractmethod
+    def pre_upgrade_check(self) -> None:
+        """Runs necessary checks validating the cluster is in a healthy state to upgrade.
+
+        Called by all units during :meth:`_on_pre_upgrade_check_action`.
+
+        Raises:
+            :class:`ClusterNotReadyError`: if cluster is not ready to upgrade
+        """
+        pass
+
+    def build_upgrade_stack(self) -> List[int]:
+        """Builds ordered iterable of all application unit.ids to upgrade in.
+
+        Called by leader unit during :meth:`_on_pre_upgrade_check_action`.
+
+        Returns:
+            Iterable of integer unit.ids, LIFO ordered in upgrade order
+                i.e `[5, 2, 4, 1, 3]`, unit `3` upgrades first, `5` upgrades last
+        """
+        # don't raise if k8s substrate, uses default statefulset order
+        if self.substrate == "k8s":
+            return []
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def log_rollback_instructions(self) -> None:
+        """Sets charm state and logs out rollback instructions.
+
+        Called by all units when `state=failed` found during :meth:`_on_upgrade_changed`.
+        """
+        pass
+
+    def _repair_upgrade_stack(self) -> None:
+        """Ensures completed units are re-added to the upgrade-stack after failure."""
+        # need to update the stack as it was not refreshed by rollback run of pre-upgrade-check
+        # avoids difficult health check implementation by charm-authors needing to exclude dead units
+
+        # if the first unit in the stack fails, the stack will be the same length as units
+        # i.e this block not ran
+        if (
+            self.cluster_state in ["failed", "recovery"]
+            and self.upgrade_stack
+            and len(self.upgrade_stack) != len(self.app_units)
+            and self.charm.unit.is_leader()
+        ):
+            new_stack = self.upgrade_stack
+            for unit in self.app_units:
+                unit_id = int(unit.name.split("/")[1])
+
+                # if a unit fails, it rolls back first
+                if unit_id not in new_stack:
+                    new_stack.insert(-1, unit_id)
+                    logger.debug(f"Inserted {unit_id} in to upgrade-stack - {new_stack}")
+
+            self.upgrade_stack = new_stack
+
+    def set_unit_failed(self, cause: Optional[str] = None) -> None:
+        """Sets unit `state=failed` to the upgrade peer data.
+
+        Args:
+            cause: short description of cause of failure
+        """
+        if not self.peer_relation:
+            return None
+
+        # needed to refresh the stack
+        # now leader pulls a fresh stack from newly updated relation data
+        if self.charm.unit.is_leader():
+            self._upgrade_stack = None
+
+        self.charm.unit.status = BlockedStatus(cause if cause else "")
+        self.peer_relation.data[self.charm.unit].update({"state": "failed"})
+        self.log_rollback_instructions()
+
+    def set_unit_completed(self) -> None:
+        """Sets unit `state=completed` to the upgrade peer data."""
+        if not self.peer_relation:
+            return None
+
+        # needed to refresh the stack
+        # now leader pulls a fresh stack from newly updated relation data
+        if self.charm.unit.is_leader():
+            self._upgrade_stack = None
+
+        self.charm.unit.status = MaintenanceStatus("upgrade completed")
+        self.peer_relation.data[self.charm.unit].update({"state": "completed"})
+
+        # Emit upgrade_finished event to run unit's post upgrade operations.
+        if self.substrate == "k8s":
+            logger.debug(
+                f"{self.charm.unit.name} has completed the upgrade, emitting `upgrade_finished` event..."
+            )
+            getattr(self.on, "upgrade_finished").emit()
+
+    def _on_upgrade_created(self, event: RelationCreatedEvent) -> None:
+        """Handler for `upgrade-relation-created` events."""
+        if not self.peer_relation:
+            event.defer()
+            return
+
+        # setting initial idle state needed to avoid execution on upgrade-changed events
+        self.peer_relation.data[self.charm.unit].update({"state": "idle"})
+
+        if self.charm.unit.is_leader():
+            logger.debug("Persisting dependencies to upgrade relation data...")
+            self.peer_relation.data[self.charm.app].update(
+                {"dependencies": json.dumps(self.dependency_model.dict())}
+            )
+
+    def _on_pre_upgrade_check_action(self, event: ActionEvent) -> None:
+        """Handler for `pre-upgrade-check-action` events."""
+        if not self.peer_relation:
+            event.fail(message="Could not find upgrade relation.")
+            return
+
+        if not self.charm.unit.is_leader():
+            event.fail(message="Action must be ran on the Juju leader.")
+            return
+
+        if self.cluster_state == "failed":
+            logger.info("Entering recovery state for rolling-back to previous version...")
+            self._repair_upgrade_stack()
+            self.charm.unit.status = BlockedStatus("ready to rollback application")
+            self.peer_relation.data[self.charm.unit].update({"state": "recovery"})
+            return
+
+        # checking if upgrade in progress
+        if self.cluster_state != "idle":
+            event.fail("Cannot run pre-upgrade checks, cluster already upgrading.")
+            return
+
+        try:
+            logger.info("Running pre-upgrade-check...")
+            self.pre_upgrade_check()
+
+            if self.substrate == "k8s":
+                logger.info("Building upgrade-stack for K8s...")
+                built_upgrade_stack = sorted(
+                    [int(unit.name.split("/")[1]) for unit in self.app_units]
+                )
+            else:
+                logger.info("Building upgrade-stack for VMs...")
+                built_upgrade_stack = self.build_upgrade_stack()
+
+            logger.debug(f"Built upgrade stack of {built_upgrade_stack}")
+
+        except ClusterNotReadyError as e:
+            logger.error(e)
+            event.fail(message=e.message)
+            return
+        except Exception as e:
+            logger.error(e)
+            event.fail(message="Unknown error found.")
+            return
+
+        logger.info("Setting upgrade-stack to relation data...")
+        self.upgrade_stack = built_upgrade_stack
+
+    def _on_resume_upgrade_action(self, event: ActionEvent) -> None:
+        """Handle resume upgrade action.
+
+        Continue the upgrade by setting the partition to the next unit.
+        """
+        if not self.peer_relation:
+            event.fail(message="Could not find upgrade relation.")
+            return
+
+        if not self.charm.unit.is_leader():
+            event.fail(message="Action must be ran on the Juju leader.")
+            return
+
+        if not self.upgrade_stack:
+            event.fail(message="Nothing to resume, upgrade stack unset.")
+            return
+
+        # Check whether this is being run after juju refresh was called
+        # (the size of the upgrade stack should match the number of total
+        # unit minus one).
+        if len(self.upgrade_stack) != len(self.peer_relation.units):
+            event.fail(message="Upgrade can be resumed only once after juju refresh is called.")
+            return
+
+        try:
+            next_partition = self.upgrade_stack[-1]
+            self._set_rolling_update_partition(partition=next_partition)
+            event.set_results({"message": f"Upgrade will resume on unit {next_partition}"})
+        except KubernetesClientError:
+            event.fail(message="Cannot set rolling update partition.")
+
+    def _upgrade_supported_check(self) -> None:
+        """Checks if previous versions can be upgraded to new versions.
+
+        Raises:
+            :class:`VersionError` if upgrading to existing `version` is not supported
+        """
+        keys = self.dependency_model.__fields__.keys()
+
+        compatible = True
+        incompatibilities: List[Tuple[str, str, str, str]] = []
+        for key in keys:
+            old_dep: DependencyModel = getattr(self.stored_dependencies, key)
+            new_dep: DependencyModel = getattr(self.dependency_model, key)
+
+            if not old_dep.can_upgrade(dependency=new_dep):
+                compatible = False
+                incompatibilities.append(
+                    (key, old_dep.version, new_dep.version, new_dep.upgrade_supported)
+                )
+
+        base_message = "Versions incompatible"
+        base_cause = "Upgrades only supported for specific versions"
+        if not compatible:
+            for incompat in incompatibilities:
+                base_message += (
+                    f", {incompat[0]} {incompat[1]} can not be upgraded to {incompat[2]}"
+                )
+                base_cause += f", {incompat[0]} versions satisfying requirement {incompat[3]}"
+
+            raise VersionError(
+                message=base_message,
+                cause=base_cause,
+            )
+
+    def _on_upgrade_charm(self, event: UpgradeCharmEvent) -> None:
+        """Handler for `upgrade-charm` events."""
+        # defer if not all units have pre-upgraded
+        if not self.peer_relation:
+            event.defer()
+            return
+
+        if not self.upgrade_stack:
+            logger.error("Cluster upgrade failed, ensure pre-upgrade checks are ran first.")
+            return
+
+        if self.substrate == "vm":
+            # for VM run version checks on leader only
+            if self.charm.unit.is_leader():
+                try:
+                    self._upgrade_supported_check()
+                except VersionError as e:  # not ready if not passed check
+                    logger.error(e)
+                    self.set_unit_failed()
+                    return
+            self.charm.unit.status = WaitingStatus("other units upgrading first...")
+            self.peer_relation.data[self.charm.unit].update({"state": "ready"})
+
+        else:
+            # for k8s run version checks only on highest ordinal unit
+            if (
+                self.charm.unit.name
+                == f"{self.charm.app.name}/{self.charm.app.planned_units() -1}"
+            ):
+                try:
+                    self._upgrade_supported_check()
+                except VersionError as e:  # not ready if not passed check
+                    logger.error(e)
+                    self.set_unit_failed()
+                    return
+            # On K8s an unit that receives the upgrade-charm event is upgrading
+            self.charm.unit.status = MaintenanceStatus("upgrading unit")
+            self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
+
+    def on_upgrade_changed(self, event: EventBase) -> None:
+        """Handler for `upgrade-relation-changed` events."""
+        if not self.peer_relation:
+            return
+
+        # if any other unit failed, don't continue with upgrade
+        if self.cluster_state == "failed":
+            logger.debug("Cluster failed to upgrade, exiting...")
+            return
+
+        if self.cluster_state == "recovery":
+            logger.debug("Cluster in recovery, deferring...")
+            event.defer()
+            return
+
+        # if all units completed, mark as complete
+        if not self.upgrade_stack:
+            if self.state == "completed" and self.cluster_state in ["idle", "completed"]:
+                logger.info("All units completed upgrade, setting idle upgrade state...")
+                self.charm.unit.status = ActiveStatus()
+                self.peer_relation.data[self.charm.unit].update({"state": "idle"})
+
+                if self.charm.unit.is_leader():
+                    logger.debug("Persisting new dependencies to upgrade relation data...")
+                    self.peer_relation.data[self.charm.app].update(
+                        {"dependencies": json.dumps(self.dependency_model.dict())}
+                    )
+                return
+
+            if self.cluster_state == "idle":
+                logger.debug("upgrade-changed event handled before pre-checks, exiting...")
+                return
+
+            logger.debug("Did not find upgrade-stack or completed cluster state, deferring...")
+            event.defer()
+            return
+
+        # upgrade ongoing, set status for waiting units
+        if "upgrading" in self.unit_states and self.state in ["idle", "ready"]:
+            self.charm.unit.status = WaitingStatus("other units upgrading first...")
+
+        # pop mutates the `upgrade_stack` attr
+        top_unit_id = self.upgrade_stack.pop()
+        top_unit = self.charm.model.get_unit(f"{self.charm.app.name}/{top_unit_id}")
+        top_state = self.peer_relation.data[top_unit].get("state")
+
+        # if top of stack is completed, leader pops it
+        if self.charm.unit.is_leader() and top_state == "completed":
+            logger.debug(f"{top_unit} has finished upgrading, updating stack...")
+
+            # writes the mutated attr back to rel data
+            self.peer_relation.data[self.charm.app].update(
+                {"upgrade-stack": json.dumps(self.upgrade_stack)}
+            )
+
+            # recurse on leader to ensure relation changed event not lost
+            # in case leader is next or the last unit to complete
+            self.on_upgrade_changed(event)
+
+        # if unit top of stack and all units ready (i.e stack), emit granted event
+        if (
+            self.charm.unit == top_unit
+            and top_state in ["ready", "upgrading"]
+            and self.cluster_state == "ready"
+        ):
+            logger.debug(
+                f"{top_unit.name} is next to upgrade, emitting `upgrade_granted` event and upgrading..."
+            )
+            self.charm.unit.status = MaintenanceStatus("upgrading...")
+            self.peer_relation.data[self.charm.unit].update({"state": "upgrading"})
+
+            try:
+                getattr(self.on, "upgrade_granted").emit()
+            except DependencyError as e:
+                logger.error(e)
+                self.set_unit_failed()
+                return
+
+    def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
+        """Handler for `upgrade-granted` events.
+
+        Handlers of this event must meet the following:
+            - SHOULD check for related application deps from :class:`DataUpgrade.dependencies`
+                - MAY raise :class:`DependencyError` if dependency not met
+            - MUST update unit `state` after validating the success of the upgrade, calling one of:
+                - :class:`DataUpgrade.set_unit_failed` if the unit upgrade fails
+                - :class:`DataUpgrade.set_unit_completed` if the unit upgrade succeeds
+            - MUST call :class:`DataUpgarde.on_upgrade_changed` on exit so event not lost on leader
+        """
+        # don't raise if k8s substrate, only return
+        if self.substrate == "k8s":
+            return
+
+        raise NotImplementedError
+
+    def _on_upgrade_finished(self, _) -> None:
+        """Handler for `upgrade-finished` events."""
+        if self.substrate == "vm" or not self.peer_relation:
+            return
+
+        # Emit the upgrade relation changed event in the leader to update the upgrade_stack.
+        if self.charm.unit.is_leader():
+            self.charm.on[self.relation_name].relation_changed.emit(
+                self.model.get_relation(self.relation_name)
+            )
+
+        # This hook shouldn't run for the last unit (the first that is upgraded). For that unit it
+        # should be done through an action after the upgrade success on that unit is double-checked.
+        unit_number = int(self.charm.unit.name.split("/")[1])
+        if unit_number == len(self.peer_relation.units):
+            logger.info(
+                f"{self.charm.unit.name} unit upgraded. Evaluate and run `resume-upgrade` action to continue upgrade"
+            )
+            return
+
+        # Also, the hook shouldn't run for the first unit (the last that is upgraded).
+        if unit_number == 0:
+            logger.info(f"{self.charm.unit.name} unit upgraded. Upgrade is complete")
+            return
+
+        try:
+            # Use the unit number instead of the upgrade stack to avoid race conditions
+            # (i.e. the leader updates the upgrade stack after this hook runs).
+            next_partition = unit_number - 1
+            logger.debug(f"Set rolling update partition to unit {next_partition}")
+            self._set_rolling_update_partition(partition=next_partition)
+        except KubernetesClientError:
+            logger.exception("Cannot set rolling update partition")
+            self.set_unit_failed()
+            self.log_rollback_instructions()
+
+    def _set_rolling_update_partition(self, partition: int) -> None:
+        """Patch the StatefulSet's `spec.updateStrategy.rollingUpdate.partition`.
+
+        Args:
+            partition: partition to set.
+
+        K8s only. It should decrement the rolling update strategy partition by using a code
+        like the following:
+
+            from lightkube.core.client import Client
+            from lightkube.core.exceptions import ApiError
+            from lightkube.resources.apps_v1 import StatefulSet
+
+            try:
+                patch = {"spec": {"updateStrategy": {"rollingUpdate": {"partition": partition}}}}
+                Client().patch(StatefulSet, name=self.charm.model.app.name, namespace=self.charm.model.name, obj=patch)
+                logger.debug(f"Kubernetes StatefulSet partition set to {partition}")
+            except ApiError as e:
+                if e.status.code == 403:
+                    cause = "`juju trust` needed"
+                else:
+                    cause = str(e)
+                raise KubernetesClientError("Kubernetes StatefulSet patch failed", cause)
+        """
+        if self.substrate == "vm":
+            return
+
+        raise NotImplementedError

--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -284,7 +284,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["pydantic>=1.10,<2"]
 
@@ -323,27 +323,26 @@ def verify_caret_requirements(version: str, requirement: str) -> bool:
     sem_version = build_complete_sem_ver(version)
     sem_requirement = build_complete_sem_ver(requirement)
 
-    # caret uses first non-zero character, not enough to just count '.
-    max_version_index = requirement.count(".")
-    for i, semver in enumerate(sem_requirement):
-        if semver != 0:
-            max_version_index = i
-            break
+    # caret uses first non-zero character, not enough to just count '.'
+    if sem_requirement[0] == 0:
+        max_version_index = requirement.count(".")
+        for i, semver in enumerate(sem_requirement):
+            if semver != 0:
+                max_version_index = i
+                break
+    else:
+        max_version_index = 0
 
     for i in range(3):
         # version higher than first non-zero
-        if (i < max_version_index) and (sem_version[i] > sem_requirement[i]):
+        if (i <= max_version_index) and (sem_version[i] != sem_requirement[i]):
             return False
 
         # version either higher or lower than first non-zero
-        if (i == max_version_index) and (sem_version[i] != sem_requirement[i]):
+        if (i > max_version_index) and (sem_version[i] < sem_requirement[i]):
             return False
 
-        # valid
-        if (i > max_version_index) and (sem_version[i] > sem_requirement[i]):
-            return True
-
-    return False
+    return True
 
 
 def verify_tilde_requirements(version: str, requirement: str) -> bool:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,6 +25,8 @@ maintainers:
 peers:
   database-peers:
     interface: mysql_peers
+  upgrade:
+    interface: upgrade
 
 provides:
   database:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2175,4 +2175,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1aec819c2821b48de7a65e60b02192175857f83e2bd52dfaa26c5286040a3972"
+content-hash = "9cad0c39845844280a3c0d574b5f086b3474d9f7128918678f6c108799efb78c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = []
 python = "^3.10"
 ops = "^2.5.0"
 tenacity = "^8.2.2"
+pydantic = "^1.10.7"
 boto3 = "^1.28.23"
 # TODO: Remove insecure dependency https://github.com/canonical/mysql-operator/issues/246
 pyopenssl = "^23.2.0"
@@ -21,7 +22,7 @@ pyopenssl = "^23.2.0"
 ops = ">=2.0.0"
 # grafana_agent/v0/cos_agent.py
 cosl = "*"
-pydantic = "<2"
+pydantic = "^1.10.7"
 # tls_certificates_interface/v1/tls_certificates.py
 cryptography = "*"
 jsonschema = "*"

--- a/src/charm.py
+++ b/src/charm.py
@@ -340,11 +340,9 @@ class MySQLOperatorCharm(MySQLCharmBase):
             and not self.unit_peer_data.get("unit-configured")
             and not self.unit_peer_data.get("unit-initialized")
             and not self.unit.is_leader()
+            and not self.upgrade.idle
         ):
-            # avoid changing status while in initialisation
-            return
-        if self.upgrade.cluster_state != "idle":
-            # avoid changing status while in upgrade
+            # avoid changing status while in initialising/upgrading
             return
 
         if self._is_unit_waiting_to_join_cluster():
@@ -518,7 +516,7 @@ class MySQLOperatorCharm(MySQLCharmBase):
             return False
 
         # Safeguard against starting while upgrading
-        if self.upgrade.cluster_state != "idle":
+        if not self.upgrade.idle:
             event.defer()
             return False
 

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -1,0 +1,14 @@
+{
+  "charm": {
+    "dependencies": {},
+    "name": "mysql",
+    "upgrade_supported": ">0",
+    "version": "1"
+  },
+  "snap": {
+    "dependencies": {},
+    "name": "charmed-mysql",
+    "upgrade_supported": "~8.0.31",
+    "version": "8.0.32"
+  }
+}

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -78,6 +78,10 @@ class MySQLFlushHostCacheError(Error):
     """Exception raised when there's an error flushing the MySQL host cache."""
 
 
+class MySQLInstallError(Error):
+    """Exception raised when there's an error installing MySQL."""
+
+
 class MySQL(MySQLBase):
     """Class to encapsulate all operations related to the MySQL instance and cluster.
 
@@ -170,15 +174,14 @@ class MySQL(MySQLBase):
             subprocess.run(["snap", "alias", "charmed-mysql.mysql", "mysql"], check=True)
 
             installed_by_mysql_server_file.touch(exist_ok=True)
-        except subprocess.CalledProcessError:
-            logger.exception("Failed to execute subprocess command")
-            raise
-        except (snap.SnapNotFoundError, snap.SnapError):
+        except snap.SnapError:
             logger.exception("Failed to install snaps")
+            # reraise SnapError exception so the caller can retry
             raise
-        except Exception:
-            logger.exception("Encountered an unexpected exception")
-            raise
+        except (subprocess.CalledProcessError, snap.SnapNotFoundError, Exception):
+            logger.exception("Failed to install and configure MySQL dependencies")
+            # other exceptions are not retried
+            raise MySQLInstallError
 
     def create_custom_mysqld_config(self, profile: str) -> None:
         """Create custom mysql config file.

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -1,0 +1,223 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Dependency model for MySQL."""
+
+import bisect
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from charms.data_platform_libs.v0.upgrade import (
+    ClusterNotReadyError,
+    DataUpgrade,
+    DependencyModel,
+    UpgradeGrantedEvent,
+    VersionError,
+)
+from charms.mysql.v0.mysql import (
+    MySQLServerNotUpgradableError,
+    MySQLSetClusterPrimaryError,
+    MySQLSetVariableError,
+)
+from ops.model import BlockedStatus, MaintenanceStatus, Unit
+from pydantic import BaseModel
+from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
+logger = logging.getLogger(__name__)
+
+
+class MySQLVMDependenciesModel(BaseModel):
+    """MySQL dependencies model."""
+
+    charm: DependencyModel
+    snap: DependencyModel
+
+
+def get_mysql_dependencies_model() -> MySQLVMDependenciesModel:
+    """Return the MySQL dependencies model."""
+    with open("src/dependency.json") as dependency_file:
+        _deps = json.load(dependency_file)
+    return MySQLVMDependenciesModel(**_deps)
+
+
+class MySQLVMUpgrade(DataUpgrade):
+    """MySQL upgrade class."""
+
+    def __init__(self, charm: "MySQLOperatorCharm", **kwargs) -> None:
+        """Initialize the class."""
+        super().__init__(charm, **kwargs)
+        self.charm = charm
+
+    @override
+    def build_upgrade_stack(self) -> list[int]:
+        """Build the upgrade stack.
+
+        This/leader/primary will be the last and others ordered by unit number.
+        Higher unit number will be upgraded first.
+        """
+
+        def unit_number(unit: Unit) -> int:
+            """Return the unit number."""
+            return int(unit.name.split("/")[1])
+
+        upgrade_stack = []
+        for unit in self.peer_relation.units:
+            bisect.insort(upgrade_stack, unit_number(unit))
+
+        upgrade_stack.insert(0, unit_number(self.charm.unit))
+        return upgrade_stack
+
+    @override
+    def pre_upgrade_check(self) -> None:
+        """Run pre-upgrade checks."""
+        fail_message = "Pre-upgrade check failed. Cannot upgrade."
+
+        def _online_instances(status_dict: dict) -> int:
+            """Return the number of online instances from status dict."""
+            return [
+                item["status"]
+                for item in status_dict["defaultreplicaset"]["topology"].values()
+                if not item.get("instanceerrors", [])
+            ].count("online")
+
+        if cluster_status := self.charm._mysql.get_cluster_status(extended=True):
+            if _online_instances(cluster_status) < self.charm.app.planned_units():
+                # case any not fully online unit is found
+                raise ClusterNotReadyError(
+                    message=fail_message,
+                    cause="Not all units are online",
+                    resolution="Ensure all units are online in the cluster",
+                )
+        else:
+            # case cluster status is not available
+            # it may be due to the refresh being ran before
+            # the pre-upgrade-check action
+            raise ClusterNotReadyError(
+                message=fail_message,
+                cause="Failed to retrieve cluster status",
+                resolution="Ensure that mysqld is running for this unit",
+            )
+
+        try:
+            self._pre_upgrade_prepare()
+        except MySQLSetClusterPrimaryError:
+            raise ClusterNotReadyError(
+                message=fail_message,
+                cause="Failed to set primary",
+                resolution="Check the cluster status",
+            )
+        except MySQLSetVariableError:
+            raise ClusterNotReadyError(
+                message=fail_message,
+                cause="Failed to set slow shutdown",
+                resolution="Check the cluster status",
+            )
+
+    @override
+    def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
+        """Handle the upgrade granted event."""
+        self.charm._mysql.stop_mysqld()
+
+        self.charm.unit.status = MaintenanceStatus("upgrading snap")
+        try:
+            self.charm._mysql.install_and_configure_mysql_dependencies()
+        except Exception:
+            logger.exception("Failed to install and configure MySQL dependencies")
+            self.set_unit_failed()
+            return
+
+        try:
+            self._check_server_upgradeability()
+        except VersionError:
+            self.set_unit_failed()
+            return
+
+        self.charm._mysql.start_mysqld()
+        self.charm.unit.status = MaintenanceStatus("recovering unit after upgrade")
+
+        try:
+            for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(10)):
+                with attempt:
+                    if not self.charm._mysql.is_instance_in_cluster(self.charm.unit_label):
+                        logger.debug(
+                            "Instance not yet back in the cluster."
+                            f" Retry {attempt.retry_state.attempt_number}/6"
+                        )
+                        raise Exception
+                    logger.debug("Upgraded unit is healthy. Set upgrade state to `completed`")
+                    self.set_unit_completed()
+                    # call update status asap
+                    self.charm._on_update_status(None)
+                    # ensures leader gets it's own relation-changed when it upgrades
+                    if self.charm.unit.is_leader():
+                        logger.debug("Re-emitting upgrade-changed on leader...")
+                        self.on_upgrade_changed(event)
+        except RetryError:
+            logger.debug("Upgraded unit is not healthy")
+            self.set_unit_failed()
+            self.charm.unit.status = BlockedStatus(
+                "upgrade failed. Check logs for rollback instruction"
+            )
+
+    @override
+    def log_rollback_instructions(self) -> None:
+        """Log rollback instructions."""
+        logger.critical(
+            "\n".join(
+                (
+                    "Upgrade failed, follow the instructions below to rollback:",
+                    "    1. Re-run `pre-upgrade-check` action on the leader unit to enter 'recovery' state",
+                    "    2. Run `juju refresh` to the previously deployed charm revision",
+                )
+            )
+        )
+
+    def _pre_upgrade_prepare(self) -> None:
+        """Pre upgrade routine for MySQL.
+
+        Set primary to the leader (this) unit to mitigate switchover during upgrade,
+        and set slow shutdown to all instances.
+        """
+        if self.charm._mysql.get_primary_label() != self.charm.unit_label:
+            # set the primary to the leader unit for switchover mitigation
+            self.charm._mysql.set_cluster_primary(self.charm.get_unit_ip(self.charm.unit))
+
+        # set slow shutdown on all instances
+        for unit in self.app_units:
+            unit_address = self.charm.get_unit_ip(unit)
+            self.charm._mysql.set_dynamic_variable(
+                variable="innodb_fast_shutdown", value="0", instance_address=unit_address
+            )
+
+    @override
+    def _upgrade_supported_check(self) -> None:
+        """Check if the upgrade is supported."""
+        # use parent class method and...
+        super()._upgrade_supported_check()
+        # ...own mysql checks
+        self._check_server_upgradeability()
+
+    def _check_server_upgradeability(self) -> None:
+        """Check if the server can be upgraded.
+
+        Use mysql-shell upgrade checker utility to ensure server upgradeability.
+
+        Raises:
+            VersionError: If the server is not upgradeable.
+        """
+        try:
+            instance = self.charm.get_unit_ip(self.charm.unit)
+            self.charm._mysql.verify_server_upgradable(instance=instance)
+            logger.debug("MySQL server is upgradeable")
+        except MySQLServerNotUpgradableError as e:
+            logger.error("MySQL server is not upgradeable")
+            raise VersionError(
+                message="Cannot upgrade MySQL server",
+                cause=e.message,
+                resolution="Check mysql-shell upgrade utility output",
+            )

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -1,0 +1,89 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from integration.helpers import (
+    get_primary_unit_wrapper,
+    retrieve_database_variable_value,
+)
+from integration.high_availability.high_availability_helpers import (
+    ensure_all_units_continuous_writes_incrementing,
+    high_availability_test_setup,
+)
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT = 15 * 60
+
+
+@pytest.mark.group(1)
+async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> None:
+    """Simple test to ensure that the mysql and application charms get deployed."""
+    await high_availability_test_setup(ops_test, mysql_charm_series)
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_pre_upgrade_check(ops_test: OpsTest, mysql_charm_series: str) -> None:
+    """Test that the pre-upgrade-check action runs successfully."""
+    mysql_app_name, _ = await high_availability_test_setup(ops_test, mysql_charm_series)
+
+    mysql_units = ops_test.model.applications[mysql_app_name].units
+
+    logger.info("Get leader unit")
+    leader_unit = None
+    for unit in mysql_units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+            break
+
+    assert leader_unit is not None, "No leader unit found"
+    logger.info("Run pre-upgrade-check action")
+    action = await leader_unit.run_action("pre-upgrade-check")
+    await action.wait()
+
+    logger.info("Assert slow shutdown is enabled")
+    for unit in mysql_units:
+        value = await retrieve_database_variable_value(ops_test, unit, "innodb_fast_shutdown")
+        assert value == 0, f"innodb_fast_shutdown not 0 at {unit.name}"
+
+    primary_unit = await get_primary_unit_wrapper(ops_test, mysql_app_name)
+
+    logger.info("Assert primary is set to leader")
+    assert await primary_unit.is_leader_from_status(), "Primary unit not set to leader"
+
+
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_upgrade_charms(
+    ops_test: OpsTest, continuous_writes, mysql_charm_series: str
+) -> None:
+    mysql_app_name, _ = await high_availability_test_setup(ops_test, mysql_charm_series)
+    logger.info("Ensure continuous_writes")
+    await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+    logger.info("Refresh the charm")
+    application = ops_test.model.applications[mysql_app_name]
+    charm = await ops_test.build_charm(".")
+    await application.refresh(path=charm)
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[mysql_app_name], status="active", timeout=TIMEOUT)
+
+    mysql_units = ops_test.model.applications[mysql_app_name].units
+    leader_unit = None
+    for unit in mysql_units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+            break
+
+    assert leader_unit is not None, "No leader unit found"
+    logger.info("Wait for upgrade to complete")
+    await ops_test.model.wait_for_idle(
+        apps=[mysql_app_name], status="active", idle_period=30, timeout=TIMEOUT
+    )
+
+    logger.info("Ensure continuous_writes")
+    await ensure_all_units_continuous_writes_incrementing(ops_test)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,12 +35,13 @@ class TestCharm(unittest.TestCase):
         self.charm = self.harness.charm
 
     @patch_network_get(private_address="1.1.1.1")
+    @patch("upgrade.MySQLVMUpgrade.cluster_state", return_value="idle")
     @patch("socket.getfqdn", return_value="test-hostname")
     @patch("socket.gethostbyname", return_value="")
     @patch("subprocess.check_call")
     @patch("mysql_vm_helpers.is_volume_mounted", return_value=True)
     @patch("mysql_vm_helpers.MySQL.install_and_configure_mysql_dependencies")
-    def test_on_install(self, _install_and_configure_mysql_dependencies, ____, ___, __, _):
+    def test_on_install(self, _install_and_configure_mysql_dependencies, ____, ___, __, _, _____):
         self.charm.on.install.emit()
         _install_and_configure_mysql_dependencies.assert_called_once()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -28,11 +28,15 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(MySQLOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+        self.charm = self.harness.charm
         self.peer_relation_id = self.harness.add_relation("database-peers", "database-peers")
+        upgrade_relation_id = self.harness.add_relation("upgrade", "upgrade")
+        self.harness.update_relation_data(
+            upgrade_relation_id, self.charm.unit.name, {"state": "idle"}
+        )
         self.harness.add_relation_unit(self.peer_relation_id, "mysql/1")
         self.db_router_relation_id = self.harness.add_relation("db-router", "app")
         self.harness.add_relation_unit(self.db_router_relation_id, "app/0")
-        self.charm = self.harness.charm
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("upgrade.MySQLVMUpgrade.cluster_state", return_value="idle")

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -1,0 +1,210 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import call, patch
+
+from charms.data_platform_libs.v0.upgrade import ClusterNotReadyError, VersionError
+from charms.mysql.v0.mysql import (
+    MySQLServerNotUpgradableError,
+    MySQLSetClusterPrimaryError,
+    MySQLSetVariableError,
+    MySQLStopMySQLDError,
+)
+from ops.testing import Harness
+
+from charm import MySQLOperatorCharm
+
+MOCK_STATUS_ONLINE = {
+    "defaultreplicaset": {
+        "topology": {
+            "0": {"status": "online"},
+            "1": {"status": "online"},
+        },
+    }
+}
+MOCK_STATUS_OFFLINE = {
+    "defaultreplicaset": {
+        "topology": {
+            "0": {"status": "online"},
+            "1": {"status": "online", "instanceerrors": ["some error"]},
+        },
+    }
+}
+
+
+class TestUpgrade(unittest.TestCase):
+    """Test the upgrade class."""
+
+    def setUp(self):
+        """Set up the test."""
+        self.harness = Harness(MySQLOperatorCharm)
+        self.harness.begin()
+        self.upgrade_relation_id = self.harness.add_relation("upgrade", "mysql")
+        self.peer_relation_id = self.harness.add_relation("database-peers", "mysql")
+        for rel_id in (self.upgrade_relation_id, self.peer_relation_id):
+            self.harness.add_relation_unit(rel_id, "mysql/1")
+        self.harness.update_relation_data(self.upgrade_relation_id, "mysql/1", {"state": "idle"})
+        self.harness.update_relation_data(
+            self.peer_relation_id,
+            "mysql",
+            {"cluster-name": "test_cluster", "cluster-set-domain-name": "test_cluster_set"},
+        )
+        self.charm = self.harness.charm
+
+    def test_build_upgrade_stack(self):
+        """Test building the upgrade stack."""
+        self.harness.add_relation_unit(self.upgrade_relation_id, "mysql/2")
+        us = self.charm.upgrade.build_upgrade_stack()
+        self.assertTrue(len(us) == 3)
+        self.assertEqual(us, [0, 1, 2])
+
+    @patch("charm.MySQLOperatorCharm.get_unit_ip", return_value="10.0.1.1")
+    @patch("upgrade.MySQLVMUpgrade._pre_upgrade_prepare")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_status", return_value=MOCK_STATUS_ONLINE)
+    def test_pre_upgrade_check(
+        self, mock_get_cluster_status, mock_pre_upgrade_prepare, mock_get_unit_ip
+    ):
+        """Test the pre upgrade check."""
+        self.harness.set_leader(True)
+        self.charm.on.config_changed.emit()
+
+        self.charm.upgrade.pre_upgrade_check()
+        mock_pre_upgrade_prepare.assert_called_once()
+        mock_get_cluster_status.assert_called_once()
+
+        self.assertEqual(
+            self.harness.get_relation_data(self.upgrade_relation_id, "mysql/0")["state"],
+            "idle",
+        )
+
+        mock_get_cluster_status.return_value = MOCK_STATUS_OFFLINE
+
+        with self.assertRaises(ClusterNotReadyError):
+            self.charm.upgrade.pre_upgrade_check()
+
+        mock_get_cluster_status.return_value = MOCK_STATUS_ONLINE
+
+        mock_pre_upgrade_prepare.side_effect = MySQLSetClusterPrimaryError
+        with self.assertRaises(ClusterNotReadyError):
+            self.charm.upgrade.pre_upgrade_check()
+
+        mock_pre_upgrade_prepare.side_effect = MySQLSetVariableError
+        with self.assertRaises(ClusterNotReadyError):
+            self.charm.upgrade.pre_upgrade_check()
+
+    @patch("upgrade.logger.critical")
+    def test_log_rollback(self, mock_logging):
+        """Test roolback logging."""
+        self.charm.upgrade.log_rollback_instructions()
+        calls = [
+            call(
+                "Upgrade failed, follow the instructions below to rollback:\n"
+                "    1. Re-run `pre-upgrade-check` action on the leader unit to enter 'recovery' state\n"
+                "    2. Run `juju refresh` to the previously deployed charm revision or local charm file"
+            )
+        ]
+        mock_logging.assert_has_calls(calls)
+
+    @patch("charm.MySQLOperatorCharm.get_unit_ip", return_value="10.0.1.1")
+    @patch("mysql_vm_helpers.MySQL.set_dynamic_variable")
+    @patch("mysql_vm_helpers.MySQL.get_primary_label", return_value="mysql-1")
+    @patch("mysql_vm_helpers.MySQL.set_cluster_primary")
+    def test_pre_upgrade_prepare(
+        self,
+        mock_set_cluster_primary,
+        mock_get_primary_label,
+        mock_set_dynamic_variable,
+        mock_get_unit_ip,
+    ):
+        """Test the pre upgrade prepare."""
+        self.harness.set_leader(True)
+        self.charm.on.config_changed.emit()
+
+        self.charm.upgrade._pre_upgrade_prepare()
+
+        mock_set_cluster_primary.assert_called_once()
+        mock_get_primary_label.assert_called_once()
+        assert mock_set_dynamic_variable.call_count == 2
+
+    @patch("upgrade.RECOVER_ATTEMPTS", 1)
+    @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.33")
+    @patch("charm.MySQLOperatorCharm.install_workload", return_value=True)
+    @patch("charm.MySQLOperatorCharm.get_unit_ip", return_value="10.0.1.1")
+    @patch("mysql_vm_helpers.MySQL.stop_mysqld")
+    @patch("mysql_vm_helpers.MySQL.start_mysqld")
+    @patch("upgrade.MySQLVMUpgrade._check_server_upgradeability")
+    @patch("mysql_vm_helpers.MySQL.is_instance_in_cluster", return_value=True)
+    def test_upgrade_granted(
+        self,
+        mock_is_instance_in_cluster,
+        mock_check_server_upgradeability,
+        mock_start_mysqld,
+        mock_stop_mysqld,
+        mock_get_unit_ip,
+        mock_install_workload,
+        mock_get_mysql_version,
+    ):
+        """Test the pebble ready."""
+        self.charm.on.config_changed.emit()
+        self.harness.update_relation_data(
+            self.upgrade_relation_id, "mysql/0", {"state": "upgrading"}
+        )
+        self.charm.upgrade._on_upgrade_granted(None)
+        self.assertEqual(
+            self.harness.get_relation_data(self.upgrade_relation_id, "mysql/1")["state"],
+            "idle",  # change to `completed` - behavior not yet set in the lib
+        )
+        mock_is_instance_in_cluster.assert_called_once()
+        mock_check_server_upgradeability.assert_called_once()
+        mock_start_mysqld.assert_called_once()
+        mock_stop_mysqld.assert_called_once()
+        mock_install_workload.assert_called_once()
+        mock_get_mysql_version.assert_called_once()
+
+        self.harness.update_relation_data(
+            self.upgrade_relation_id, "mysql/0", {"state": "upgrading"}
+        )
+        # setup for exception
+        mock_is_instance_in_cluster.return_value = False
+
+        self.charm.upgrade._on_upgrade_granted(None)
+        self.assertEqual(
+            self.harness.get_relation_data(self.upgrade_relation_id, "mysql/0")["state"], "failed"
+        )
+
+        self.harness.update_relation_data(
+            self.upgrade_relation_id, "mysql/0", {"state": "upgrading"}
+        )
+        mock_check_server_upgradeability.side_effect = VersionError(message="foo", cause="bar")
+        self.charm.upgrade._on_upgrade_granted(None)
+        self.assertEqual(
+            self.harness.get_relation_data(self.upgrade_relation_id, "mysql/0")["state"], "failed"
+        )
+
+        self.harness.update_relation_data(
+            self.upgrade_relation_id, "mysql/0", {"state": "upgrading"}
+        )
+        mock_stop_mysqld.side_effect = MySQLStopMySQLDError
+        self.charm.upgrade._on_upgrade_granted(None)
+        self.assertEqual(
+            self.harness.get_relation_data(self.upgrade_relation_id, "mysql/0")["state"], "failed"
+        )
+
+    @patch("charm.MySQLOperatorCharm.get_unit_ip", return_value="10.0.1.1")
+    @patch("mysql_vm_helpers.MySQL.verify_server_upgradable")
+    def test_check_server_upgradeability(self, mock_is_server_upgradeable, mock_get_unit_ip):
+        """Test the server upgradeability check."""
+        self.charm.upgrade.upgrade_stack = [0, 1]
+        self.charm.upgrade._check_server_upgradeability()
+        mock_is_server_upgradeable.assert_called_once()
+        mock_get_unit_ip.assert_called_once()
+
+        mock_is_server_upgradeable.side_effect = MySQLServerNotUpgradableError
+        with self.assertRaises(VersionError):
+            self.charm.upgrade._check_server_upgradeability()
+
+        self.charm.upgrade.upgrade_stack = [0]
+        mock_is_server_upgradeable.reset_mock()
+        self.charm.upgrade._check_server_upgradeability()
+        mock_is_server_upgradeable.assert_not_called()


### PR DESCRIPTION
### In place upgrades for mysql vm

Usage upgrade lib and follow procedure per spec.

## Solution

Implemented upgrade module, unit test and simple case integration test.
To follow:
* rollback testing
* test with patched snap versions
* discourse doc page

### Manual Testing (with same local built charm)

Instructions (happy path):

```shell

git clone git@github.com:canonical/mysql-operator.git
cd mysql-operator
git checkout feature/dpe-1800-in-place-upgrade

charmcraft pack
# deploy local charm
juju deploy ./*.charm -n 3

# After units settle, run pre-upgrade-check to build update-stack.
# This will change primary to the leader if not already
juju run-action mysql/leader pre-upgrade-check --wait

# inspect update relation data
juju show-unit mysql/0|yq '.*.relation-info[]|select(.endpoint=="upgrade")'

# refresh command - we are updating to the same charm, which will pass version checking
# optionally, patch the `src/constants.py`, bump snap revision (66->67) and pack the charm
juju refresh --path ./*.charm mysql

# enjoy the process

```

