### PR TITLE
Update mysql charm lib patch; leftover from PR 440

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -116,7 +116,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 58
+LIBPATCH = 59
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"


### PR DESCRIPTION
## Issue
As a mix up, when [PR 440](https://github.com/canonical/mysql-operator/pull/440/files) was merged (shortly after the async repl PR was merged), the libpatch for the mysql charm lib was not updated

## Solution
Bump the libpatch
