### PR TITLE
fix: when removing a secret, remove it from the cache, too

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -651,6 +651,7 @@ class MySQLCharmBase(CharmBase, ABC):
             secret.set_content(content)
         else:
             secret.meta.remove_all_revisions()
+            del self.secrets._secrets[label]
 
     def set_secret(
         self, scope: Scopes, key: str, value: Optional[str], fallback_key: Optional[str] = None


### PR DESCRIPTION
## Issue

When a secret is completely emptied of content, the lib removes all revisions from Juju, but leaves the cached object in place. This means that code can still access it, when in practice it has actually gone.

## Solution

Remove the secret from the `SecretCache` when it's removed from Juju with `remove_all_revisions()`. This does access a private attribute, but the comment just above this says that this code is temporary until the removal is in the lib itself, where the private attribute access would be fine.