### PR TITLE
[DPE-3705, DPE-3542] Reintroduce fallback keys and fix TLS secrets initialization

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -625,7 +625,7 @@ class MySQLCharmBase(CharmBase, ABC):
 
         fallback_key_to_secret_key = {v: k for k, v in SECRET_KEY_FALLBACKS.items()}
         if key in fallback_key_to_secret_key:
-            if value := self.peer_relation_data(scope).fetch_my_relation_field(peers.id, key):
+            if self.peer_relation_data(scope).fetch_my_relation_field(peers.id, key):
                 self.remove_secret(scope, key)
             self.peer_relation_data(scope).update_relation_data(
                 peers.id, {fallback_key_to_secret_key[key]: value}

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -620,8 +620,9 @@ class MySQLCharmBase(CharmBase, ABC):
 
         if not value:
             if key in SECRET_KEY_FALLBACKS:
-                self.remove_secret(scope, SECRET_ACCESS_KEY[key])
-            return self.remove_secret(scope, key)
+                self.remove_secret(scope, SECRET_KEY_FALLBACKS[key])
+            self.remove_secret(scope, key)
+            return
 
         peers = self.model.get_relation(PEER)
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -115,7 +115,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 56
+LIBPATCH = 57
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -619,6 +619,8 @@ class MySQLCharmBase(CharmBase, ABC):
             raise MySQLSecretError("Can only set app secrets on the leader unit")
 
         if not value:
+            if key in SECRET_KEY_FALLBACKS:
+                self.remove_secret(scope, SECRET_ACCESS_KEY[key])
             return self.remove_secret(scope, key)
 
         peers = self.model.get_relation(PEER)

--- a/src/constants.py
+++ b/src/constants.py
@@ -47,3 +47,12 @@ ROOT_SYSTEM_USER = "root"
 GR_MAX_MEMBERS = 9
 HOSTNAME_DETAILS = "hostname-details"
 COS_AGENT_RELATION_NAME = "cos-agent"
+SECRET_KEY_FALLBACKS = {
+    "root-password": "root_password",
+    "server-config-password": "server_config_password",
+    "cluster-admin-password": "cluster_admin_password",
+    "monitoring-password": "monitoring_password",
+    "backups-password": "backups_password",
+    "certificate": "cert",
+    "certificate-authority": "ca",
+}


### PR DESCRIPTION
## Issue
1. We are not correctly initializing some TLS secret keys (e.g. `cert` instead of `certificate`, `cauth` instead of `certificate-authority`)
2. As part of [PR 385](https://github.com/canonical/mysql-operator/pull/385/files), we got rid of the secret fallback keys. However, this is necessary for clients who are upgrading from old versions of the charm (without secrets) to this version of the charm (with secrets) 

## Solution
1. Correctly initialize the TLS secret keys
2. Re-introduce fallback keys in the framework of the new secrets lib (data_interfaces) (see Jira ticket for link to conversation for more context)