### PR TITLE
DPE-4273 avoid restart being triggered after upgrade

### DIFF
--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -183,6 +183,11 @@ class MySQLVMUpgrade(DataUpgrade):
                 return
             self.charm.unit.status = MaintenanceStatus("check if upgrade is possible")
             self._check_server_upgradeability()
+            # override config, avoid restart
+            self.charm._mysql.write_mysqld_config(
+                profile=self.charm.config.profile,
+                memory_limit=self.charm.config.profile_limit_memory,
+            )
             self.charm.unit.status = MaintenanceStatus("starting services...")
             self.charm._mysql.start_mysqld()
             self.charm._mysql.setup_logrotate_and_cron()

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -131,6 +131,7 @@ class TestUpgrade(unittest.TestCase):
         mock_get_primary_label.assert_called_once()
         assert mock_set_dynamic_variable.call_count == 2
 
+    @patch("mysql_vm_helpers.MySQL.write_mysqld_config")
     @patch("upgrade.MySQLVMUpgrade._check_server_unsupported_downgrade")
     @patch("upgrade.MySQLVMUpgrade._reset_on_unsupported_downgrade")
     @patch("mysql_vm_helpers.MySQL.hold_if_recovering")
@@ -158,6 +159,7 @@ class TestUpgrade(unittest.TestCase):
         mock_hold_if_recovering,
         mock_reset_on_unsupported_downgrade,
         mock_check_server_unsupported_downgrade,
+        mock_write_mysqld_config,
     ):
         """Test upgrade-granted hook."""
         self.charm.on.config_changed.emit()
@@ -176,6 +178,7 @@ class TestUpgrade(unittest.TestCase):
         mock_install_workload.assert_called_once()
         mock_get_mysql_version.assert_called_once()
         mock_setup_logrotate_and_cron.assert_called_once()
+        mock_write_mysqld_config.assert_called_once()
 
         self.harness.update_relation_data(
             self.upgrade_relation_id, "mysql/0", {"state": "upgrading"}


### PR DESCRIPTION
## Issue

* on upgrade, config file was not being update/override in the process
* after updgrade, config change was triggering restart of the service
* restart hook failed to consider all units

This was causing the failure of scaling up after a successful upgrade.

## Solution

* addressed issues above
