### PR TITLE
DPE-4677 Remove parameter not in spec

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -74,10 +74,6 @@ promote-to-primary:
     Promotes this cluster to become the primary in the cluster-set. Used for safe switchover or failover.
     Can only be run against the charm leader unit of a standby cluster.
   params:
-    cluster-set-name:
-      type: string
-      description: |
-        The name of the cluster-set. Mandatory option, used for confirmation.
     force:
       type: boolean
       default: False

--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 # The unique Charmhub library identifier, never change it
 LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
-LIBPATCH = 2
+LIBPATCH = 3
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"

--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -158,10 +158,6 @@ class MySQLAsyncReplication(Object):
             event.fail("Only a standby cluster can be promoted")
             return
 
-        if event.params.get("cluster-set-name") != self.cluster_set_name:
-            event.fail("Invalid/empty cluster set name")
-            return
-
         # promote cluster to primary
         cluster_name = self.cluster_name
         force = event.params.get("force", False)

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -15,12 +15,7 @@ from juju.model import Model
 from pytest_operator.plugin import OpsTest
 
 from .. import juju_
-from ..helpers import (
-    execute_queries_on_unit,
-    get_cluster_status,
-    get_leader_unit,
-    get_relation_data,
-)
+from ..helpers import execute_queries_on_unit, get_cluster_status, get_leader_unit
 from ..markers import juju3
 from .high_availability_helpers import DATABASE_NAME, TABLE_NAME
 
@@ -228,11 +223,10 @@ async def test_standby_promotion(
 
     assert leader_unit is not None, "No leader unit found on standby cluster"
 
-    relation_data = await get_relation_data(ops_test, MYSQL_APP1, "database-peers")
-    cluster_set_name = relation_data[0]["application-data"]["cluster-set-domain-name"]
     logger.info("Promoting standby cluster to primary")
     await juju_.run_action(
-        leader_unit, "promote-to-primary", **{"cluster-set-name": cluster_set_name}
+        leader_unit,
+        "promote-to-primary",
     )
 
     results = await get_max_written_value(first_model, second_model)
@@ -261,12 +255,10 @@ async def test_failover(ops_test: OpsTest, first_model: Model, second_model: Mod
     logger.info("Promoting standby cluster to primary with force flag")
     leader_unit = await get_leader_unit(None, MYSQL_APP1, first_model)
     assert leader_unit is not None, "No leader unit found"
-    relation_data = await get_relation_data(ops_test, MYSQL_APP1, "database-peers")
-    cluster_set_name = relation_data[0]["application-data"]["cluster-set-domain-name"]
     await juju_.run_action(
         leader_unit,
         "promote-to-primary",
-        **{"--wait": "5m", "cluster-set-name": cluster_set_name, "force": True},
+        **{"--wait": "5m", "force": True},
     )
 
     cluster_set_status = await get_cluster_status(leader_unit, cluster_set=True)


### PR DESCRIPTION
## Issue

`cluster-set-name` as parameter to `promote-to-primary` action is not in accordance with the spec.

## Solution

Remove the action parameter
