### PR TITLE
[do not merge] test branch charmcraft latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,6 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v4.2.3
-    with:
-      charmcraft-snap-revision: 1349  # version 2.3.0
     permissions:
       actions: write  # Needed to manage GitHub Actions cache
 


### PR DESCRIPTION
## Issue

charmcraft latest cannot use pip secure install (i.e. requirements.txt with hashes).
Test branch for testing charmcraft 
