### PR TITLE
[DPE-3702] Add snap aliases for MySQL server / Router

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -409,9 +409,9 @@ class Snap(object):
         """Remove the refresh hold of a snap."""
         self._snap("refresh", ["--unhold"])
 
-
     def alias(self, application: str, alias: Optional[str] = None) -> None:
         """Create an alias for a given application.
+        
         Args:
             application: application to get an alias.
             alias: (optional) name of the alias; if not provided, the application name is used.

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -273,13 +273,13 @@ class Snap(object):
           SnapError if there is a problem encountered
         """
         optargs = optargs or []
-        _cmd = ["snap", command, self._name, *optargs]
+        args = ["snap", command, self._name, *optargs]
         try:
-            return subprocess.check_output(_cmd, universal_newlines=True)
+            return subprocess.check_output(args, universal_newlines=True)
         except CalledProcessError as e:
             raise SnapError(
                 "Snap: {!r}; command {!r} failed with output = {!r}".format(
-                    self._name, _cmd, e.output
+                    self._name, args, e.output
                 )
             )
 
@@ -303,12 +303,12 @@ class Snap(object):
         else:
             services = [self._name]
 
-        _cmd = ["snap", *command, *services]
+        args = ["snap", *command, *services]
 
         try:
-            return subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+            return subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
         except CalledProcessError as e:
-            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
+            raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
     def get(self, key) -> str:
         """Fetch a snap configuration value.
@@ -387,11 +387,11 @@ class Snap(object):
         elif slot:
             command = command + [slot]
 
-        _cmd = ["snap", *command]
+        args = ["snap", *command]
         try:
-            subprocess.run(_cmd, universal_newlines=True, check=True, capture_output=True)
+            subprocess.run(args, universal_newlines=True, check=True, capture_output=True)
         except CalledProcessError as e:
-            raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
+            raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
     def hold(self, duration: Optional[timedelta] = None) -> None:
         """Add a refresh hold to a snap.
@@ -408,6 +408,26 @@ class Snap(object):
     def unhold(self) -> None:
         """Remove the refresh hold of a snap."""
         self._snap("refresh", ["--unhold"])
