### PR TITLE
DPE-3688 fix KeyError when no ca-chain

### DIFF
--- a/lib/charms/mysql/v0/s3_helpers.py
+++ b/lib/charms/mysql/v0/s3_helpers.py
@@ -50,9 +50,9 @@ def upload_content_to_s3(content: str, content_path: str, s3_parameters: Dict) -
 
     Returns: a boolean indicating success.
     """
+    ca_file = None
     try:
         logger.info(f"Uploading content to bucket={s3_parameters['bucket']}, path={content_path}")
-        ca_file = tempfile.NamedTemporaryFile()
         session = boto3.session.Session(
             aws_access_key_id=s3_parameters["access-key"],
             aws_secret_access_key=s3_parameters["secret-key"],
@@ -60,6 +60,7 @@ def upload_content_to_s3(content: str, content_path: str, s3_parameters: Dict) -
         )
         verif = True
         if ca_chain := s3_parameters.get("tls-ca-chain"):
+            ca_file = tempfile.NamedTemporaryFile()
             ca = "\n".join([base64.b64decode(s).decode() for s in ca_chain])
             ca_file.write(ca.encode())
             ca_file.flush()
@@ -85,7 +86,8 @@ def upload_content_to_s3(content: str, content_path: str, s3_parameters: Dict) -
         )
         return False
     finally:
-        ca_file.close()
+        if ca_file:
+            ca_file.close()
 
     return True
 

--- a/lib/charms/mysql/v0/s3_helpers.py
+++ b/lib/charms/mysql/v0/s3_helpers.py
@@ -31,7 +31,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 # botocore/urllib3 clutter the logs when on debug
 logging.getLogger("botocore").setLevel(logging.WARNING)
@@ -59,8 +59,7 @@ def upload_content_to_s3(content: str, content_path: str, s3_parameters: Dict) -
             region_name=s3_parameters["region"] or None,
         )
         verif = True
-        ca_chain = s3_parameters["tls-ca-chain"]
-        if ca_chain:
+        if ca_chain := s3_parameters.get("tls-ca-chain"):
             ca = "\n".join([base64.b64decode(s).decode() for s in ca_chain])
             ca_file.write(ca.encode())
             ca_file.flush()

--- a/tests/unit/test_s3_helpers.py
+++ b/tests/unit/test_s3_helpers.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from lib.charms.mysql.v0.s3_helpers import upload_content_to_s3
+
+
+class TestS3Helpers(unittest.TestCase):
+    def setUp(self) -> None:
+        self.s3_parameters = {
+            "access-key": "AK",
+            "secret-key": "SK",
+            "region": "AS-1",
+            "bucket": "balde",
+            "endpoint": "http://localhost:9000",
+        }
+
+    @patch("lib.charms.mysql.v0.s3_helpers.boto3")
+    def test_upload_content_without_ca_chain(self, mock_boto):
+        mock_session = MagicMock()
+        mock_resource = MagicMock()
+        mock_bucket = MagicMock()
+
+        mock_boto.session.Session.return_value = mock_session
+        mock_session.resource.return_value = mock_resource
+        mock_resource.Bucket.return_value = mock_bucket
+
+        upload_content_to_s3("content", "key", self.s3_parameters)
+
+        mock_bucket.upload_file.assert_called_once()
+        mock_session.resource.assert_called_with(
+            "s3", endpoint_url="http://localhost:9000", verify=True
+        )
+
+    @patch("lib.charms.mysql.v0.s3_helpers.boto3")
+    def test_upload_content_with_ca_chain(self, mock_boto):
+        mock_session = MagicMock()
+        mock_resource = MagicMock()
+        mock_bucket = MagicMock()
+
+        mock_boto.session.Session.return_value = mock_session
+        mock_session.resource.return_value = mock_resource
+        mock_resource.Bucket.return_value = mock_bucket
+
+        s3_parameters = {
+            "access-key": "AK",
+            "secret-key": "SK",
+            "region": "AS-1",
+            "bucket": "balde",
+            "endpoint": "http://localhost:9000",
+            "tls-ca-chain": ["Zm9vYmFy"],
+        }
+
+        upload_content_to_s3("content", "key", s3_parameters)
+
+        mock_bucket.upload_file.assert_called_once()
+        mock_session.resource.assert_called_once()


### PR DESCRIPTION
## Issue

backup fail due to dict key error


## Solution

- avoid KeyError when no ca chain
- Increase coverage


Fixes #402
