### PR TITLE
Avoid logging FLUSH LOG statements to the binlog

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -116,7 +116,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 49
+LIBPATCH = 50
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -2552,7 +2552,9 @@ class MySQLBase(ABC):
         """Flushes the specified logs_type logs."""
         flush_logs_commands = (
             f"shell.connect('{self.server_config_user}:{self.server_config_password}@{self.instance_address}')",
+            'session.run_sql("SET sql_log_bin = 0")',
             f'session.run_sql("FLUSH {logs_type.value}")',
+            'session.run_sql("SET sql_log_bin = 1")',
         )
 
         try:


### PR DESCRIPTION
## Issue
By default, `FLUSH LOG` statements are logged to the binlog. When a member is not part of a group (self-healing scenarios), these log statements result in GTID conflicts which prevents the member from self-healing.

## Solution
Disable logging `FLUSH LOG` statements to the bin log.