+
+
+    def alias(self, application: str, alias: Optional[str] = None) -> None:
+        """Create an alias for a given application.
+        Args:
+            application: application to get an alias.
+            alias: (optional) name of the alias; if not provided, the application name is used.
+        """
+        if alias is None:
+            alias = application
+        args = ["snap", "alias", f"{self.name}.{application}", alias]
+        try:
+            subprocess.check_output(args, universal_newlines=True)
+        except CalledProcessError as e:
+            raise SnapError(
+                "Snap: {!r}; command {!r} failed with output = {!r}".format(
+                    self._name, args, e.output
+                )
+            )
+
 
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False
@@ -992,17 +1012,17 @@ def install_local(
     Raises:
         SnapError if there is a problem encountered
     """
-    _cmd = [
+    args = [
         "snap",
         "install",
         filename,
     ]
     if classic:
-        _cmd.append("--classic")
+        args.append("--classic")
     if dangerous:
-        _cmd.append("--dangerous")
+        args.append("--dangerous")
     try:
-        result = subprocess.check_output(_cmd, universal_newlines=True).splitlines()[-1]
+        result = subprocess.check_output(args, universal_newlines=True).splitlines()[-1]
         snap_name, _ = result.split(" ", 1)
         snap_name = ansi_filter.sub("", snap_name)
 
@@ -1026,9 +1046,9 @@ def _system_set(config_item: str, value: str) -> None:
         config_item: name of snap system setting. E.g. 'refresh.hold'
         value: value to assign
     """
-    _cmd = ["snap", "set", "system", "{}={}".format(config_item, value)]
+    args = ["snap", "set", "system", "{}={}".format(config_item, value)]
     try:
-        subprocess.check_call(_cmd, universal_newlines=True)
+        subprocess.check_call(args, universal_newlines=True)
     except CalledProcessError:
         raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
 

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -411,7 +411,7 @@ class Snap(object):
 
     def alias(self, application: str, alias: Optional[str] = None) -> None:
         """Create an alias for a given application.
-        
+
         Args:
             application: application to get an alias.
             alias: (optional) name of the alias; if not provided, the application name is used.
@@ -427,7 +427,6 @@ class Snap(object):
                     self._name, args, e.output
                 )
             )
-
 
     def restart(
         self, services: Optional[List[str]] = None, reload: Optional[bool] = False

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -79,11 +79,11 @@ logger = logging.getLogger(__name__)
 LIBID = "05394e5893f94f2d90feb7cbe6b633cd"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 1
+LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 4
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -214,7 +214,7 @@ class Snap(object):
       - state: a `SnapState` representation of its install status
       - channel: "stable", "candidate", "beta", and "edge" are common
       - revision: a string representing the snap's revision
-      - confinement: "classic" or "strict"
+      - confinement: "classic", "strict", or "devmode"
     """
 
     def __init__(
@@ -222,7 +222,7 @@ class Snap(object):
         name,
         state: SnapState,
         channel: str,
-        revision: int,
+        revision: str,
         confinement: str,
         apps: Optional[List[Dict[str, str]]] = None,
         cohort: Optional[str] = "",
@@ -310,23 +310,38 @@ class Snap(object):
         except CalledProcessError as e:
             raise SnapError("Could not {} for snap [{}]: {}".format(args, self._name, e.stderr))
 
-    def get(self, key) -> str:
-        """Fetch a snap configuration value.
+    def get(self, key: Optional[str], *, typed: bool = False) -> Any:
+        """Fetch snap configuration values.
 
         Args:
-            key: the key to retrieve
+            key: the key to retrieve. Default to retrieve all values for typed=True.
+            typed: set to True to retrieve typed values (set with typed=True).
+                Default is to return a string.
         """
+        if typed:
+            config = json.loads(self._snap("get", ["-d", key]))
+            if key:
+                return config.get(key)
+            return config
+
+        if not key:
+            raise TypeError("Key must be provided when typed=False")
+
         return self._snap("get", [key]).strip()
 
-    def set(self, config: Dict) -> str:
+    def set(self, config: Dict[str, Any], *, typed: bool = False) -> str:
         """Set a snap configuration value.
 
         Args:
            config: a dictionary containing keys and values specifying the config to set.
+           typed: set to True to convert all values in the config into typed values while
+                configuring the snap (set with typed=True). Default is not to convert.
         """
-        args = ['{}="{}"'.format(key, val) for key, val in config.items()]
+        if typed:
+            kv = [f"{key}={json.dumps(val)}" for key, val in config.items()]
+            return self._snap("set", ["-t"] + kv)
 
-        return self._snap("set", [*args])
+        return self._snap("set", [f"{key}={val}" for key, val in config.items()])
 
     def unset(self, key) -> str:
         """Unset a snap configuration value.
@@ -434,7 +449,7 @@ class Snap(object):
         """Restarts a snap's services.
 
         Args:
-            services (list): (optional) list of individual snap services to show logs from.
+            services (list): (optional) list of individual snap services to restart.
                 (otherwise all)
             reload (bool): (optional) flag to use the service reload command, if available.
                 Default `False`
@@ -446,7 +461,7 @@ class Snap(object):
         self,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[int] = None,
+        revision: Optional[str] = None,
     ) -> None:
         """Add a snap to the system.
 
@@ -460,6 +475,8 @@ class Snap(object):
         args = []
         if self.confinement == "classic":
             args.append("--classic")
+        if self.confinement == "devmode":
+            args.append("--devmode")
         if channel:
             args.append('--channel="{}"'.format(channel))
         if revision:
@@ -473,7 +490,8 @@ class Snap(object):
         self,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[int] = None,
+        revision: Optional[str] = None,
+        devmode: bool = False,
         leave_cohort: Optional[bool] = False,
     ) -> None:
         """Refresh a snap.
@@ -482,6 +500,7 @@ class Snap(object):
           channel: the channel to install from
           cohort: optionally, specify a cohort.
           revision: optionally, specify the revision of the snap to refresh
+          devmode: optionally, specify devmode confinement
           leave_cohort: leave the current cohort.
         """
         args = []
@@ -490,6 +509,9 @@ class Snap(object):
 
         if revision:
             args.append('--revision="{}"'.format(revision))
+
+        if devmode:
+            args.append("--devmode")
 
         if not cohort:
             cohort = self._cohort
@@ -515,15 +537,17 @@ class Snap(object):
         self,
         state: SnapState,
         classic: Optional[bool] = False,
+        devmode: bool = False,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
-        revision: Optional[int] = None,
+        revision: Optional[str] = None,
     ):
         """Ensure that a snap is in a given state.
 
         Args:
           state: a `SnapState` to reconcile to.
           classic: an (Optional) boolean indicating whether classic confinement should be used
+          devmode: an (Optional) boolean indicating whether devmode confinement should be used
           channel: the channel to install from
           cohort: optional. Specify the key of a snap cohort.
           revision: optional. the revision of the snap to install/refresh
@@ -534,7 +558,15 @@ class Snap(object):
         Raises:
           SnapError if an error is encountered
         """
