### PR TITLE
Add charmcraft part to prime files

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,7 +11,8 @@ bases:
     architectures: [arm64]
 parts:
   files:
-    plugin: nil
+    plugin: dump
+    source: .
     prime:
       - snap_revisions.json
   charm:


### PR DESCRIPTION
Support for `prime` in `charm` part removed in charmcraft 3
