### PR TITLE
Remove unused key/values from the databag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,7 @@ jobs:
       cloud: lxd
       juju-agent-version: ${{ matrix.juju.agent }}
       libjuju-version-constraint: ${{ matrix.juju.libjuju }}
+      lxd-snap-channel: 5.21/stable
       _beta_allure_report: ${{ matrix.juju.allure_on_amd64 && matrix.architecture == 'amd64' }}
     secrets:
       # GitHub appears to redact each line of a multi-line secret

--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -248,8 +248,6 @@ class MySQLAsyncReplication(Object):
                 "\tThe cluster can be recreated with the `recreate-cluster` action.\n"
                 "\tAlternatively the cluster can be rejoined to the cluster set."
             )
-            # reset the cluster node count flag
-            del self._charm.app_peer_data["units-added-to-cluster"]
             # set flag to persist removed from cluster-set state
             self._charm.app_peer_data["removed-from-cluster-set"] = "true"
 
@@ -834,8 +832,6 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
             self._charm.unit.status = MaintenanceStatus("Dissolving replica cluster")
             logger.info("Dissolving replica cluster")
             self._charm._mysql.dissolve_cluster()
-            # reset the cluster node count flag
-            del self._charm.app_peer_data["units-added-to-cluster"]
             # reset force rejoin-secondaries flag
             del self._charm.app_peer_data["rejoin-secondaries"]
 
@@ -869,11 +865,6 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
             if cluster_set_domain_name := self._charm._mysql.get_cluster_set_name():
                 self._charm.app_peer_data["cluster-set-domain-name"] = cluster_set_domain_name
 
-            # set the number of units added to the cluster for a single unit replica cluster
-            # needed here since it will skip the `RECOVERING` state
-            if self._charm.app.planned_units() == 1:
-                self._charm.app_peer_data["units-added-to-cluster"] = "1"
-
             self._charm._on_update_status(None)
         elif state == States.RECOVERING:
             # recovering cluster (copying data and/or joining units)
@@ -882,10 +873,6 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
                 "Waiting for recovery to complete on other units"
             )
             logger.debug("Awaiting other units to join the cluster")
-            # reset the number of units added to the cluster
-            # this will trigger secondaries to join the cluster
-            node_count = self._charm._mysql.get_cluster_node_count()
-            self._charm.app_peer_data["units-added-to-cluster"] = str(node_count)
             # set state flags to allow secondaries to join the cluster
             self._charm.unit_peer_data["member-state"] = "online"
             self._charm.unit_peer_data["member-role"] = "primary"

--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # The unique Charmhub library identifier, never change it
 LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
-LIBPATCH = 4
+LIBPATCH = 5
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -589,7 +589,6 @@ class MySQLCharmBase(CharmBase, ABC):
         # rescan cluster for cleanup of unused
         # recovery users
         self._mysql.rescan_cluster()
-        self.app_peer_data["units-added-to-cluster"] = "1"
 
         state, role = self._mysql.get_member_state()
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -128,7 +128,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 62
+LIBPATCH = 63
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/src/charm.py
+++ b/src/charm.py
@@ -508,9 +508,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         self._handle_non_online_instance_status(state)
 
         if self.unit.is_leader():
-            nodes = self._mysql.get_cluster_node_count()
-            if nodes > 0:
-                self.app_peer_data["units-added-to-cluster"] = str(nodes)
             try:
                 primary_address = self._mysql.get_cluster_primary_address()
             except MySQLGetClusterPrimaryAddressError:
@@ -818,7 +815,6 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 self.unit.status = WaitingStatus("waiting to join the cluster")
                 logger.debug("Waiting to joing the cluster, failed to acquire lock.")
                 return
-        # Update 'units-added-to-cluster' counter in the peer relation databag
         self.unit_peer_data["member-state"] = "online"
         self.unit.status = ActiveStatus(self.active_status_message)
         logger.debug(f"Instance {instance_label} is cluster member")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -388,8 +388,8 @@ def cut_network_from_unit(machine_name: str) -> None:
         machine_name: lxc container hostname
     """
     # apply a mask (device type `none`)
-    cut_network_command = f"lxc config device add {machine_name} eth0 none --project default"
-    subprocess.run(cut_network_command.split(), check=True)
+    cut_network_command = f"lxc config device add {machine_name} eth0 none"
+    subprocess.check_call(cut_network_command.split())
 
 
 def restore_network_for_unit(machine_name: str) -> None:
@@ -399,8 +399,8 @@ def restore_network_for_unit(machine_name: str) -> None:
         machine_name: lxc container hostname
     """
     # remove mask from eth0
