### PR TITLE
DPE-4658 global-primary on endpoint

### DIFF
--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -391,8 +391,11 @@ class MySQLAsyncReplicationOffer(MySQLAsyncReplication):
             else:
                 return States.RECOVERING
         if self.role.relation_side == RELATION_CONSUMER:
-            # if on the consume and is primary, the cluster is ready
-            return States.READY
+            # if on the consume and is primary
+            # the cluster is ready when fully initialized
+            if self._charm.cluster_fully_initialized:
+                return States.READY
+            return States.RECOVERING
 
     @property
     def idle(self) -> bool:

--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -6,7 +6,6 @@
 import enum
 import logging
 import typing
-import uuid
 from functools import cached_property
 from time import sleep
 
@@ -55,7 +54,7 @@ logger = logging.getLogger(__name__)
 # The unique Charmhub library identifier, never change it
 LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
-LIBPATCH = 3
+LIBPATCH = 4
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"
@@ -129,10 +128,9 @@ class MySQLAsyncReplication(Object):
     @property
     def relation(self) -> Optional[Relation]:
         """Relation."""
-        if isinstance(self, MySQLAsyncReplicationOffer):
-            return self.model.get_relation(RELATION_OFFER)
-
-        return self.model.get_relation(RELATION_CONSUMER)
+        return self.model.get_relation(RELATION_OFFER) or self.model.get_relation(
+            RELATION_CONSUMER
+        )
 
     @property
     def relation_data(self) -> Optional[RelationDataContent]:
@@ -168,6 +166,10 @@ class MySQLAsyncReplication(Object):
             logger.info(message)
             event.set_results({"message": message})
             self._charm._on_update_status(None)
+            # write counter to propagate status update on the other side
+            self.relation_data["switchover"] = str(
+                int(self.relation_data.get("switchover", 0)) + 1
+            )
         except MySQLPromoteClusterToPrimaryError:
             logger.exception("Failed to promote cluster to primary")
             event.fail("Failed to promote cluster to primary")
@@ -388,6 +390,9 @@ class MySQLAsyncReplicationOffer(MySQLAsyncReplication):
                 return States.INITIALIZING
             else:
                 return States.RECOVERING
+        if self.role.relation_side == RELATION_CONSUMER:
+            # if on the consume and is primary, the cluster is ready
+            return States.READY
 
     @property
     def idle(self) -> bool:
@@ -570,6 +575,11 @@ class MySQLAsyncReplicationOffer(MySQLAsyncReplication):
             # Recover replica cluster
             self._charm.unit.status = MaintenanceStatus("Replica cluster in recovery")
 
+        elif state == States.READY:
+            # trigger update status on relation update when ready
+            # speeds up status on switchover
+            self._charm._on_update_status(None)
+
     def _on_offer_relation_broken(self, event: RelationBrokenEvent):
         """Handle the async_primary relation being broken."""
         if self._charm.unit.is_leader():
@@ -642,11 +652,15 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
             # and did not synced credentials
             return States.SYNCING
 
-        if self.replica_initialized:
-            # cluster added to cluster-set by primary cluster
-            if self._charm.cluster_fully_initialized:
-                return States.READY
-            return States.RECOVERING
+        if self.model.get_relation(RELATION_CONSUMER):
+            if self.replica_initialized:
+                # cluster added to cluster-set by primary cluster
+                if self._charm.cluster_fully_initialized:
+                    return States.READY
+                return States.RECOVERING
+        else:
+            return States.READY
+
         return States.INITIALIZING
 
     @property
@@ -672,7 +686,7 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
 
     @property
     def replica_initialized(self) -> bool:
-        """Whether the replica cluster is initialized as such."""
+        """Whether the replica cluster was initialized."""
         return self.remote_relation_data.get("replica-state") == "initialized"
 
     def _check_version(self) -> bool:
@@ -685,7 +699,8 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
 
         if remote_version != local_version:
             logger.error(
-                f"Primary cluster MySQL version {remote_version} is not compatible with this cluster MySQL version {local_version}"
+                f"Primary cluster MySQL version {remote_version} is not compatible with this"
+                f"cluster MySQL version {local_version}"
             )
             return False
 
