### PR TITLE
Decrement mysql libpatch from 59 to 58 to match published version on charmhub

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -116,7 +116,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 59
+LIBPATCH = 58
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 class LockNoRelationError(Exception):
@@ -318,6 +318,7 @@ class RollingOpsManager(Object):
         self.framework.observe(charm.on[self.name].acquire_lock, self._on_acquire_lock)
         self.framework.observe(charm.on[self.name].run_with_lock, self._on_run_with_lock)
         self.framework.observe(charm.on[self.name].process_locks, self._on_process_locks)
+        self.framework.observe(charm.on.leader_elected, self._on_process_locks)
 
     def _callback(self: CharmBase, event: EventBase) -> None:
         """Placeholder for the function that actually runs our event.

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -39,7 +39,8 @@ class TestMySQLBackups(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
         self.peer_relation_id = self.harness.add_relation("database-peers", "database-peers")
-        self.harness.set_leader(True)
+        with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks") as _:
+            self.harness.set_leader(True)
         self.harness.charm.on.config_changed.emit()
         self.charm = self.harness.charm
         self.s3_integrator_id = self.harness.add_relation(
@@ -319,9 +320,6 @@ Juju Version: 0.0.0
         _offline_mode_and_hidden_instance_exists,
     ):
         """Test _can_unit_perform_backup()."""
-        self.harness.set_leader(True)
-        self.charm.on.config_changed.emit()
-
         success, error_message = self.mysql_backups._can_unit_perform_backup()
         self.assertTrue(success)
         self.assertIsNone(error_message)

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -41,7 +41,8 @@ class TestDatabase(unittest.TestCase):
         _get_mysql_version,
     ):
         # run start-up events to enable usage of the helper class
-        self.harness.set_leader(True)
+        with patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks") as _:
+            self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
 
         # confirm that the relation databag is empty

--- a/tests/unit/test_db_router.py
+++ b/tests/unit/test_db_router.py
@@ -17,6 +17,7 @@ from charm import MySQLOperatorCharm
 from .helpers import patch_network_get
 
 
+@patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
 class TestDBRouter(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(MySQLOperatorCharm)
@@ -41,6 +42,7 @@ class TestDBRouter(unittest.TestCase):
         _does_mysql_user_exist,
         _get_cluster_primary_address,
         _generate_random_password,
+        _,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
@@ -128,6 +130,7 @@ class TestDBRouter(unittest.TestCase):
         _configure_mysqlrouter_user,
         _does_mysql_user_exist,
         _generate_random_password,
+        _,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)

--- a/tests/unit/test_relation_mysql_legacy.py
+++ b/tests/unit/test_relation_mysql_legacy.py
@@ -13,6 +13,7 @@ from constants import LEGACY_MYSQL, PEER
 from .helpers import patch_network_get
 
 
+@patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
 class TestMariaDBRelation(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(MySQLOperatorCharm)
@@ -37,6 +38,7 @@ class TestMariaDBRelation(unittest.TestCase):
         _get_or_set_password_in_peer_secrets,
         _get_cluster_primary_address,
         _does_mysql_user_exist,
+        _,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
@@ -92,6 +94,7 @@ class TestMariaDBRelation(unittest.TestCase):
         _get_or_set_password_in_peer_secrets,
         _get_cluster_primary_address,
         _does_mysql_user_exist,
+        _,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
@@ -151,6 +154,7 @@ class TestMariaDBRelation(unittest.TestCase):
         _delete_users_for_unit,
         _get_cluster_primary_address,
         _does_mysql_user_exist,
+        _,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)

--- a/tests/unit/test_shared_db.py
+++ b/tests/unit/test_shared_db.py
@@ -14,6 +14,7 @@ from constants import LEGACY_DB_SHARED
 from .helpers import patch_network_get
 
 
+@patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
 class TestSharedDBRelation(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(MySQLOperatorCharm)
@@ -34,6 +35,7 @@ class TestSharedDBRelation(unittest.TestCase):
         _create_application_database_and_scoped_user,
         _generate_random_password,
         _get_cluster_primary_address,
+        _,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
@@ -89,7 +91,7 @@ class TestSharedDBRelation(unittest.TestCase):
     @patch("utils.generate_random_password", return_value="super_secure_password")
     @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
     def test_shared_db_relation_changed_error_on_user_creation(
-        self, _create_application_database_and_scoped_user, _generate_random_password
+        self, _create_application_database_and_scoped_user, _generate_random_password, _
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
@@ -123,6 +125,7 @@ class TestSharedDBRelation(unittest.TestCase):
         _generate_random_password,
         _delete_users_for_unit,
         _get_cluster_primary_address,
+        _,
     ):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -60,11 +60,12 @@ class TestUpgrade(unittest.TestCase):
         self.assertTrue(len(us) == 3)
         self.assertEqual(us, [0, 1, 2])
 
+    @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
     @patch("charm.MySQLOperatorCharm.get_unit_ip", return_value="10.0.1.1")
     @patch("upgrade.MySQLVMUpgrade._pre_upgrade_prepare")
     @patch("mysql_vm_helpers.MySQL.get_cluster_status", return_value=MOCK_STATUS_ONLINE)
     def test_pre_upgrade_check(
-        self, mock_get_cluster_status, mock_pre_upgrade_prepare, mock_get_unit_ip
+        self, mock_get_cluster_status, mock_pre_upgrade_prepare, mock_get_unit_ip, _
     ):
         """Test the pre upgrade check."""
         self.harness.set_leader(True)
@@ -107,6 +108,7 @@ class TestUpgrade(unittest.TestCase):
         ]
         mock_logging.assert_has_calls(calls)
 
+    @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
     @patch("charm.MySQLOperatorCharm.get_unit_ip", return_value="10.0.1.1")
     @patch("mysql_vm_helpers.MySQL.set_dynamic_variable")
     @patch("mysql_vm_helpers.MySQL.get_primary_label", return_value="mysql-1")
@@ -117,6 +119,7 @@ class TestUpgrade(unittest.TestCase):
         mock_get_primary_label,
         mock_set_dynamic_variable,
         mock_get_unit_ip,
+        _,
     ):
         """Test the pre upgrade prepare."""
         self.harness.set_leader(True)
@@ -261,8 +264,9 @@ class TestUpgrade(unittest.TestCase):
         self.assertEqual(self.charm.unit_peer_data["member-role"], "secondary")
         self.assertEqual(self.charm.unit_peer_data["member-state"], "waiting")
 
+    @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
     @patch("upgrade.MySQLVMUpgrade._prepare_upgrade_from_legacy")
-    def test_upgrade_charm_legacy(self, mock_prepare_upgrade_from_legacy):
+    def test_upgrade_charm_legacy(self, mock_prepare_upgrade_from_legacy, _):
         self.harness.update_relation_data(self.upgrade_relation_id, "mysql/0", {"state": ""})
 
         # non leader


### PR DESCRIPTION
## Issue
here was a mixup (two prs in vm were merged simultaneously, both with libpatch 58 - the release libs from the [first PR failed](https://github.com/canonical/mysql-operator/actions/runs/8822816145/job/24223455067) and the release from the [second PR](https://github.com/canonical/mysql-operator/actions/runs/8838306232/job/24277534541) also failed... but un-atomically published both changes in the same libpatch)

[attempt](https://github.com/canonical/mysql-operator/actions/runs/8894633351/job/24433700055#step:4:78) to increment the libpatch only failed

## Solution
Decrement libpatch back to 58 (to match published lib in charmhub) so that the next update to this lib does not fail to publish