### PR TITLE
Use 60s interval for fast forward instead of 5s

### DIFF
--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -139,7 +139,7 @@ async def deploy_and_scale_mysql(
 
     config = {"cluster-name": CLUSTER_NAME, "profile": "testing"}
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.deploy(
             charm,
             application_name=mysql_application_name,
@@ -174,7 +174,7 @@ async def deploy_and_scale_application(ops_test: OpsTest) -> str:
 
         return application_name
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.deploy(
             APPLICATION_DEFAULT_APP_NAME,
             application_name=APPLICATION_DEFAULT_APP_NAME,

--- a/tests/integration/high_availability/test_replication.py
+++ b/tests/integration/high_availability/test_replication.py
@@ -159,7 +159,7 @@ async def test_kill_primary_check_reelection(ops_test: OpsTest, mysql_charm_seri
     logger.info("Destroying leader unit")
     await ops_test.model.destroy_units(primary_unit.name)
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(lambda: len(application.units) == 2)
         await ops_test.model.wait_for_idle(
             apps=[mysql_application_name],
@@ -174,7 +174,7 @@ async def test_kill_primary_check_reelection(ops_test: OpsTest, mysql_charm_seri
     assert primary_unit_name != new_primary_unit.name, "Primary has not changed"
 
     # Add the unit back and wait until it is active
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         logger.info("Scaling back to 3 units")
         await scale_application(ops_test, mysql_application_name, 3)
 
@@ -225,7 +225,7 @@ async def test_scaling_without_data_loss(ops_test: OpsTest, mysql_charm_series: 
     old_unit_names = [unit.name for unit in ops_test.model.applications[app].units]
 
     # Add a unit and wait until it is active
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await scale_application(ops_test, app, 4)
 
     added_unit = [unit for unit in application.units if unit.name not in old_unit_names][0]
@@ -247,7 +247,7 @@ async def test_scaling_without_data_loss(ops_test: OpsTest, mysql_charm_series: 
 
     # Destroy the recently created unit and wait until the application is active
     await ops_test.model.destroy_units(added_unit.name)
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(lambda: len(ops_test.model.applications[app].units) == 3)
         await ops_test.model.wait_for_idle(
             apps=[app],
@@ -288,7 +288,7 @@ async def test_cluster_isolation(ops_test: OpsTest, mysql_charm_series: str) -> 
         num_units=1,
         series=mysql_charm_series,
     )
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[ANOTHER_APP_NAME].units) == 1
         )

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -69,7 +69,7 @@ async def test_upgrade_charms(
     application = ops_test.model.applications[mysql_app_name]
     charm = await ops_test.build_charm(".")
     await application.refresh(path=charm)
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.wait_for_idle(apps=[mysql_app_name], status="active", timeout=TIMEOUT)
 
     mysql_units = ops_test.model.applications[mysql_app_name].units

--- a/tests/integration/relations/test_database.py
+++ b/tests/integration/relations/test_database.py
@@ -72,7 +72,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> N
     )
 
     # Reduce the update_status frequency until the cluster is deployed
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[DATABASE_APP_NAME].units) == 3
         )
@@ -244,7 +244,7 @@ async def test_relation_creation(ops_test: OpsTest):
         f"{APPLICATION_APP_NAME}:{ENDPOINT}", f"{DATABASE_APP_NAME}:{ENDPOINT}"
     )
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(
             lambda: is_relation_joined(ops_test, ENDPOINT, ENDPOINT) == True  # noqa: E712
         )
@@ -265,14 +265,14 @@ async def test_read_only_endpoints(ops_test: OpsTest):
     )
 
     # increase the number of units
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await scale_application(ops_test, DATABASE_APP_NAME, 4)
     await check_read_only_endpoints(
         ops_test=ops_test, app_name=DATABASE_APP_NAME, relation_name=DB_RELATION_NAME
     )
 
     # decrease the number of units
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await scale_application(ops_test, DATABASE_APP_NAME, 2)
 
     # wait for the update of the endpoints
@@ -287,7 +287,7 @@ async def test_read_only_endpoints(ops_test: OpsTest):
         assert False
 
     # increase the number of units
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await scale_application(ops_test, DATABASE_APP_NAME, 3)
 
     # remove the leader unit
@@ -317,7 +317,7 @@ async def test_relation_broken(ops_test: OpsTest):
         lambda: is_relation_broken(ops_test, ENDPOINT, ENDPOINT) is True
     )
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await asyncio.gather(
             ops_test.model.wait_for_idle(
                 apps=[DATABASE_APP_NAME], status="active", raise_on_blocked=True

--- a/tests/integration/relations/test_db_router.py
+++ b/tests/integration/relations/test_db_router.py
@@ -148,7 +148,7 @@ async def test_keystone_bundle_db_router(ops_test: OpsTest, mysql_charm_series: 
     )
 
     # Reduce the update_status frequency for the duration of the test
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await asyncio.gather(
             ops_test.model.block_until(
                 lambda: mysql_app.status in ("active", "error"), timeout=SLOW_WAIT_TIMEOUT

--- a/tests/integration/relations/test_relation_mysql_legacy.py
+++ b/tests/integration/relations/test_relation_mysql_legacy.py
@@ -60,7 +60,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> N
     )
 
     # Reduce the update_status frequency until the cluster is deployed
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[DATABASE_APP_NAME].units) == 3, timeout=TIMEOUT
         )
@@ -107,7 +107,7 @@ async def test_relation_creation(ops_test: OpsTest):
         f"{APPLICATION_APP_NAME}:{ENDPOINT}", f"{DATABASE_APP_NAME}:{ENDPOINT}"
     )
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(
             lambda: is_relation_joined(ops_test, ENDPOINT, ENDPOINT) is True,
             timeout=TIMEOUT,
@@ -134,7 +134,7 @@ async def test_relation_broken(ops_test: OpsTest):
         timeout=TIMEOUT,
     )
 
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await asyncio.gather(
             ops_test.model.wait_for_idle(
                 apps=[DATABASE_APP_NAME],

--- a/tests/integration/relations/test_shared_db.py
+++ b/tests/integration/relations/test_shared_db.py
@@ -166,7 +166,7 @@ async def test_keystone_bundle_shared_db(ops_test: OpsTest, mysql_charm_series: 
     )
 
     # Reduce the update_status frequency for the duration of the test
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         # Wait until the mysql charm is successfully deployed
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -51,7 +51,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mysql_charm_series: str) -> N
     )
 
     # Reduce the update_status frequency until the cluster is deployed
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         await ops_test.model.block_until(
             lambda: len(ops_test.model.applications[APP_NAME].units) == 3
         )
@@ -101,7 +101,7 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
 
     # Deploy TLS Certificates operator.
     logger.info("Deploy TLS operator")
-    async with ops_test.fast_forward():
+    async with ops_test.fast_forward("60s"):
         tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "Test CA"}
         await ops_test.model.deploy(TLS_APP_NAME, channel="beta", config=tls_config)
         await ops_test.model.wait_for_idle(apps=[TLS_APP_NAME], status="active", timeout=15 * 60)


### PR DESCRIPTION
When wait_for_idle called in fast forward

wait_for_idle requires all units to be idle for 15 seconds in a row. Fast forward triggers update status events every 5 seconds, which causes the charm to execute (not idle). This causes wait_for_idle to stall on less powerful hardware (e.g. `large` self-hosted runners) and potentially slows down integration tests on more powerful hardware