### PR TITLE
fix: ensure that poetry is available to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ allowlist_externals =
     {[testenv]allowlist_externals}
     charmcraft
     mv
+deps:
+    poetry
 commands_pre =
     poetry export --only main,charm-libs --output requirements.txt
 commands =
@@ -33,6 +35,8 @@ commands_post =
 
 [testenv:format]
 description = Apply coding style standards to code
+deps:
+    poetry
 commands_pre =
     poetry install --only format
 commands =
@@ -45,6 +49,8 @@ description = Check code against coding style standards
 allowlist_externals =
     {[testenv]allowlist_externals}
     find
+deps:
+    poetry
 commands_pre =
     poetry install --only lint
 commands =
@@ -62,6 +68,8 @@ commands =
 description = Run unit tests
 set_env =
     {[testenv]set_env}
+deps:
+    poetry
 commands_pre =
     poetry install --only main,charm-libs,unit
 commands =
@@ -82,6 +90,8 @@ pass_env =
     SECRETS_FROM_GITHUB
 allowlist_externals =
     {[testenv:pack-wrapper]allowlist_externals}
+deps:
+    poetry
 commands_pre =
     poetry install --only integration
     {[testenv:pack-wrapper]commands_pre}


### PR DESCRIPTION
## Issue

If you don't have `poetry` installed locally (and on your PATH) then cloning the repo and running `tox` will fail (because tox tries to use poetry to set up the test requirements).

## Solution

Have tox install `poetry` as a dependency. I haven't pinned it at all - I'm not sure if you would prefer to do that or not (but currently you're using whatever `poetry` people have on their system, or is in the CI runner, so that's also unpinned in a way). I can do that if you pick a version, or feel free to adjust it yourself of course.