### PR TITLE
DPE-2390 upgrade rollback test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -325,7 +325,7 @@ class MySQLOperatorCharm(MySQLCharmBase):
             and not self.unit_peer_data.get("unit-configured")
             and not self.unit_peer_data.get("unit-initialized")
             and not self.unit.is_leader()
-            and not self.upgrade.idle
+            and (self.upgrade.peer_relation and not self.upgrade.idle)
         ):
             # avoid changing status while in initialising/upgrading
             return
@@ -443,7 +443,7 @@ class MySQLOperatorCharm(MySQLCharmBase):
             return "Primary"
         return ""
 
-    def install_workload(self) -> bool:
+    def install_workload(self, upgrading: bool = False) -> bool:
         """Exponential backoff retry to install and configure MySQL.
 
         Returns: True if successful, False otherwise.
@@ -462,7 +462,7 @@ class MySQLOperatorCharm(MySQLCharmBase):
                 after=set_retry_status,
             ):
                 with attempt:
-                    MySQL.install_and_configure_mysql_dependencies()
+                    MySQL.install_and_configure_mysql_dependencies(ignore_multiple=upgrading)
         except (RetryError, MySQLInstallError):
             return False
         return True

--- a/src/dependency.json
+++ b/src/dependency.json
@@ -9,6 +9,6 @@
     "dependencies": {},
     "name": "charmed-mysql",
     "upgrade_supported": "~8.0.31",
-    "version": "8.0.32"
+    "version": "8.0.33"
   }
 }

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -155,7 +155,8 @@ class MySQLVMUpgrade(DataUpgrade):
             )
             # call leader elected handler to populate any missing data
             self.charm._on_leader_elected(None)
-            # TODO: remove root@%
+            # remove root@%
+            self.charm._mysql.delete_user("root@%")
             # TODO: create backup user
 
     @override

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -404,6 +404,7 @@ def cluster_name(unit: Unit, model_name: str) -> str:
     for relation in output[unit.name]["relation-info"]:
         if relation["endpoint"] == "database-peers":
             return relation["application-data"]["cluster-name"]
+    logger.error(f"Failed to retrieve cluster name from unit {unit.name}")
     raise ValueError("Failed to retrieve cluster name")
 
 
@@ -647,6 +648,16 @@ def get_read_only_endpoints(relation_data: list) -> Set[str]:
             raise ValueError("Relation data are not valid JSON.")
 
     return read_only_endpoints
+
+
+async def get_leader_unit(ops_test: OpsTest, app_name: str) -> Optional[Unit]:
+    leader_unit = None
+    for unit in ops_test.model.applications[app_name].units:
+        if await unit.is_leader_from_status():
+            leader_unit = unit
+            break
+
+    return leader_unit
 
 
 def get_read_only_endpoint_ips(relation_data: list) -> List[str]:

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -69,10 +69,13 @@ def get_application_name(ops_test: OpsTest, application_name_substring: str) -> 
     the first one found will be returned.
     """
     for application in ops_test.model.applications:
-        if application_name_substring in application:
+        if (
+            application_name_substring in application
+            and application != APPLICATION_DEFAULT_APP_NAME
+        ):
             return application
 
-    return None
+    return ""
 
 
 async def ensure_n_online_mysql_members(
@@ -106,7 +109,8 @@ async def ensure_n_online_mysql_members(
                 assert len(online_members) == number_online_members
                 return True
     except RetryError:
-        return False
+        pass
+    return False
 
 
 async def deploy_and_scale_mysql(

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -434,18 +434,23 @@ class TestMySQL(unittest.TestCase):
         with self.assertRaises(MySQLStartMySQLDError):
             self.mysql.start_mysqld()
 
+    @patch("os.system")
     @patch("pathlib.Path")
     @patch("subprocess.check_call")
     @patch("subprocess.run")
     @patch("os.path.exists", return_value=True)
     @patch("mysql_vm_helpers.snap.SnapCache")
-    def test_install_snap(self, _cache, _path_exists, _run, _check_call, _pathlib):
+    def test_install_snap(self, _cache, _path_exists, _run, _check_call, _pathlib, _system):
         """Test execution of install_snap()."""
         _mysql_snap = MagicMock()
         _cache.return_value = {CHARMED_MYSQL_SNAP_NAME: _mysql_snap}
 
+        common_path_mock = MagicMock()
+
         _mysql_snap.present = False
         _path_exists.return_value = False
+        _pathlib.return_value = common_path_mock
+        common_path_mock.exists.return_value = False
 
         self.mysql.install_and_configure_mysql_dependencies()
 


### PR DESCRIPTION
## Issue

Additionally to upgrade happy path, we need test rollback and upgrade from `8.0/stable`

## To make it work:

**Upgrade from 8.0/stable - revision 151**
1. fix permission ownership for `/var/snap/charmed-mysql/common` from root to snap daemon after snap refresh ✅
2. add flag to bypass lack of `installed-by-charmed-mysql` file, avoid multiple snaps exceptions ✅
3. create `upgrade-peer-relation` data:
	1. each unit add `state="ready"` ✅
	2. leader unit populates `upgrade_stack` ✅
	3. leader unit populate `dependencies` structure ✅
4. leader unit runs `charm.leader-elected` hook to create missing backup user password ✅
5. leader unit remove `root@%` user ✅
6. leader unit create `backup@%` user 

**Upgrade from 8.0/edge**
1. No adaptations