-    restore_network_command = f"lxc config device remove {machine_name} eth0 --project default"
-    subprocess.run(restore_network_command.split(), check=True)
+    restore_network_command = f"lxc config device remove {machine_name} eth0"
+    subprocess.check_call(restore_network_command.split())
 
 
 async def unit_hostname(ops_test: OpsTest, unit_name: str) -> str:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -388,7 +388,7 @@ def cut_network_from_unit(machine_name: str) -> None:
         machine_name: lxc container hostname
     """
     # apply a mask (device type `none`)
-    cut_network_command = f"lxc config device add {machine_name} eth0 none"
+    cut_network_command = f"lxc config device add {machine_name} eth0 none --project default"
     subprocess.check_call(cut_network_command.split())
 
 
@@ -399,7 +399,7 @@ def restore_network_for_unit(machine_name: str) -> None:
         machine_name: lxc container hostname
     """
     # remove mask from eth0
-    restore_network_command = f"lxc config device remove {machine_name} eth0"
+    restore_network_command = f"lxc config device remove {machine_name} eth0 --project default"
     subprocess.check_call(restore_network_command.split())
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -389,11 +389,7 @@ def cut_network_from_unit(machine_name: str) -> None:
     """
     # apply a mask (device type `none`)
     cut_network_command = f"lxc config device add {machine_name} eth0 none --project default"
-    try:
-        subprocess.run(cut_network_command.split(), check=True)
-    except Exception as e:
-        logger.error(e)
-        raise
+    subprocess.run(cut_network_command.split(), check=True)
 
 
 def restore_network_for_unit(machine_name: str) -> None:
@@ -404,11 +400,7 @@ def restore_network_for_unit(machine_name: str) -> None:
     """
     # remove mask from eth0
     restore_network_command = f"lxc config device remove {machine_name} eth0 --project default"
-    try:
-        subprocess.run(restore_network_command.split(), check=True)
-    except Exception as e:
-        logger.error(e)
-        raise
+    subprocess.run(restore_network_command.split(), check=True)
 
 
 async def unit_hostname(ops_test: OpsTest, unit_name: str) -> str:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -389,7 +389,11 @@ def cut_network_from_unit(machine_name: str) -> None:
     """
     # apply a mask (device type `none`)
     cut_network_command = f"lxc config device add {machine_name} eth0 none --project default"
-    subprocess.check_call(cut_network_command.split())
+    try:
+        subprocess.run(cut_network_command.split(), check=True)
+    except Exception as e:
+        logger.error(e)
+        raise
 
 
 def restore_network_for_unit(machine_name: str) -> None:
@@ -400,7 +404,11 @@ def restore_network_for_unit(machine_name: str) -> None:
     """
     # remove mask from eth0
     restore_network_command = f"lxc config device remove {machine_name} eth0 --project default"
-    subprocess.check_call(restore_network_command.split())
+    try:
+        subprocess.run(restore_network_command.split(), check=True)
+    except Exception as e:
+        logger.error(e)
+        raise
 
 
 async def unit_hostname(ops_test: OpsTest, unit_name: str) -> str:

--- a/tests/unit/test_async_replication.py
+++ b/tests/unit/test_async_replication.py
@@ -100,8 +100,6 @@ class TestAsyncRelation(unittest.TestCase):
         self.harness.remove_relation(async_primary_relation_id)
 
         self.assertEqual(self.charm.app_peer_data["removed-from-cluster-set"], "true")
-        self.assertNotIn("unit-initialized", self.charm.unit_peer_data)
-        self.assertNotIn("units-added-to-cluster", self.charm.app_peer_data)
 
     @patch("charm.MySQLOperatorCharm._mysql")
     def test_get_state(self, _mysql, _):
@@ -149,13 +147,6 @@ class TestAsyncRelation(unittest.TestCase):
         _mysql.is_cluster_replica.return_value = False
         _mysql.get_mysql_version.return_value = "8.0.36-0ubuntu0.22.04.1"
         _mysql.get_member_state.return_value = ("online", "primary")
