### PR TITLE
[DPE-4118] Port mysql lib changes from k8s + increment tls lib for local changes

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -128,7 +128,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 63
+LIBPATCH = 64
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1778,6 +1778,23 @@ class MySQLBase(ABC):
 
         return ",".join(rw_endpoints), ",".join(ro_endpoints), ",".join(no_endpoints)
 
+    def execute_remove_instance(self, connect_instance: Optional[str] = None) -> None:
+        """Execute the remove_instance() script with mysqlsh.
+        Args:
+            connect_instance: (optional) The instance from where to run the remove_instance()
+        """
+        remove_instance_options = {
+            "password": self.cluster_admin_password,
+            "force": "true",
+        }
+        remove_instance_commands = (
+            f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{connect_instance or self.instance_address}')",
+            f"cluster = dba.get_cluster('{self.cluster_name}')",
+            "cluster.remove_instance("
+            f"'{self.cluster_admin_user}@{self.instance_address}', {remove_instance_options})",
+        )
+        self._run_mysqlsh_script("\n".join(remove_instance_commands))
+
     @retry(
         retry=retry_if_exception_type(MySQLRemoveInstanceRetryError),
         stop=stop_after_attempt(15),
@@ -1841,17 +1858,7 @@ class MySQLBase(ABC):
                     )
 
                 # Just remove instance
-                remove_instance_options = {
-                    "password": self.cluster_admin_password,
-                    "force": "true",
-                }
-                remove_instance_commands = (
-                    f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{self.instance_address}')",
-                    f"cluster = dba.get_cluster('{self.cluster_name}')",
-                    "cluster.remove_instance("
-                    f"'{self.cluster_admin_user}@{self.instance_address}', {remove_instance_options})",
-                )
-                self._run_mysqlsh_script("\n".join(remove_instance_commands))
+                self.execute_remove_instance()
         except MySQLClientError as e:
             # In case of an error, raise an error and retry
             logger.warning(

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1778,15 +1778,18 @@ class MySQLBase(ABC):
 
         return ",".join(rw_endpoints), ",".join(ro_endpoints), ",".join(no_endpoints)
 
-    def execute_remove_instance(self, connect_instance: Optional[str] = None) -> None:
+    def execute_remove_instance(
+        self, connect_instance: Optional[str] = None, force: bool = False
+    ) -> None:
         """Execute the remove_instance() script with mysqlsh.
 
         Args:
             connect_instance: (optional) The instance from where to run the remove_instance()
+            force: (optional) Whether to force the removal of the instance
         """
         remove_instance_options = {
             "password": self.cluster_admin_password,
-            "force": "true",
+            "force": "true" if force else "false",
         }
         remove_instance_commands = (
             f"shell.connect('{self.cluster_admin_user}:{self.cluster_admin_password}@{connect_instance or self.instance_address}')",
@@ -1859,7 +1862,7 @@ class MySQLBase(ABC):
                     )
 
                 # Just remove instance
-                self.execute_remove_instance()
+                self.execute_remove_instance(force=True)
         except MySQLClientError as e:
             # In case of an error, raise an error and retry
             logger.warning(

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1780,6 +1780,7 @@ class MySQLBase(ABC):
 
     def execute_remove_instance(self, connect_instance: Optional[str] = None) -> None:
         """Execute the remove_instance() script with mysqlsh.
+
         Args:
             connect_instance: (optional) The instance from where to run the remove_instance()
         """

--- a/lib/charms/mysql/v0/tls.py
+++ b/lib/charms/mysql/v0/tls.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "eb73947deedd4380a3a90d527e0878eb"
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 SCOPE = "unit"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1988,7 +1988,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -488,6 +488,19 @@ class TestMySQLBase(unittest.TestCase):
         )
         self.assertFalse(is_instance_configured)
 
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_execute_remove_instance(self, _run_mysqlsh_script):
+        expected_remove_instance_commands = (
+            "shell.connect('clusteradmin:clusteradminpassword@1.2.3.4')\n"
+            "cluster = dba.get_cluster('test_cluster')\n"
+            "cluster.remove_instance('clusteradmin@127.0.0.1', "
+            "{'password': 'clusteradminpassword', 'force': 'false'})"
+        )
+
+        self.mysql.execute_remove_instance(connect_instance="1.2.3.4", force=False)
+
+        _run_mysqlsh_script.assert_called_once_with(expected_remove_instance_commands)
+
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_node_count")
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address")
     @patch("charms.mysql.v0.mysql.MySQLBase._acquire_lock")


### PR DESCRIPTION
## Issue
1. We need to break out a method for executing remove_instance commands (changes already in [k8s PR](https://github.com/canonical/mysql-k8s-operator/pull/433)
2. We need to increment the tls lib as there were changes in [PR 482](https://github.com/canonical/mysql-operator/pull/482), but libpatch wasnt updated

## Solution
1. Port over changes from the k8s PR
2. Increment tls lib's libpatch