-        self._confinement = "classic" if classic or self._confinement == "classic" else ""
+        if classic and devmode:
+            raise ValueError("Cannot set both classic and devmode confinement")
+
+        if classic or self._confinement == "classic":
+            self._confinement = "classic"
+        elif devmode or self._confinement == "devmode":
+            self._confinement = "devmode"
+        else:
+            self._confinement = ""
 
         if state not in (SnapState.Present, SnapState.Latest):
             # We are attempting to remove this snap.
@@ -551,7 +583,7 @@ class Snap(object):
                 self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).
-                self._refresh(channel, cohort, revision)
+                self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
 
         self._update_snap_apps()
         self._state = state
@@ -594,7 +626,7 @@ class Snap(object):
         self._state = state
 
     @property
-    def revision(self) -> int:
+    def revision(self) -> str:
         """Returns the revision for a snap."""
         return self._revision
 
@@ -677,7 +709,7 @@ class SnapClient:
         socket_path: str = "/run/snapd.socket",
         opener: Optional[urllib.request.OpenerDirector] = None,
         base_url: str = "http://localhost/v2/",
-        timeout: float = 5.0,
+        timeout: float = 30.0,
     ):
         """Initialize a client instance.
 
@@ -686,7 +718,7 @@ class SnapClient:
             opener: specifies an opener for unix socket, if unspecified a default is used
             base_url: base url for making requests to the snap client. Defaults to
                 http://localhost/v2/
-            timeout: timeout in seconds to use when making requests to the API. Default is 5.0s.
+            timeout: timeout in seconds to use when making requests to the API. Default is 30.0s.
         """
         if opener is None:
             opener = self._get_default_opener(socket_path)
@@ -847,7 +879,7 @@ class SnapCache(Mapping):
                 name=i["name"],
                 state=SnapState.Latest,
                 channel=i["channel"],
-                revision=int(i["revision"]),
+                revision=i["revision"],
                 confinement=i["confinement"],
                 apps=i.get("apps", None),
             )
@@ -865,7 +897,7 @@ class SnapCache(Mapping):
             name=info["name"],
             state=SnapState.Available,
             channel=info["channel"],
-            revision=int(info["revision"]),
+            revision=info["revision"],
             confinement=info["confinement"],
             apps=None,
         )
@@ -877,8 +909,9 @@ def add(
     state: Union[str, SnapState] = SnapState.Latest,
     channel: Optional[str] = "",
     classic: Optional[bool] = False,
+    devmode: bool = False,
     cohort: Optional[str] = "",
-    revision: Optional[int] = None,
+    revision: Optional[str] = None,
 ) -> Union[Snap, List[Snap]]:
     """Add a snap to the system.
 
@@ -889,8 +922,10 @@ def add(
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
+        devmode: an (Optional) boolean specifying whether it should be added with devmode
+            confinement. Default `False`
         cohort: an (Optional) string specifying the snap cohort to use
-        revision: an (Optional) integer specifying the snap revision to use
+        revision: an (Optional) string specifying the snap revision to use
 
     Raises:
         SnapError if some snaps failed to install or were not found.
@@ -898,14 +933,14 @@ def add(
     if not channel and not revision:
         channel = "latest"
 
-    snap_names = [snap_names] if type(snap_names) is str else snap_names
+    snap_names = [snap_names] if isinstance(snap_names, str) else snap_names
     if not snap_names:
         raise TypeError("Expected at least one snap to add, received zero!")
 
-    if type(state) is str:
+    if isinstance(state, str):
         state = SnapState(state)
 
-    return _wrap_snap_operations(snap_names, state, channel, classic, cohort, revision)
+    return _wrap_snap_operations(snap_names, state, channel, classic, devmode, cohort, revision)
 
 
 @_cache_init
@@ -918,11 +953,16 @@ def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
     Raises:
         SnapError if some snaps failed to install.
     """
-    snap_names = [snap_names] if type(snap_names) is str else snap_names
+    snap_names = [snap_names] if isinstance(snap_names, str) else snap_names
     if not snap_names:
         raise TypeError("Expected at least one snap to add, received zero!")
-
-    return _wrap_snap_operations(snap_names, SnapState.Absent, "", False)
+    return _wrap_snap_operations(
+        snap_names=snap_names,
+        state=SnapState.Absent,
+        channel="",
+        classic=False,
+        devmode=False,
+    )
 
 
 @_cache_init
