### PR TITLE
DPE-2214 Avoid resetting workload if recovery from unreachable state unsuccessful

### DIFF
--- a/lib/charms/data_platform_libs/v0/upgrade.py
+++ b/lib/charms/data_platform_libs/v0/upgrade.py
@@ -284,7 +284,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["pydantic>=1.10,<2"]
 
@@ -1117,7 +1117,6 @@ class DataUpgrade(Object, ABC):
                 return
 
             logger.debug("Did not find upgrade-stack or completed cluster state, deferring...")
-            event.defer()
             return
 
         # upgrade ongoing, set status for waiting units

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,7 +25,6 @@ from charms.mysql.v0.mysql import (
     MySQLInitializeJujuOperationsTableError,
     MySQLLockAcquisitionError,
     MySQLRebootFromCompleteOutageError,
-    MySQLRescanClusterError,
 )
 from charms.mysql.v0.tls import MySQLTLS
 from ops.charm import (
@@ -40,7 +39,6 @@ from ops.model import (
     ActiveStatus,
     BlockedStatus,
     MaintenanceStatus,
-    StatusBase,
     Unit,
     WaitingStatus,
 )
@@ -69,10 +67,7 @@ from hostname_resolution import MySQLMachineHostnameResolution
 from mysql_vm_helpers import (
     MySQL,
     MySQLCreateCustomMySQLDConfigError,
-    MySQLDataPurgeError,
     MySQLInstallError,
-    MySQLReconfigureError,
-    MySQLResetRootPasswordAndStartMySQLDError,
     SnapServiceOperationError,
     instance_hostname,
     is_volume_mounted,
@@ -303,8 +298,7 @@ class MySQLOperatorCharm(MySQLCharmBase):
                 ):
                     # mysqld access not possible and daemon restart fails
                     # force reset necessary
-                    self.unit.status = MaintenanceStatus("Workload reset")
-                    self.unit.status = self._workload_reset()
+                    self.unit.status = BlockedStatus("Unable to recover from an unreachable state")
             except SnapServiceOperationError as e:
                 self.unit.status = BlockedStatus(e.message)
 
@@ -545,51 +539,6 @@ class MySQLOperatorCharm(MySQLCharmBase):
             return False
 
         return True
-
-    def _workload_reset(self) -> StatusBase:
-        """Reset an errored workload.
-
-        Purge all files and re-initialise the workload.
-
-        Returns:
-            A `StatusBase` to be set by the caller
-        """
-        try:
-            primary_address = self._get_primary_address_from_peers()
-            if not primary_address:
-                logger.debug("Primary not yet defined on peers. Waiting new primary.")
-                return MaintenanceStatus("Workload reset: waiting new primary")
-
-            snap_service_operation(CHARMED_MYSQL_SNAP_NAME, CHARMED_MYSQLD_SERVICE, "stop")
-            self._mysql.reset_data_dir()
-            self._mysql.reconfigure_mysqld()
-            self._workload_initialise()
-
-            # On a full reset, member must firstly be removed from cluster metadata
-            self._mysql.rescan_cluster(from_instance=primary_address, remove_instances=True)
-            # Re-add the member as if it's the first time
-
-            self._mysql.add_instance_to_cluster(
-                self.get_unit_ip(self.unit), self.unit_label, from_instance=primary_address
-            )
-        except MySQLReconfigureError:
-            return MaintenanceStatus("Failed to re-initialize MySQL data-dir")
-        except MySQLConfigureMySQLUsersError:
-            return MaintenanceStatus("Failed to re-initialize MySQL users")
-        except MySQLConfigureInstanceError:
-            return MaintenanceStatus("Failed to re-configure instance for InnoDB")
-        except MySQLDataPurgeError:
-            return MaintenanceStatus("Failed to purge data dir")
-        except MySQLResetRootPasswordAndStartMySQLDError:
-            return MaintenanceStatus("Failed to reset root password")
-        except MySQLCreateCustomMySQLDConfigError:
-            return MaintenanceStatus("Failed to create custom mysqld config")
-        except MySQLRescanClusterError:
-            return MaintenanceStatus("Failed to rescan cluster and remove obsolete instances")
-        except SnapServiceOperationError as e:
-            return MaintenanceStatus(e.message)
-
-        return ActiveStatus(self.active_status_message)
 
     def _reboot_on_detached_storage(self, event) -> None:
         """Reboot on detached storage.

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -50,14 +50,6 @@ from constants import (
 logger = logging.getLogger(__name__)
 
 
-class MySQLReconfigureError(Error):
-    """Exception raised when the MySQL server fails to bootstrap."""
-
-
-class MySQLDataPurgeError(Error):
-    """Exception raised when there's an error purging data dir."""
-
-
 class MySQLResetRootPasswordAndStartMySQLDError(Error):
     """Exception raised when there's an error resetting root password and starting mysqld."""
 
@@ -674,39 +666,6 @@ class MySQL(MySQLBase):
             return expected_content <= set(content)
         except FileNotFoundError:
             return False
-
-    def reset_data_dir(self) -> None:
-        """Reset a data directory to a pristine state."""
-        logger.info("Purge data directory")
-        try:
-            for file_name in os.listdir(MYSQL_DATA_DIR):
-                file_path = os.path.join(MYSQL_DATA_DIR, file_name)
-                if os.path.isfile(file_path) or os.path.islink(file_path):
-                    os.unlink(file_path)
-                elif os.path.isdir(file_path):
-                    shutil.rmtree(file_path)
-        except OSError:
-            logger.error(f"Failed to remove {file_path}")
-            raise MySQLDataPurgeError("Failed to purge data")
-
-    def reconfigure_mysqld(self) -> None:
-        """Reconfigure mysql-server package.
-
-        Reconfiguring mysql-package recreates data structures as if it was newly installed.
-
-        Raises:
-            MySQLReconfigureError: Error occurred when reconfiguring server package.
-        """
-        logger.debug("Retrieving snap cache")
-        cache = snap.SnapCache()
-        charmed_mysql = cache[CHARMED_MYSQL_SNAP_NAME]
-
-        if charmed_mysql.present:
-            logger.debug("Uninstalling charmed-mysql snap")
-            charmed_mysql._remove()
-
-        logger.debug("Installing charmed-mysql snap")
-        charmed_mysql.ensure(snap.SnapState.Latest, channel="8.0/edge")
 
     @staticmethod
     def write_content_to_file(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -292,12 +292,10 @@ class TestCharm(unittest.TestCase):
     @patch("charm.is_volume_mounted", return_value=True)
     @patch("mysql_vm_helpers.MySQL.reboot_from_complete_outage")
     @patch("charm.snap_service_operation")
-    @patch("charm.MySQLOperatorCharm._workload_reset")
     @patch("hostname_resolution.MySQLMachineHostnameResolution._remove_host_from_etc_hosts")
     def test_on_update(
         self,
         _,
-        _workload_reset,
         _snap_service_operation,
         __reboot_from_complete_outage,
         _is_volume_mounted,
@@ -326,7 +324,6 @@ class TestCharm(unittest.TestCase):
         _get_member_state.assert_called_once()
         __reboot_from_complete_outage.assert_not_called()
         _snap_service_operation.assert_not_called()
-        _workload_reset.assert_not_called()
         _is_volume_mounted.assert_called_once()
         _get_cluster_node_count.assert_called_once()
         _get_cluster_primary_address.assert_called_once()
@@ -350,7 +347,6 @@ class TestCharm(unittest.TestCase):
         _get_member_state.assert_called_once()
         __reboot_from_complete_outage.assert_called_once()
         _snap_service_operation.assert_not_called()
-        _workload_reset.assert_not_called()
         _get_cluster_primary_address.assert_called_once()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, MaintenanceStatus))
@@ -360,14 +356,12 @@ class TestCharm(unittest.TestCase):
 
         __reboot_from_complete_outage.reset_mock()
         _snap_service_operation.return_value = False
-        _workload_reset.return_value = ActiveStatus()
         _get_member_state.return_value = ("unreachable", "primary")
 
         self.charm.on.update_status.emit()
         _get_member_state.assert_called_once()
         __reboot_from_complete_outage.assert_not_called()
         _snap_service_operation.assert_called_once()
-        _workload_reset.assert_called_once()
         _get_cluster_primary_address.assert_called_once()
 
-        self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
+        self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -179,20 +179,6 @@ class TestMySQL(unittest.TestCase):
         self.assertEqual(1, _wait_until_mysql_connection.call_count)
 
     @patch("mysql_vm_helpers.snap.SnapCache")
-    def test_reconfigure_mysqld(self, _snap_cache):
-        """Test a successful execution of method reconfigure_mysqld."""
-        _charmed_mysql_mock = MagicMock()
-        _cache = {CHARMED_MYSQL_SNAP_NAME: _charmed_mysql_mock}
-        _snap_cache.return_value.__getitem__.side_effect = _cache.__getitem__
-
-        self.mysql.reconfigure_mysqld()
-
-        _snap_cache.assert_called_once()
-
-        _charmed_mysql_mock._remove.assert_called_once()
-        _charmed_mysql_mock.ensure.assert_called_once()
-
-    @patch("mysql_vm_helpers.snap.SnapCache")
     def test_snap_service_operation(self, _snap_cache):
         """Test a successful execution of function snap_service_operation."""
         _charmed_mysql_mock = MagicMock()


### PR DESCRIPTION
## Issue
We are resetting the workload (wiping the data directory clean and re-initializing mysql) when a recovery (restart of `charmed-mysql` snap) from `unreachable` state is unsuccessful. This is super dangerous and we would like to avoid doing so 

## Solution
Instead, go to `BlockedStatus` to allow the admin to determine how to best resolve the issue