@@ -824,11 +839,12 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
 
             if self.remote_relation_data["cluster-name"] == self.cluster_name:  # pyright: ignore
                 # this cluster need a new cluster name
+                # we append the model uuid, trimming to a max of 63 characters
                 logger.warning(
-                    "Cluster name is the same as the primary cluster. Appending generated value"
+                    "Cluster name is the same as the primary cluster. Appending model uuid"
                 )
                 self._charm.app_peer_data["cluster-name"] = (
-                    f"{self.cluster_name}{uuid.uuid4().hex[:4]}"
+                    f"{self.cluster_name}{self.model.uuid.replace('-', '')}"[:63]
                 )
 
             self._charm.unit.status = MaintenanceStatus("Populate endpoint")

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -130,7 +130,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 60
+LIBPATCH = 61
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1963,11 +1963,17 @@ class MySQLBase(ABC):
             for v in topology.values()
             if v["mode"] == "r/o" and v["status"] == MySQLMemberState.ONLINE
         }
-        rw_endpoints = {
-            _get_host_ip(v["address"]) if get_ips else v["address"]
-            for v in topology.values()
-            if v["mode"] == "r/w" and v["status"] == MySQLMemberState.ONLINE
-        }
+
+        if self.is_cluster_replica():
+            # replica return global primary address
+            global_primary = self.get_cluster_set_global_primary_address()
+            rw_endpoints = {_get_host_ip(global_primary) if get_ips else global_primary}
+        else:
+            rw_endpoints = {
+                _get_host_ip(v["address"]) if get_ips else v["address"]
+                for v in topology.values()
+                if v["mode"] == "r/w" and v["status"] == MySQLMemberState.ONLINE
+            }
         # won't get offline endpoints to IP as they maybe unreachable
         no_endpoints = {
             v["address"] for v in topology.values() if v["status"] != MySQLMemberState.ONLINE

--- a/tests/unit/test_async_replication.py
+++ b/tests/unit/test_async_replication.py
@@ -444,6 +444,7 @@ class TestAsyncRelation(unittest.TestCase):
     @patch("charm.MySQLOperatorCharm._mysql")
     def test_promote_to_primary(self, _mysql, _):
         self.harness.set_leader(True)
+        self.harness.add_relation(RELATION_CONSUMER, "db1")
 
         _mysql.is_cluster_replica.return_value = True
 
@@ -455,6 +456,7 @@ class TestAsyncRelation(unittest.TestCase):
         _mysql.promote_cluster_to_primary.assert_called_with(
             self.charm.app_peer_data["cluster-name"], False
         )
+        self.assertEqual(self.async_replica.relation_data["switchover"], "1")
 
         _mysql.reset_mock()
 
@@ -469,6 +471,7 @@ class TestAsyncRelation(unittest.TestCase):
         _mysql.promote_cluster_to_primary.assert_called_with(
             self.charm.app_peer_data["cluster-name"], True
         )
+        self.assertEqual(self.async_replica.relation_data["switchover"], "2")
 
     @patch("charm.MySQLOperatorCharm._mysql")
     def test_rejoin_cluster_action(self, _mysql, _):

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -964,8 +964,9 @@ class TestMySQLBase(unittest.TestCase):
 
         _run_mysqlsh_script.assert_called_with(expected_commands)
 
+    @patch("charms.mysql.v0.mysql.MySQLBase.is_cluster_replica", return_value=False)
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_status", return_value=SHORT_CLUSTER_STATUS)
-    def test_get_cluster_endpoints(self, _):
+    def test_get_cluster_endpoints(self, _, _is_cluster_replica):
         """Test get_cluster_endpoints() method."""
         endpoints = self.mysql.get_cluster_endpoints(get_ips=False)
 


### PR DESCRIPTION
## Issue

1. Slow status update on switchover
1. Endpoint being empty breaks related router
1. cluster name clash workaround use meaningless hash


## Solution

* propagating switchover status change across cluster
* use global cluster set primary on standby endpoint
* use model_uuid to workaround cluster name clash (instead of generated uuid)
