### PR TITLE
DPE-2478 Use actual observer pid in databag + reduce volume of secrets related logs

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -111,7 +111,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 44
+LIBPATCH = 45
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -522,8 +522,8 @@ class MySQLCharmBase(CharmBase):
                 secret = self.model.get_secret(id=secret_id)
                 content = secret.get_content()
                 self.unit_secrets = content
+                logger.debug(f"Retrieved secret {key} for unit from juju")
 
-            logger.debug(f"Retrieved secret {key} for unit")
             return self.unit_secrets.get(key)
 
         secret_id = self.app_peer_data.get(SECRET_ID_KEY)
@@ -536,8 +536,8 @@ class MySQLCharmBase(CharmBase):
             secret = self.model.get_secret(id=secret_id)
             content = secret.get_content()
             self.app_secrets = content
+            logger.debug(f"Retrieved secert {key} for app from juju")
 
-        logger.debug(f"Retrieved secret {key} for app")
         return self.app_secrets.get(key)
 
     def _get_secret_from_databag(self, scope: str, key: Optional[str]) -> Optional[str]:
@@ -619,7 +619,7 @@ class MySQLCharmBase(CharmBase):
             else:
                 secret = self.app.add_secret(content)
                 self.app_peer_data[SECRET_ID_KEY] = secret.id
-            logger.debug(f"Added {scope} secret {secret_id} for {key}")
+            logger.debug(f"Added {scope} secret {secret.id} for {key}")
 
         if scope == "unit":
             self.unit_secrets = content

--- a/src/ip_address_observer.py
+++ b/src/ip_address_observer.py
@@ -62,7 +62,7 @@ class IPAddressObserver(Object):
         if "JUJU_CONTEXT_ID" in new_env:
             new_env.pop("JUJU_CONTEXT_ID")
 
-        pid = subprocess.Popen(
+        process = subprocess.Popen(
             [
                 "/usr/bin/python3",
                 "src/ip_address_observer.py",
@@ -75,8 +75,8 @@ class IPAddressObserver(Object):
             env=new_env,
         )
 
-        self.charm.unit_peer_data.update({"observer-pid": f"{pid}"})
-        logging.info(f"Started IP address observer process with PID {pid}")
+        self.charm.unit_peer_data.update({"observer-pid": f"{process.pid}"})
+        logging.info(f"Started IP address observer process with PID {process.pid}")
 
     def stop_observer(self):
         """Stop running the observer if it is indeed running."""


### PR DESCRIPTION
## Issue
1, We are producing a lot of logs in `_get_secret_from_juju` (every time we initialize the MySQL helper class)
2. We are not storing the IP address observer PID (but rather the process) in the peer relation databag

## Solution
1. Only produce logs when actually getting secret from juju secrets backend
2. Store the PID in the peer relation databag
