### PR TITLE
DPE-2618 broken after restart

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -90,7 +90,7 @@ from ops.model import Unit
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed, wait_random
 
 from constants import (
-    BACKUPS_PASSWORD_KEY
+    BACKUPS_PASSWORD_KEY,
     BACKUPS_USERNAME,
     CLUSTER_ADMIN_PASSWORD_KEY,
     CLUSTER_ADMIN_USERNAME,

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -87,16 +87,10 @@ from charms.data_platform_libs.v0.data_secrets import (
 )
 from ops.charm import ActionEvent, CharmBase, RelationBrokenEvent
 from ops.model import Unit
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_fixed,
-    wait_random,
-)
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed, wait_random
 
 from constants import (
-    BACKUPS_PASSWORD_KEY,
+    BACKUPS_PASSWORD_KEY
     BACKUPS_USERNAME,
     CLUSTER_ADMIN_PASSWORD_KEY,
     CLUSTER_ADMIN_USERNAME,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1071,13 +1071,13 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "ops"
-version = "2.5.1"
+version = "2.9.0"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "ops-2.5.1-py3-none-any.whl", hash = "sha256:b7efc373031c52cb4ce61a455bcb990330bc1b81c01b1061626ed957bc58bbc1"},
-    {file = "ops-2.5.1.tar.gz", hash = "sha256:7f74552e48ee42af3ae87148767fd0cedef03e6d28248728f2258e05a0dfd86d"},
+    {file = "ops-2.9.0-py3-none-any.whl", hash = "sha256:1d443e4d45e0c2443b8334d37a177287f22a12ee0cb02a30cf7c3159316cb643"},
+    {file = "ops-2.9.0.tar.gz", hash = "sha256:d3c541659eded56f42f9c18270408cc6313895968f1360b3f1de75c99cc99ada"},
 ]
 
 [package.dependencies]
@@ -2215,4 +2215,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e1067077432b837c6011fc590be3e64af9ce5d737aabe69508137b241bbb2c98"
+content-hash = "626d00d031eb1b1c37ceac357442f24330f69cc4673ce03d40d654dec2b07a9c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = []
 
 [tool.poetry.dependencies]
 python = "^3.10"
-ops = "^2.5.0"
+ops = "^2.8.0"
 tenacity = "^8.2.2"
 boto3 = "^1.28.23"
 # TODO: Remove insecure dependency https://github.com/canonical/mysql-operator/issues/246
@@ -93,6 +93,7 @@ target-version = ["py38"]
 [tool.isort]
 profile = "black"
 known_third_party = "mysql.connector"
+line_length = 99
 
 # Linting tools configuration
 [tool.flake8]

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,22 +33,20 @@ from charms.mysql.v0.mysql import (
 )
 from charms.mysql.v0.tls import MySQLTLS
 from charms.rolling_ops.v0.rollingops import RollingOpsManager
