### PR TITLE
[DPE-3063] Change dateformat in logrotate config to avoid causing filename conflicts after 24hrs of uptime

### DIFF
--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -11,7 +11,7 @@ rotate 10800
 
 # Naming of rotated files should be in the format:
 dateext
-dateformat -%Y%m%d_%H:%M.log
+dateformat -%Y%m%d_%H:%M
 
 # Settings to prevent misconfigurations and unwanted behaviours
 ifempty

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -11,7 +11,7 @@ rotate 10800
 
 # Naming of rotated files should be in the format:
 dateext
-dateformat -%V_%H%M
+dateformat -%Y%m%d_%H:%M.log
 
 # Settings to prevent misconfigurations and unwanted behaviours
 ifempty


### PR DESCRIPTION
## Issue
We are using `-%V_%H%M` as the dateformat for logrotate - this causes filename conflicts after a day of uptime due to file name conflicts.

## Solution
Use `-%Y%m%d_%H:%M` as the dateformat (for consistency with pgbouncer)

## Alternatives
`-%u` in the dateformat does not get correctly substituted as per the docs:
```
error: destination /var/log/mysql/archive_general/general.log-%u_1637 already exists, skipping rotation

root@mysql-k8s-0:/# ls -la /var/log/mysql/archive_error/
total 8
drwxrwx--- 2 mysql mysql 4096 Nov 30 16:37 .
drwxr-xr-x 1 mysql mysql 4096 Nov 30 16:37 ..
-rw-r----- 1 mysql mysql    0 Nov 30 16:36 error.log-%u_1637
```