### PR TITLE
[DPE-2677] Avoid setting secret upon tls relation broken if using juju secrets

### DIFF
--- a/lib/charms/mysql/v0/tls.py
+++ b/lib/charms/mysql/v0/tls.py
@@ -22,6 +22,7 @@ It requires the TLS certificates library and the MySQL library.
 
 import base64
 import logging
+import ops
 import re
 import socket
 from typing import List, Optional, Tuple
@@ -52,7 +53,7 @@ LIBID = "eb73947deedd4380a3a90d527e0878eb"
 
 LIBAPI = 0
 
-LIBPATCH = 2
+LIBPATCH = 3
 
 SCOPE = "unit"
 
@@ -165,9 +166,10 @@ class MySQLTLS(Object):
     def _on_tls_relation_broken(self, _) -> None:
         """Disable TLS when TLS relation broken."""
         try:
-            self.charm.set_secret(SCOPE, "certificate-authority", None, fallback_key="ca")
-            self.charm.set_secret(SCOPE, "certificate", None, fallback_key="cert")
-            self.charm.set_secret(SCOPE, "chain", None)
+            if not ops.jujuversion.JujuVersion.from_environ().has_secrets:
+                self.charm.set_secret(SCOPE, "certificate-authority", None, fallback_key="ca")
+                self.charm.set_secret(SCOPE, "certificate", None, fallback_key="cert")
+                self.charm.set_secret(SCOPE, "chain", None)
         except KeyError:
             # ignore key error for unit teardown
             pass


### PR DESCRIPTION
## Issue
We do not have access to a juju secret upon relation-broken event. However, the tls relation code in MySQL is setting tls related secrets to None. This is necessary for secrets stored in the databag (as they are reset to None), but causes the trace in the Jira ticket as the secret is deleted from the secrets backend

## Solution
Do not attempt to reset the tls secrets upon relation broken if using juju secrets