### PR TITLE
DPE-4556 Bump Juju version to the lastest patchset level of 2.9/3.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,10 +65,10 @@ jobs:
       fail-fast: false
       matrix:
         juju:
-          - agent: 2.9.49
+          - agent: 2.9.49  # renovate: juju-agent-pin-minor
             libjuju: ^2
             allure: false
-          - agent: 3.1.8
+          - agent: 3.1.8  # renovate: juju-agent-pin-minor
             allure: true
     name: Integration test charm | ${{ matrix.juju.agent }}
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,10 +65,10 @@ jobs:
       fail-fast: false
       matrix:
         juju:
-          - agent: 2.9.46
+          - agent: 2.9.49
             libjuju: ^2
             allure: false
-          - agent: 3.1.7
+          - agent: 3.1.8
             allure: true
     name: Integration test charm | ${{ matrix.juju.agent }}
     needs:


### PR DESCRIPTION
## Issue
We are running tests agains outdated Juju versions 2.9.46/3.1.7.

## Solution
Update tests to use the latest Juju versions 2.9.49/3.1.8.