### PR TITLE
DPE-2455 Fix bug that caused unnecessary truncation of the mysql hosts cache

### DIFF
--- a/src/hostname_resolution.py
+++ b/src/hostname_resolution.py
@@ -97,9 +97,11 @@ class MySQLMachineHostnameResolution(Object):
         host_details = self._get_host_details()
         if not host_details:
             logger.debug("No hostnames in the peer databag. Skipping update of /etc/hosts")
+            return
 
         if not self._does_etc_hosts_need_update(host_details):
             logger.debug("No hostnames in /etc/hosts changed. Skipping update to /etc/hosts")
+            return
 
         hosts_in_file = []
 
@@ -116,7 +118,7 @@ class MySQLMachineHostnameResolution(Object):
 
                             fqdn, ip, unit = details["fqdn"], details["ip"], details["unit"]
 
-                            logger.info(
+                            logger.debug(
                                 f"Overwriting {hostname} ({unit=}) with {ip=}, {fqdn=} in /etc/hosts"
                             )
                             updated_hosts_file.write(f"{ip} {fqdn} {hostname} # unit={unit}\n")
@@ -126,7 +128,7 @@ class MySQLMachineHostnameResolution(Object):
                 if hostname not in hosts_in_file:
                     fqdn, ip, unit = details["fqdn"], details["ip"], details["unit"]
 
-                    logger.info(f"Adding {hostname} ({unit=} with {ip=}, {fqdn=} in /etc/hosts")
+                    logger.debug(f"Adding {hostname} ({unit=} with {ip=}, {fqdn=} in /etc/hosts")
                     updated_hosts_file.write(f"{ip} {fqdn} {hostname} # unit={unit}\n")
 
             with open("/etc/hosts", "w") as hosts_file:
@@ -140,6 +142,17 @@ class MySQLMachineHostnameResolution(Object):
     def _remove_host_from_etc_hosts(self, event: RelationDepartedEvent) -> None:
         departing_unit_name = event.unit.name
 
+        logger.debug(f"Checking if an entry for {departing_unit_name} is in /etc/hosts")
+        has_departed_unit = False
+        with open("/etc/hosts", "r") as hosts_file:
+            for line in hosts_file:
+                if f"# unit={departing_unit_name}" in line:
+                    has_departed_unit = True
+
+        if not has_departed_unit:
+            return
+
+        logger.debug(f"Removing entry for {departing_unit_name} from /etc/hosts")
         with io.StringIO() as updated_hosts_file:
             with open("/etc/hosts", "r") as hosts_file:
                 for line in hosts_file:

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -528,7 +528,7 @@ class MySQL(MySQLBase):
         flush_host_cache_command = "TRUNCATE TABLE performance_schema.host_cache"
 
         try:
-            logger.info("Truncating the MySQL host cache")
+            logger.debug("Truncating the MySQL host cache")
             self._run_mysqlcli_script(
                 flush_host_cache_command,
                 user=self.server_config_user,


### PR DESCRIPTION
## Issue
1. We are using info debug messages which is causing unnecessary volume in the debug log
2. We are not return-ing in `_potentially_update_etc_hosts` if there are no changes to the /etc/hosts file
3. When a unit has departed, in the handler, we are not checking if an update to the etc hosts file is needed. If the file was updated due to the relation changed event, we are repeating an update of the etc hosts file and unnecessarily truncating the mysql hosts cache

## Solution
1. Use debug statements
2. Add return statements
3. Check if the departing unit is in the etc hosts file, and only then run the logic in `_remove_host_from_etc_hosts`

## Logs from sample removal of unit from a cluster of 3 nodes:

```
unit-mysql-2: 13:55:35 DEBUG unit.mysql/2.juju-log ops 2.5.1 up and running.
unit-mysql-1: 13:55:35 DEBUG unit.mysql/1.juju-log database-peers:0: ops 2.5.1 up and running.
unit-mysql-1: 13:55:35 INFO unit.mysql/1.juju-log database-peers:0: Starting IP address observer process
unit-mysql-2: 13:55:35 DEBUG unit.mysql/2.juju-log Emitting Juju event database_storage_detaching.
unit-mysql-0: 13:55:35 DEBUG unit.mysql/0.juju-log database-peers:0: ops 2.5.1 up and running.
unit-mysql-1: 13:55:35 INFO unit.mysql/1.juju-log database-peers:0: Started IP address observer process with PID <Popen: returncode: None args: ['/usr/bin/python3', 'src/ip_address_observer...>
unit-mysql-2: 13:55:35 DEBUG unit.mysql/2.juju-log Checking existence of unit mysql-2 in cluster cluster-37de9aa812d1a67a0119c06f017a7428
unit-mysql-1: 13:55:35 DEBUG unit.mysql/1.juju-log database-peers:0: Emitting Juju event database_peers_relation_departed.
unit-mysql-0: 13:55:35 DEBUG unit.mysql/0.juju-log database-peers:0: Emitting Juju event database_peers_relation_departed.
unit-mysql-0: 13:55:35 DEBUG unit.mysql/0.juju-log database-peers:0: Checking if an entry for mysql/2 is in /etc/hosts
unit-mysql-0: 13:55:35 DEBUG unit.mysql/0.juju-log database-peers:0: Removing entry for mysql/2 from /etc/hosts
unit-mysql-1: 13:55:35 DEBUG unit.mysql/1.juju-log database-peers:0: Checking if an entry for mysql/2 is in /etc/hosts
unit-mysql-1: 13:55:35 DEBUG unit.mysql/1.juju-log database-peers:0: Removing entry for mysql/2 from /etc/hosts
unit-mysql-0: 13:55:35 DEBUG unit.mysql/0.juju-log database-peers:0: Truncating the MySQL host cache
unit-mysql-1: 13:55:35 DEBUG unit.mysql/1.juju-log database-peers:0: Truncating the MySQL host cache
unit-mysql-2: 13:55:36 DEBUG unit.mysql/2.juju-log Getting cluster primary member's address from 10.105.138.163
unit-mysql-0: 13:55:37 DEBUG unit.mysql/0.juju-log upgrade:1: ops 2.5.1 up and running.
unit-mysql-1: 13:55:37 DEBUG unit.mysql/1.juju-log upgrade:1: ops 2.5.1 up and running.
unit-mysql-2: 13:55:38 DEBUG unit.mysql/2.juju-log Attempting to acquire lock unit-teardown on juju-f91bfd-0.lxd for unit mysql-2
unit-mysql-0: 13:55:38 DEBUG unit.mysql/0.juju-log upgrade:1: Emitting Juju event upgrade_relation_departed.
unit-mysql-1: 13:55:38 DEBUG unit.mysql/1.juju-log upgrade:1: Emitting Juju event upgrade_relation_departed.
unit-mysql-2: 13:55:38 DEBUG unit.mysql/2.juju-log Getting cluster member addresses, excluding units ['mysql-2']
unit-mysql-0: 13:55:39 DEBUG unit.mysql/0.juju-log database-peers:0: ops 2.5.1 up and running.
unit-mysql-0: 13:55:39 DEBUG unit.mysql/0.juju-log database-peers:0: Emitting Juju event database_peers_relation_changed.
unit-mysql-0: 13:55:39 DEBUG unit.mysql/0.juju-log database-peers:0: No hostnames in /etc/hosts changed. Skipping update to /etc/hosts
unit-mysql-2: 13:55:40 DEBUG unit.mysql/2.juju-log Removing instance 10.105.138.163 from cluster cluster-37de9aa812d1a67a0119c06f017a7428
unit-mysql-2: 13:55:44 DEBUG unit.mysql/2.juju-log Getting cluster primary member's address from juju-f91bfd-0.lxd:3306
unit-mysql-2: 13:55:44 DEBUG unit.mysql/2.juju-log Releasing lock unit-teardown on juju-f91bfd-0.lxd for unit mysql-2
unit-mysql-2: 13:55:46 DEBUG unit.mysql/2.juju-log database-peers:0: ops 2.5.1 up and running.
unit-mysql-2: 13:55:46 DEBUG unit.mysql/2.juju-log database-peers:0: Emitting Juju event database_peers_relation_departed.
unit-mysql-2: 13:55:46 DEBUG unit.mysql/2.juju-log database-peers:0: Checking if an entry for mysql/0 is in /etc/hosts
unit-mysql-2: 13:55:46 DEBUG unit.mysql/2.juju-log database-peers:0: Removing entry for mysql/0 from /etc/hosts
unit-mysql-2: 13:55:46 DEBUG unit.mysql/2.juju-log database-peers:0: Truncating the MySQL host cache
unit-mysql-2: 13:55:47 DEBUG unit.mysql/2.juju-log upgrade:1: ops 2.5.1 up and running.
unit-mysql-2: 13:55:47 DEBUG unit.mysql/2.juju-log upgrade:1: Emitting Juju event upgrade_relation_departed.
unit-mysql-2: 13:55:48 DEBUG unit.mysql/2.juju-log database-peers:0: ops 2.5.1 up and running.
unit-mysql-2: 13:55:48 DEBUG unit.mysql/2.juju-log database-peers:0: Emitting Juju event database_peers_relation_departed.
unit-mysql-2: 13:55:48 DEBUG unit.mysql/2.juju-log database-peers:0: Checking if an entry for mysql/1 is in /etc/hosts
unit-mysql-2: 13:55:48 DEBUG unit.mysql/2.juju-log database-peers:0: Removing entry for mysql/1 from /etc/hosts
unit-mysql-2: 13:55:48 DEBUG unit.mysql/2.juju-log database-peers:0: Truncating the MySQL host cache
unit-mysql-2: 13:55:49 DEBUG unit.mysql/2.juju-log upgrade:1: ops 2.5.1 up and running.
unit-mysql-2: 13:55:49 DEBUG unit.mysql/2.juju-log upgrade:1: Emitting Juju event upgrade_relation_departed.
unit-mysql-2: 13:55:50 DEBUG unit.mysql/2.juju-log ops 2.5.1 up and running.
unit-mysql-2: 13:55:50 DEBUG unit.mysql/2.juju-log Emitting Juju event stop.
unit-mysql-2: 13:55:51 DEBUG unit.mysql/2.juju-log ops 2.5.1 up and running.
unit-mysql-2: 13:55:51 DEBUG unit.mysql/2.juju-log Emitting Juju event remove.
```