-from ops import EventBase
-from ops.charm import (
+from ops import (
+    ActiveStatus,
+    BlockedStatus,
+    EventBase,
     InstallEvent,
+    MaintenanceStatus,
     RelationBrokenEvent,
     RelationChangedEvent,
     RelationCreatedEvent,
     StartEvent,
-)
-from ops.main import main
-from ops.model import (
-    ActiveStatus,
-    BlockedStatus,
-    MaintenanceStatus,
     Unit,
     WaitingStatus,
 )
+from ops.main import main
 from tenacity import (
     RetryError,
     Retrying,

--- a/src/relations/db_router.py
+++ b/src/relations/db_router.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import typing
 from collections import namedtuple
 from typing import Dict, List, Set, Tuple
 
@@ -15,12 +16,7 @@ from charms.mysql.v0.mysql import (
     MySQLDeleteUsersForUnitError,
     MySQLGetClusterPrimaryAddressError,
 )
-from ops.charm import (
-    CharmBase,
-    LeaderElectedEvent,
-    RelationChangedEvent,
-    RelationDepartedEvent,
-)
+from ops.charm import LeaderElectedEvent, RelationChangedEvent, RelationDepartedEvent
 from ops.framework import Object
 from ops.model import BlockedStatus, RelationDataContent
 
@@ -33,11 +29,14 @@ RequestedUser = namedtuple(
     "RequestedUser", ["application_name", "username", "hostname", "database"]
 )
 
+if typing.TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
 
 class DBRouterRelation(Object):
     """Encapsulation of the legacy db-router relation."""
 
-    def __init__(self, charm: CharmBase):
+    def __init__(self, charm: "MySQLOperatorCharm"):
         super().__init__(charm, LEGACY_DB_ROUTER)
 
         self.charm = charm

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -4,11 +4,9 @@
 """Library containing the implementation of the standard relation."""
 
 import logging
+import typing
 
-from charms.data_platform_libs.v0.data_interfaces import (
-    DatabaseProvides,
-    DatabaseRequestedEvent,
-)
+from charms.data_platform_libs.v0.data_interfaces import DatabaseProvides, DatabaseRequestedEvent
 from charms.mysql.v0.mysql import (
     MySQLClientError,
     MySQLCreateApplicationDatabaseAndScopedUserError,
@@ -29,11 +27,14 @@ from utils import generate_random_password
 
 logger = logging.getLogger(__name__)
 
+if typing.TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
 
 class MySQLProvider(Object):
     """Standard database relation class."""
 
-    def __init__(self, charm):
+    def __init__(self, charm: "MySQLOperatorCharm"):
         super().__init__(charm, DB_RELATION_NAME)
 
         self.charm = charm

--- a/src/relations/shared_db.py
+++ b/src/relations/shared_db.py
@@ -4,17 +4,13 @@
 """Library containing the implementation of the legacy shared-db relation."""
 
 import logging
+import typing
 
 from charms.mysql.v0.mysql import (
     MySQLCreateApplicationDatabaseAndScopedUserError,
     MySQLGetClusterPrimaryAddressError,
 )
-from ops.charm import (
-    CharmBase,
-    LeaderElectedEvent,
-    RelationChangedEvent,
-    RelationDepartedEvent,
-)
+from ops.charm import LeaderElectedEvent, RelationChangedEvent, RelationDepartedEvent
 from ops.framework import Object
 from ops.model import BlockedStatus
 
@@ -23,11 +19,14 @@ from utils import generate_random_password
 
 logger = logging.getLogger(__name__)
 
+if typing.TYPE_CHECKING:
+    from charm import MySQLOperatorCharm
+
 
 class SharedDBRelation(Object):
     """Legacy `shared-db` relation implementation."""
 
-    def __init__(self, charm: CharmBase):
+    def __init__(self, charm: "MySQLOperatorCharm"):
         super().__init__(charm, "shared-db-handler")
 
         self._charm = charm

--- a/tests/integration/high_availability/conftest.py
+++ b/tests/integration/high_availability/conftest.py
@@ -6,10 +6,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from .. import juju_
-from .high_availability_helpers import (
-    APPLICATION_DEFAULT_APP_NAME,
-    get_application_name,
-)
+from .high_availability_helpers import APPLICATION_DEFAULT_APP_NAME, get_application_name
 
 
 @pytest.fixture()

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -8,11 +8,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from .. import juju_
-from ..helpers import (
-    get_leader_unit,
-    get_primary_unit_wrapper,
-    retrieve_database_variable_value,
-)
+from ..helpers import get_leader_unit, get_primary_unit_wrapper, retrieve_database_variable_value
 from .high_availability_helpers import (
     ensure_all_units_continuous_writes_incrementing,
     relate_mysql_and_application,

--- a/tests/integration/relations/test_database.py
+++ b/tests/integration/relations/test_database.py
@@ -11,12 +11,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 from tenacity import AsyncRetrying, RetryError, stop_after_delay, wait_fixed
 
-from constants import (
-    DB_RELATION_NAME,
-    PASSWORD_LENGTH,
-    ROOT_USERNAME,
-    SERVER_CONFIG_USERNAME,
-)
+from constants import DB_RELATION_NAME, PASSWORD_LENGTH, ROOT_USERNAME, SERVER_CONFIG_USERNAME
 from utils import generate_random_password
 
 from .. import markers

--- a/tests/integration/relations/test_db_router.py
+++ b/tests/integration/relations/test_db_router.py
@@ -11,11 +11,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import (
-    execute_queries_on_unit,
-    get_server_config_credentials,
-    scale_application,
-)
+from ..helpers import execute_queries_on_unit, get_server_config_credentials, scale_application
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -114,9 +114,6 @@ class TestCharm(unittest.TestCase):
         # trigger the leader_elected event
         self.harness.set_leader(True)
 
-        # ensure passwords set in the peer relation databag
-        secret_data = self.harness.model.get_secret(label="mysql.app").get_content()
-
         expected_peer_relation_databag_keys = [
             "root-password",
             "server-config-password",
@@ -125,7 +122,8 @@ class TestCharm(unittest.TestCase):
             "backups-password",
         ]
 
-        self.assertEqual(sorted(secret_data.keys()), sorted(expected_peer_relation_databag_keys))
+        for key in expected_peer_relation_databag_keys:
+            self.assertTrue(self.harness.charm.get_secret("app", key).isalnum())
 
     @patch_network_get(private_address="1.1.1.1")
     def test_on_leader_elected_sets_config_cluster_name_in_peer_databag(self):
@@ -551,10 +549,6 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.set_secret("app", "replication", "somepw")
         self.harness.charm.set_secret("app", "replication", "")
         assert self.harness.charm.get_secret("app", "replication") is None
-
-        self.harness.charm.set_secret("unit", "somekey", "somesecret")
-        self.harness.charm.set_secret("unit", "somekey", "")
-        assert self.harness.charm.get_secret("unit", "somekey") is None
 
         with self._caplog.at_level(logging.ERROR):
             self.harness.charm.set_secret("app", "replication", "")


### PR DESCRIPTION
## Issue

- mysqlsh log directory is not set, rendering permission denied
- on restart, the test for charmed-mysql snap common directory mount runs before snapd is able to mount it

## Solution

- set mysqlsh log directory
- add retry period for mount test of charmed-mysql snap common directory

### Chore

- some typing and formatting fixes
- unit test fixes for ops>=2.8.0 (required for using `unit.reboot`) 

Fixes #380 