### PR TITLE
Avoid `{` and `}` getting redacted in logs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,8 @@ jobs:
       libjuju-version-constraint: ${{ matrix.juju.libjuju }}
       _beta_allure_report: ${{ matrix.juju.allure }}
     secrets:
+      # GitHub appears to redact each line of a multi-line secret
+      # Avoid putting `{` or `}` on a line by itself so that it doesn't get redacted in logs
       integration-test: |
         { "AWS_ACCESS_KEY": "${{ secrets.AWS_ACCESS_KEY }}",
           "AWS_SECRET_KEY": "${{ secrets.AWS_SECRET_KEY }}",


### PR DESCRIPTION
https://github.com/canonical/data-platform-workflows/pull/166