@@ -931,6 +971,7 @@ def ensure(
     state: str,
     channel: Optional[str] = "",
     classic: Optional[bool] = False,
+    devmode: bool = False,
     cohort: Optional[str] = "",
     revision: Optional[int] = None,
 ) -> Union[Snap, List[Snap]]:
@@ -941,6 +982,8 @@ def ensure(
         state: a string representation of the desired state, from `SnapState`
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
+            confinement. Default `False`
+        devmode: an (Optional) boolean specifying whether it should be added with devmode
             confinement. Default `False`
         cohort: an (Optional) string specifying the snap cohort to use
         revision: an (Optional) integer specifying the snap revision to use
@@ -955,7 +998,15 @@ def ensure(
         channel = "latest"
 
     if state in ("present", "latest") or revision:
-        return add(snap_names, SnapState(state), channel, classic, cohort, revision)
+        return add(
+            snap_names=snap_names,
+            state=SnapState(state),
+            channel=channel,
+            classic=classic,
+            devmode=devmode,
+            cohort=cohort,
+            revision=revision,
+        )
     else:
         return remove(snap_names)
 
@@ -965,8 +1016,9 @@ def _wrap_snap_operations(
     state: SnapState,
     channel: str,
     classic: bool,
+    devmode: bool,
     cohort: Optional[str] = "",
-    revision: Optional[int] = None,
+    revision: Optional[str] = None,
 ) -> Union[Snap, List[Snap]]:
     """Wrap common operations for bare commands."""
     snaps = {"success": [], "failed": []}
@@ -980,7 +1032,12 @@ def _wrap_snap_operations(
                 snap.ensure(state=SnapState.Absent)
             else:
                 snap.ensure(
-                    state=state, classic=classic, channel=channel, cohort=cohort, revision=revision
+                    state=state,
+                    classic=classic,
+                    devmode=devmode,
+                    channel=channel,
+                    cohort=cohort,
+                    revision=revision,
                 )
             snaps["success"].append(snap)
         except SnapError as e:
@@ -999,13 +1056,17 @@ def _wrap_snap_operations(
 
 
 def install_local(
-    filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
+    filename: str,
+    classic: Optional[bool] = False,
+    devmode: Optional[bool] = False,
+    dangerous: Optional[bool] = False,
 ) -> Snap:
     """Perform a snap operation.
 
     Args:
         filename: the path to a local .snap file to install
         classic: whether to use classic confinement
+        devmode: whether to use devmode confinement
         dangerous: whether --dangerous should be passed to install snaps without a signature
 
     Raises:
@@ -1018,6 +1079,8 @@ def install_local(
     ]
     if classic:
         args.append("--classic")
+    if devmode:
+        args.append("--devmode")
     if dangerous:
         args.append("--dangerous")
     try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -178,18 +178,17 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             self.unit.reboot(now=True)
 
         if self.install_workload():
+            cache = snap.SnapCache()
+            mysql_snap = cache[CHARMED_MYSQL_SNAP_NAME]
+            mysql_snap.alias("mysql")
+            mysql_snap.alias("mysqlrouter")
+            mysql_snap.alias("mysqlsh")
+            mysql_snap.alias("xbcloud")
+            mysql_snap.alias("xbstream")
+            mysql_snap.alias("xtrabackup")
             self.unit.status = WaitingStatus("Waiting to start MySQL")
         else:
             self.unit.status = BlockedStatus("Failed to install and configure MySQL")
-
-        cache = snap.SnapCache()
-        mysql_snap = cache[CHARMED_MYSQL_SNAP_NAME]
-        mysql_snap.alias("mysql")
-        mysql_snap.alias("mysqlrouter")
-        mysql_snap.alias("mysqlsh")
-        mysql_snap.alias("xbcloud")
-        mysql_snap.alias("xbstream")
-        mysql_snap.alias("xtrabackup")
 
     def _on_leader_elected(self, _) -> None:
         """Handle the leader elected event."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -182,6 +182,15 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         else:
             self.unit.status = BlockedStatus("Failed to install and configure MySQL")
 
+        cache = snap.SnapCache()
+        mysql_snap = cache[CHARMED_MYSQL_SNAP_NAME]
+        mysql_snap.alias("mysql")
+        mysql_snap.alias("mysqlrouter")
+        mysql_snap.alias("mysqlsh")
+        mysql_snap.alias("xbcloud")
+        mysql_snap.alias("xbstream")
+        mysql_snap.alias("xtrabackup")
+
     def _on_leader_elected(self, _) -> None:
         """Handle the leader elected event."""
         # Set MySQL config values in the peer relation databag

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -25,7 +25,7 @@ from charms.mysql.v0.mysql import (
     MySQLStartMySQLDError,
     MySQLStopMySQLDError,
 )
-from charms.operator_libs_linux.v1 import snap
+from charms.operator_libs_linux.v2 import snap
 from ops.charm import CharmBase
 from tenacity import RetryError, Retrying, retry, stop_after_attempt, stop_after_delay, wait_fixed
 from typing_extensions import override

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,13 +16,13 @@ from ops.testing import Harness
 from tenacity import Retrying, stop_after_attempt
 
 from charm import MySQLOperatorCharm
+from constants import CHARMED_MYSQL_SNAP_NAME
 from mysql_vm_helpers import (
     MySQLCreateCustomMySQLDConfigError,
     MySQLResetRootPasswordAndStartMySQLDError,
 )
 
 from .helpers import patch_network_get
-from constants import CHARMED_MYSQL_SNAP_NAME
 
 
 class TestCharm(unittest.TestCase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,7 +16,6 @@ from ops.testing import Harness
 from tenacity import Retrying, stop_after_attempt
 
 from charm import MySQLOperatorCharm
-from constants import CHARMED_MYSQL_SNAP_NAME
 from mysql_vm_helpers import (
     MySQLCreateCustomMySQLDConfigError,
     MySQLResetRootPasswordAndStartMySQLDError,
@@ -49,9 +48,10 @@ class TestCharm(unittest.TestCase):
     @patch("charm.snap.SnapCache")
     @patch("mysql_vm_helpers.is_volume_mounted", return_value=True)
     @patch("mysql_vm_helpers.MySQL.install_and_configure_mysql_dependencies")
-    def test_on_install(self, _install_and_configure_mysql_dependencies, _snap_cache, ___, __, _, _____, ____):
+    def test_on_install(
+        self, _install_and_configure_mysql_dependencies, _snap_cache, ___, __, _, _____, ____
+    ):
         self.charm.on.install.emit()
-        mysql_snap = _snap_cache.return_value[CHARMED_MYSQL_SNAP_NAME]
         _install_and_configure_mysql_dependencies.assert_called_once()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, WaitingStatus))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,6 +16,7 @@ from ops.testing import Harness
 from tenacity import Retrying, stop_after_attempt
 
 from charm import MySQLOperatorCharm
+from constants import CHARMED_MYSQL_SNAP_NAME
 from mysql_vm_helpers import (
     MySQLCreateCustomMySQLDConfigError,
     MySQLResetRootPasswordAndStartMySQLDError,
@@ -45,10 +46,12 @@ class TestCharm(unittest.TestCase):
     @patch("socket.getfqdn", return_value="test-hostname")
     @patch("socket.gethostbyname", return_value="")
     @patch("subprocess.check_call")
+    @patch("charm.snap.SnapCache")
     @patch("mysql_vm_helpers.is_volume_mounted", return_value=True)
     @patch("mysql_vm_helpers.MySQL.install_and_configure_mysql_dependencies")
-    def test_on_install(self, _install_and_configure_mysql_dependencies, ____, ___, __, _, _____):
+    def test_on_install(self, _install_and_configure_mysql_dependencies, _snap_cache, ___, __, _, _____, ____):
         self.charm.on.install.emit()
+        mysql_snap = _snap_cache.return_value[CHARMED_MYSQL_SNAP_NAME]
         _install_and_configure_mysql_dependencies.assert_called_once()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, WaitingStatus))


### PR DESCRIPTION
## Issue

Missing snap aliases (ie using <snap> instead of charmed-msql.<snap>) for better tool usability inside VM.

## Solution

Heavily inspired by [ticket DPE-2090](https://github.com/canonical/postgresql-operator/pull/170).

## Testing

Since it is my first PR, here's how I went about testing my changes. Any feedback is appreciated!

```
# building local charm
tox run -e build-wrapper && mv requirements-last-build.txt requirements.txt && charmcraft pack

# deploy local charm
juju deploy ./mysql_ubuntu-22.04-amd64.charm 

# ssh into VM
juju ssh mysql/0 bash

# seeing snap aliases
snap aliases
```

With output:
```
Command                    Alias        Notes
charmed-mysql.mysql        mysql        manual
charmed-mysql.mysqlrouter  mysqlrouter  manual
charmed-mysql.mysqlsh      mysqlsh      manual
charmed-mysql.xbcloud      xbcloud      manual
charmed-mysql.xbstream     xbstream     manual
charmed-mysql.xtrabackup   xtrabackup   manual
lxd.lxc                    lxc          -
```