-
-        self.harness.update_relation_data(
-            self.peers_relation_id, self.charm.unit.name, {"unit-initialized": "True"}
-        )
-        self.harness.update_relation_data(
-            self.peers_relation_id, self.charm.app.name, {"units-added-to-cluster": "1"}
-        )
 
         async_primary_relation_id = self.harness.add_relation(
             RELATION_OFFER, "db2", app_data={"is-replica": "true"}
@@ -317,9 +308,6 @@ class TestAsyncRelation(unittest.TestCase):
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
 
-        self.harness.update_relation_data(
-            self.peers_relation_id, self.charm.unit.name, {"unit-initialized": "True"}
-        )
         async_relation_id = self.harness.add_relation(RELATION_CONSUMER, "db1")
 
         # 1. returning cluster
@@ -409,7 +397,6 @@ class TestAsyncRelation(unittest.TestCase):
 
         _update_status.assert_called_once()
         self.assertEqual(self.charm.app_peer_data["cluster-set-domain-name"], "cluster-set-test")
-        self.assertEqual(self.charm.app_peer_data["units-added-to-cluster"], "1")
 
     @patch("ops.framework.EventBase.defer")
     @patch(
@@ -432,7 +419,6 @@ class TestAsyncRelation(unittest.TestCase):
             {"some": "data3"},
         )
 
-        self.assertEqual(self.charm.app_peer_data["units-added-to-cluster"], "2")
         _defer.assert_called_once()
 
     def test_consumer_created_non_leader(self, _):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -259,7 +259,6 @@ class TestCharm(unittest.TestCase):
         "charm.MySQLOperatorCharm.unit_initialized", new_callable=PropertyMock(return_value=True)
     )
     @patch("charms.mysql.v0.mysql.MySQLCharmBase.active_status_message", return_value="")
-    @patch("mysql_vm_helpers.MySQL.get_cluster_node_count", return_value=1)
     @patch("mysql_vm_helpers.MySQL.get_member_state")
     @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address")
     @patch("charm.is_volume_mounted", return_value=True)
@@ -274,7 +273,6 @@ class TestCharm(unittest.TestCase):
         _is_volume_mounted,
         _get_cluster_primary_address,
         _get_member_state,
-        _get_cluster_node_count,
         _active_status_message,
         _unit_initialized,
         _cluster_initialized,
@@ -297,7 +295,6 @@ class TestCharm(unittest.TestCase):
         _reboot_from_complete_outage.assert_not_called()
         _snap_service_operation.assert_not_called()
         _is_volume_mounted.assert_called_once()
-        _get_cluster_node_count.assert_called_once()
         _get_cluster_primary_address.assert_called_once()
 
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))

--- a/tests/unit/test_db_router.py
+++ b/tests/unit/test_db_router.py
@@ -51,7 +51,6 @@ class TestDBRouter(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
-        self.charm.unit_peer_data["unit-initialized"] = "True"
 
         # confirm that the relation databag is empty
         db_router_relation_databag = self.harness.get_relation_data(
@@ -143,7 +142,6 @@ class TestDBRouter(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
-        self.charm.unit_peer_data["unit-initialized"] = "True"
 
         # confirm that the relation databag is empty
         db_router_relation_databag = self.harness.get_relation_data(

--- a/tests/unit/test_relation_mysql_legacy.py
+++ b/tests/unit/test_relation_mysql_legacy.py
@@ -45,7 +45,6 @@ class TestMariaDBRelation(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
-        self.charm.unit_peer_data["unit-initialized"] = "True"
         self.harness.update_config(
             {"mysql-interface-user": "mysql", "mysql-interface-database": "default_database"}
         )
@@ -103,7 +102,6 @@ class TestMariaDBRelation(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
-        self.charm.unit_peer_data["unit-initialized"] = "True"
         self.harness.update_config(
             {"mysql-interface-user": "mysql", "mysql-interface-database": "default_database"}
         )

--- a/tests/unit/test_shared_db.py
+++ b/tests/unit/test_shared_db.py
@@ -42,7 +42,6 @@ class TestSharedDBRelation(unittest.TestCase):
         # run start-up events to enable usage of the helper class
         self.harness.set_leader(True)
         self.charm.on.config_changed.emit()
-        self.charm.unit_peer_data["unit-initialized"] = "True"
 
         # confirm that the relation databag is empty
         shared_db_relation_databag = self.harness.get_relation_data(


### PR DESCRIPTION
## Issue
We refactored how we calculate `cluster_initialized` and `unit_initialized` in #482. This uses the metadata in the database instead of relying on `units-added-to-cluster` and `unit-intialized` values in the databag. However, there are still places in the code where we set these keys

## Solution
Remove statements that set these keys
