### PR TITLE
Replace `poetry lock --check` with `poetry check --lock`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ allowlist_externals =
 commands_pre =
     poetry install --only lint
 commands =
-    poetry lock --check
+    poetry check --lock
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
     poetry run codespell {[vars]all_path}


### PR DESCRIPTION
Poetry 1.6.0 deprecated `poetry lock --check` https://github.com/python-poetry/poetry/pull/8015
