### PR TITLE
Mark rollback test unstable

### DIFF
--- a/tests/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -120,6 +120,7 @@ async def test_upgrade_to_failling(
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
+@pytest.mark.unstable
 async def test_rollback(ops_test, continuous_writes) -> None:
     application = ops_test.model.applications[MYSQL_APP_NAME]
 


### PR DESCRIPTION
## Issue
The rollback test is really flake-y (failed 9 times in a row in https://github.com/canonical/mysql-operator/actions/runs/8883862972/job/24418820238)

## Solution
There is a ticket to determine the root cause which @paulomach will pick up, but mark the test as unstable until then