### PR TITLE
Avoid any actions when a unit is offline and allow mysql GR to recover

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -328,11 +328,6 @@ class MySQLOperatorCharm(MySQLCharmBase):
                 except MySQLRebootFromCompleteOutageError:
                     logger.error("Failed to reboot cluster from complete outage.")
                     self.unit.status = BlockedStatus("failed to recover cluster.")
-            primary = self._get_primary_from_online_peer()
-            if primary:
-                # Reset variables to allow unit join the cluster
-                self.unit_peer_data["member-state"] = "waiting"
-                del self.unit_peer_data["unit-initialized"]
 
         if state == "unreachable":
             try:


### PR DESCRIPTION
## Issue
The SST test fails because we are taking an action when a unit is offline (we are currently trying to rejoin the instance to the cluster).

## Solution
Do nothing, as MySQL Group Replication has logic around rejoining an offline instance.