### PR TITLE
DPE-381 Remove last unstable test flag

### DIFF
--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -306,7 +306,6 @@ async def test_replicate_data_on_restart(
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-@pytest.mark.unstable
 async def test_cluster_pause(ops_test: OpsTest, continuous_writes, mysql_charm_series: str):
     """Pause test.
 


### PR DESCRIPTION
## Issue

Pause test still marked with unstable flag, masking the real status of the test.

## Solution

Remove the unstable flag from the pause test.

Fixes #414
