### PR TITLE
Set up logrotate when upgrading + account for logrotate's systemd timer

### DIFF
--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -257,7 +257,10 @@ class MySQL(MySQLBase):
         with open("/etc/logrotate.d/flush_mysql_logs", "w") as file:
             file.write(rendered)
 
-        cron = "* 1-23 * * * root logrotate -f /etc/logrotate.d/flush_mysql_logs\n1-59 0 * * * root logrotate -f /etc/logrotate.d/flush_mysql_logs\n"
+        cron = (
+            "* 1-23 * * * root logrotate -f /etc/logrotate.d/flush_mysql_logs\n"
+            "1-59 0 * * * root logrotate -f /etc/logrotate.d/flush_mysql_logs\n"
+        )
         with open("/etc/cron.d/flush_mysql_logs", "w") as file:
             file.write(cron)
 

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -257,7 +257,7 @@ class MySQL(MySQLBase):
         with open("/etc/logrotate.d/flush_mysql_logs", "w") as file:
             file.write(rendered)
 
-        cron = "* * * * * root logrotate -f /etc/logrotate.d/flush_mysql_logs\n"
+        cron = "* 1-23 * * * root logrotate -f /etc/logrotate.d/flush_mysql_logs\n1-59 0 * * * root logrotate -f /etc/logrotate.d/flush_mysql_logs\n"
         with open("/etc/cron.d/flush_mysql_logs", "w") as file:
             file.write(cron)
 

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -185,6 +185,7 @@ class MySQLVMUpgrade(DataUpgrade):
             self._check_server_upgradeability()
             self.charm.unit.status = MaintenanceStatus("starting services...")
             self.charm._mysql.start_mysqld()
+            self.charm._mysql.setup_logrotate_and_cron()
         except VersionError:
             logger.exception("Failed to upgrade MySQL dependencies")
             self.set_unit_failed()

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -137,8 +137,10 @@ class TestUpgrade(unittest.TestCase):
     @patch("mysql_vm_helpers.MySQL.start_mysqld")
     @patch("upgrade.MySQLVMUpgrade._check_server_upgradeability")
     @patch("mysql_vm_helpers.MySQL.is_instance_in_cluster", return_value=True)
+    @patch("mysql_vm_helpers.MySQL.setup_logrotate_and_cron", return_value=True)
     def test_upgrade_granted(
         self,
+        mock_setup_logrotate_and_cron,
         mock_is_instance_in_cluster,
         mock_check_server_upgradeability,
         mock_start_mysqld,
@@ -165,6 +167,7 @@ class TestUpgrade(unittest.TestCase):
         mock_stop_mysqld.assert_called_once()
         mock_install_workload.assert_called_once()
         mock_get_mysql_version.assert_called_once()
+        mock_setup_logrotate_and_cron.assert_called_once()
 
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql/0", {"state": "upgrading"}


### PR DESCRIPTION
## Issue
1. We are not setting up logrotate's cron and config files when we upgrade from the previous stable (which does not have logrotate implemented)
2. Everyday, at midnight, the cron job running logrotate for us conflicts with the logrotate run by logrotate's systemd time

## Solution
1. Set up cron and logrotate config files when upgrade_granted
2. Change cron to avoid running at midnight 
