### PR TITLE
[DPE-2477] Add a minimal set of alert rules from the Awesome Prometheus Alert Rules blog

### DIFF
--- a/src/alert_rules/prometheus/metrics_alert_rules.yaml
+++ b/src/alert_rules/prometheus/metrics_alert_rules.yaml
@@ -14,7 +14,7 @@ groups:
 
       # 2.1.2
       # customized: 80% -> 90%
-      - alert: MySQLTooManyConnections(>80%)
+      - alert: MySQLTooManyConnections(>90%)
         expr: max_over_time(mysql_global_status_threads_connected[1m]) / mysql_global_variables_max_connections * 100 > 90
         for: 2m
         labels:

--- a/src/alert_rules/prometheus/metrics_alert_rules.yaml
+++ b/src/alert_rules/prometheus/metrics_alert_rules.yaml
@@ -1,7 +1,8 @@
 groups:
-  - name: MysqlExporter
+  - name: MySQLExporter
 
     rules:
+      # 2.1.1
       - alert: MySQLDown
         expr: "mysql_up == 0"
         for: 0m
@@ -11,3 +12,65 @@ groups:
           summary: MySQL Down (instance {{ $labels.instance }})
           description: "MySQL instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
+      # 2.1.2
+      # customized: 80% -> 90%
+      - alert: MySQLTooManyConnections(>80%)
+        expr: max_over_time(mysql_global_status_threads_connected[1m]) / mysql_global_variables_max_connections * 100 > 90
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: MySQL too many connections (> 90%) (instance {{ $labels.instance }})
+          description: "More than 90% of MySQL connections are in use on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+      # 2.1.3
+      - alert: MySQLHighPreparedStatementsUtilization(>80%)
+        expr: max_over_time(mysql_global_status_prepared_stmt_count[1m]) / mysql_global_variables_max_prepared_stmt_count * 100 > 80
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: MySQL high prepared statements utilization (> 80%) (instance {{ $labels.instance }})
+          description: "High utilization of prepared statements (>80%) on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+      # 2.1.4
+      # customized: 60% -> 80%
+      - alert: MySQLHighThreadsRunning
+        expr: max_over_time(mysql_global_status_threads_running[1m]) / mysql_global_variables_max_connections * 100 > 80
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: MySQL high threads running (instance {{ $labels.instance }})
+          description: "More than 80% of MySQL connections are in running state on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+      # 2.1.8
+      # customized: warning -> info
+      - alert: MySQLSlowQueries
+        expr: increase(mysql_global_status_slow_queries[1m]) > 0
+        for: 2m
+        labels:
+          severity: info
+        annotations:
+          summary: MySQL slow queries (instance {{ $labels.instance }})
+          description: "MySQL server mysql has some new slow query.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+      # 2.1.9
+      - alert: MySQLInnoDBLogWaits
+        expr: rate(mysql_global_status_innodb_log_waits[15m]) > 10
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: MySQL InnoDB log waits (instance {{ $labels.instance }})
+          description: "MySQL innodb log writes stalling\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+      # 2.1.10
+      - alert: MySQLRestarted
+        expr: mysql_global_status_uptime < 60
+        for: 0m
+        labels:
+          severity: info
+        annotations:
+          summary: MySQL restarted (instance {{ $labels.instance }})
+          description: "MySQL has just been restarted, less than one minute ago on {{ $labels.instance }}.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
## Issue
We would like to import a minimal set of alert rules from the [Awesome Prometheus Alert Rules blog](https://samber.github.io/awesome-prometheus-alerts/rules#mysql)

## Solution
Import rules (noting slight modifications). Do not include any replication rules as they are not Group Replication related

![image](https://github.com/user-attachments/assets/a36fe70a-f570-4ec5-b6ba-f16dc7588319)

