### PR TITLE
Remove charmcraft beta channel

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,6 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v11.0.0
     with:
       cache: true
-      charmcraft-snap-channel: beta
 
   integration-test:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,8 +36,6 @@ jobs:
   build:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v11.0.0
-    with:
-      charmcraft-snap-channel: beta
 
   release:
     name: Release charm


### PR DESCRIPTION
charmcraft 2.5.4 was released to stable
