### PR TITLE
Use `ubuntu-advantage` charm instead of `ubuntu-pro`

### DIFF
--- a/tests/integration/test_subordinate_charms.py
+++ b/tests/integration/test_subordinate_charms.py
@@ -9,7 +9,7 @@ import pytest
 
 from .relations.test_database import APPLICATION_APP_NAME, CLUSTER_NAME, DATABASE_APP_NAME, TIMEOUT
 
-UBUNTU_PRO_APP_NAME = "ubuntu-pro"
+UBUNTU_PRO_APP_NAME = "ubuntu-advantage"
 
 
 @pytest.mark.group(1)


### PR DESCRIPTION
Per recommendation by Commercial Systems team: https://warthogs.atlassian.net/browse/DPE-3656?focusedCommentId=423968
