### PR TITLE
[DPE-4266] Strip passwords from command execute output and tracebacks

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -128,7 +128,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 65
+LIBPATCH = 66
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -857,6 +857,14 @@ class MySQLBase(ABC):
         self.monitoring_password = monitoring_password
         self.backups_user = backups_user
         self.backups_password = backups_password
+
+        self.passwords = [
+            self.root_password,
+            self.server_config_password,
+            self.cluster_admin_password,
+            self.monitoring_password,
+            self.backups_password,
+        ]
 
     def render_mysqld_configuration(
         self,
@@ -2402,7 +2410,7 @@ class MySQLBase(ABC):
         except Exception:
             # Catch all other exceptions to prevent the database being stuck in
             # a bad state due to pre-backup operations
-            logger.exception("Failed to execute commands prior to running backup")
+            logger.exception("Failed unexpectedly to execute commands prior to running backup")
             raise MySQLExecuteBackupCommandsError
 
         # TODO: remove flags --no-server-version-check
@@ -2452,13 +2460,13 @@ class MySQLBase(ABC):
                 },
                 stream_output="stderr",
             )
-        except MySQLExecError as e:
+        except MySQLExecError:
             logger.exception("Failed to execute backup commands")
-            raise MySQLExecuteBackupCommandsError(e.message)
+            raise MySQLExecuteBackupCommandsError
         except Exception:
             # Catch all other exceptions to prevent the database being stuck in
             # a bad state due to pre-backup operations
-            logger.exception("Failed to execute backup commands")
+            logger.exception("Failed unexpectedly to execute backup commands")
             raise MySQLExecuteBackupCommandsError
 
     def delete_temp_backup_directory(
@@ -2841,6 +2849,13 @@ class MySQLBase(ABC):
             "performance_schema",
             "sys",
         }
+
+    def strip_off_passwords(self, input: str) -> str:
+        """Strips off passwords from the input string"""
+        stripped_input = input
+        for password in self.passwords:
+            stripped_input = stripped_input.replace(password, "xxxxxxxxxxxx")
+        return stripped_input
 
     @abstractmethod
     def is_mysqld_running(self) -> bool:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -2850,9 +2850,9 @@ class MySQLBase(ABC):
             "sys",
         }
 
-    def strip_off_passwords(self, input: str) -> str:
-        """Strips off passwords from the input string"""
-        stripped_input = input
+    def strip_off_passwords(self, input_string: str) -> str:
+        """Strips off passwords from the input string."""
+        stripped_input = input_string
         for password in self.passwords:
             stripped_input = stripped_input.replace(password, "xxxxxxxxxxxx")
         return stripped_input

--- a/lib/charms/tempo_k8s/v1/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v1/charm_tracing.py
@@ -176,8 +176,10 @@ import functools
 import inspect
 import logging
 import os
+import shutil
 from contextlib import contextmanager
 from contextvars import Context, ContextVar, copy_context
+from importlib.metadata import distributions
 from pathlib import Path
 from typing import (
     Any,
@@ -217,7 +219,7 @@ LIBAPI = 1
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 11
+LIBPATCH = 13
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 
@@ -359,6 +361,30 @@ def _get_server_cert(
     return server_cert
 
 
+def _remove_stale_otel_sdk_packages():
+    """Hack to remove stale opentelemetry sdk packages from the charm's python venv.
+
+    See https://github.com/canonical/grafana-agent-operator/issues/146 and
+    https://bugs.launchpad.net/juju/+bug/2058335 for more context. This patch can be removed after
+    this juju issue is resolved and sufficient time has passed to expect most users of this library
+    have migrated to the patched version of juju.
+
+    This only does something if executed on an upgrade-charm event.
+    """
+    if os.getenv("JUJU_DISPATCH_PATH") == "hooks/upgrade-charm":
+        logger.debug("Executing _remove_stale_otel_sdk_packages patch on charm upgrade")
+        # Find any opentelemetry_sdk distributions
+        otel_sdk_distributions = list(distributions(name="opentelemetry_sdk"))
+        # If there is more than 1, inspect each and if it has 0 entrypoints, infer that it is stale
+        if len(otel_sdk_distributions) > 1:
+            for distribution in otel_sdk_distributions:
+                if len(distribution.entry_points) == 0:
+                    # Distribution appears to be empty. Remove it
+                    path = distribution._path  # type: ignore
+                    logger.debug(f"Removing empty opentelemetry_sdk distribution at: {path}")
+                    shutil.rmtree(path)
+
+
 def _setup_root_span_initializer(
     charm_type: _CharmType,
     tracing_endpoint_attr: str,
@@ -391,6 +417,10 @@ def _setup_root_span_initializer(
         _service_name = service_name or f"{self.app.name}-charm"
 
         unit_name = self.unit.name
+        # apply hacky patch to remove stale opentelemetry sdk packages on upgrade-charm.
+        # it could be trouble if someone ever decides to implement their own tracer parallel to
+        # ours and before the charm has inited. We assume they won't.
+        _remove_stale_otel_sdk_packages()
         resource = Resource.create(
             attributes={
                 "service.name": _service_name,
@@ -612,38 +642,58 @@ def trace_type(cls: _T) -> _T:
             dev_logger.info(f"skipping {method} (dunder)")
             continue
 
-        new_method = trace_method(method)
-        if isinstance(inspect.getattr_static(cls, method.__name__), staticmethod):
+        # the span title in the general case should be:
+        #   method call: MyCharmWrappedMethods.b
+        # if the method has a name (functools.wrapped or regular method), let
+        # _trace_callable use its default algorithm to determine what name to give the span.
+        trace_method_name = None
+        try:
+            qualname_c0 = method.__qualname__.split(".")[0]
+            if not hasattr(cls, method.__name__):
+                # if the callable doesn't have a __name__ (probably a decorated method),
+                # it probably has a bad qualname too (such as my_decorator.<locals>.wrapper) which is not
+                # great for finding out what the trace is about. So we use the method name instead and
+                # add a reference to the decorator name. Result:
+                #   method call: @my_decorator(MyCharmWrappedMethods.b)
+                trace_method_name = f"@{qualname_c0}({cls.__name__}.{name})"
+        except Exception:  # noqa: failsafe
+            pass
+
+        new_method = trace_method(method, name=trace_method_name)
+
+        if isinstance(inspect.getattr_static(cls, name), staticmethod):
             new_method = staticmethod(new_method)
         setattr(cls, name, new_method)
 
     return cls
 
 
-def trace_method(method: _F) -> _F:
+def trace_method(method: _F, name: Optional[str] = None) -> _F:
     """Trace this method.
 
     A span will be opened when this method is called and closed when it returns.
     """
-    return _trace_callable(method, "method")
+    return _trace_callable(method, "method", name=name)
 
 
-def trace_function(function: _F) -> _F:
+def trace_function(function: _F, name: Optional[str] = None) -> _F:
     """Trace this function.
 
     A span will be opened when this function is called and closed when it returns.
     """
-    return _trace_callable(function, "function")
+    return _trace_callable(function, "function", name=name)
 
 
-def _trace_callable(callable: _F, qualifier: str) -> _F:
+def _trace_callable(callable: _F, qualifier: str, name: Optional[str] = None) -> _F:
     dev_logger.info(f"instrumenting {callable}")
 
     # sig = inspect.signature(callable)
     @functools.wraps(callable)
     def wrapped_function(*args, **kwargs):  # type: ignore
-        name = getattr(callable, "__qualname__", getattr(callable, "__name__", str(callable)))
-        with _span(f"{qualifier} call: {name}"):  # type: ignore
+        name_ = name or getattr(
+            callable, "__qualname__", getattr(callable, "__name__", str(callable))
+        )
+        with _span(f"{qualifier} call: {name_}"):  # type: ignore
             return callable(*args, **kwargs)  # type: ignore
 
     # wrapped_function.__signature__ = sig

--- a/lib/charms/tempo_k8s/v2/tracing.py
+++ b/lib/charms/tempo_k8s/v2/tracing.py
@@ -107,7 +107,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 PYDEPS = ["pydantic"]
 
@@ -116,14 +116,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_RELATION_NAME = "tracing"
 RELATION_INTERFACE_NAME = "tracing"
 
+# Supported list rationale https://github.com/canonical/tempo-coordinator-k8s-operator/issues/8
 ReceiverProtocol = Literal[
     "zipkin",
-    "kafka",
-    "opencensus",
-    "tempo_http",
-    "tempo_grpc",
     "otlp_grpc",
     "otlp_http",
+    "jaeger_grpc",
+    "jaeger_thrift_http",
 ]
 
 RawReceiver = Tuple[ReceiverProtocol, str]
@@ -141,14 +140,12 @@ class TransportProtocolType(str, enum.Enum):
     grpc = "grpc"
 
 
-receiver_protocol_to_transport_protocol = {
+receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtocolType] = {
     "zipkin": TransportProtocolType.http,
-    "kafka": TransportProtocolType.http,
-    "opencensus": TransportProtocolType.http,
-    "tempo_http": TransportProtocolType.http,
-    "tempo_grpc": TransportProtocolType.grpc,
     "otlp_grpc": TransportProtocolType.grpc,
     "otlp_http": TransportProtocolType.http,
+    "jaeger_thrift_http": TransportProtocolType.http,
+    "jaeger_grpc": TransportProtocolType.grpc,
 }
 """A mapping between telemetry protocols and their corresponding transport protocol.
 """

--- a/poetry.lock
+++ b/poetry.lock
@@ -1744,7 +1744,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -743,7 +743,7 @@ class MySQL(MySQLBase):
                 command, stderr=subprocess.PIPE, timeout=timeout
             ).decode("utf-8")
         except subprocess.CalledProcessError as e:
-            raise MySQLClientError(self.strip_off_passwords(e.stderr))
+            raise MySQLClientError(self.strip_off_passwords(e.stderr.decode("utf-8")))
 
     def is_data_dir_initialised(self) -> bool:
         """Check if data dir is initialised.

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -564,11 +564,11 @@ class MySQL(MySQLBase):
         if return_code != 0:
             message = (
                 "Failed command: "
-                f"{' '.join(commands).replace(self.backups_password, 'xxxxxxx')};"
+                f"{self.strip_off_passwords(' '.join(commands))};"
                 f" {user=}; {group=}"
             )
-            logger.debug(message)
-            raise MySQLExecError(message)
+            logger.error(message)
+            raise MySQLExecError from None
 
         if not stdout and process.stdout:
             stdout = process.stdout.read()

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -743,7 +743,7 @@ class MySQL(MySQLBase):
                 command, stderr=subprocess.PIPE, timeout=timeout
             ).decode("utf-8")
         except subprocess.CalledProcessError as e:
-            raise MySQLClientError(e.stderr)
+            raise MySQLClientError(self.strip_off_passwords(e.stderr))
 
     def is_data_dir_initialised(self) -> bool:
         """Check if data dir is initialised.

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -95,7 +95,9 @@ class TestMySQL(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_run_mysqlcli_script_exception(self, _check_output):
         """Test a failed execution of run_mysqlsh_script."""
-        _check_output.side_effect = subprocess.CalledProcessError(cmd="", returncode=-1, stderr="Test error message")
+        _check_output.side_effect = subprocess.CalledProcessError(
+            cmd="", returncode=-1, stderr="Test error message"
+        )
 
         with self.assertRaises(MySQLClientError):
             self.mysql._run_mysqlcli_script("script")

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -96,7 +96,7 @@ class TestMySQL(unittest.TestCase):
     def test_run_mysqlcli_script_exception(self, _check_output):
         """Test a failed execution of run_mysqlsh_script."""
         _check_output.side_effect = subprocess.CalledProcessError(
-            cmd="", returncode=-1, stderr="Test error message"
+            cmd="", returncode=-1, stderr=b"Test error message"
         )
 
         with self.assertRaises(MySQLClientError):

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -95,7 +95,7 @@ class TestMySQL(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_run_mysqlcli_script_exception(self, _check_output):
         """Test a failed execution of run_mysqlsh_script."""
-        _check_output.side_effect = subprocess.CalledProcessError(cmd="", returncode=-1)
+        _check_output.side_effect = subprocess.CalledProcessError(cmd="", returncode=-1, stderr="Test error message")
 
         with self.assertRaises(MySQLClientError):
             self.mysql._run_mysqlcli_script("script")


### PR DESCRIPTION
## Issue
We are leaking passwords when there's an issue creating a backup
Counterpart in K8s charm: 

## Solution
Modify code to avoid leaks of any passwords when `_execute_command` or `_run_mysqlcli_script` is called

## Example traceback

```
unit-mysql-0: 20:16:52 INFO unit.mysql/0.juju-log A backup has been requested on unit
unit-mysql-0: 20:16:52 INFO unit.mysql/0.juju-log Checking if the unit is waiting to start or restart
unit-mysql-0: 20:16:52 INFO unit.mysql/0.juju-log Checking if backup already in progress
unit-mysql-0: 20:16:52 INFO unit.mysql/0.juju-log Checking state and role of unit
unit-mysql-0: 20:16:52 INFO unit.mysql/0.juju-log Uploading content to bucket=mysql-backups-development, path=mysql-test/2024-08-05T20:16:52Z.metadata
unit-mysql-0: 20:16:53 INFO unit.mysql/0.juju-log Running the xtrabackup commands
unit-mysql-0: 20:16:54 ERROR unit.mysql/0.juju-log Failed command: bash -c set -o pipefail; x/snap/bin/charmed-mysql.xtrabackup --defaults-file=/var/snap/charmed-mysql/current/etc/mysql/mysql.cnf --defaults-group=mysqld --no-version-check --parallel=12 --user=backups --password=xxxxxxxxxxxx --socket=/var/snap/charmed-mysql/common/var/run/mysqld/mysqld.sock --lock-ddl --backup --stream=xbstream --xtrabackup-plugin-dir=/snap/charmed-mysql/current/usr/lib/xtrabackup/plugin --target-dir=/var/snap/charmed-mysql/common/xtra_backup_6f8V --no-server-version-check | /snap/bin/charmed-mysql.xbcloud put --curl-retriable-errors=7 --insecure --parallel=10 --md5 --storage=S3 --s3-region=us-east-1 --s3-bucket=mysql-backups-development --s3-endpoint=https://s3.amazonaws.com --s3-api-version=auto --s3-bucket-lookup=auto mysql-test/2024-08-05T20:16:52Z; user='root'; group='root'
unit-mysql-0: 20:16:54 ERROR unit.mysql/0.juju-log Failed to execute backup commands
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-mysql-0/charm/lib/charms/mysql/v0/mysql.py", line 2452, in execute_backup_commands
    return self._execute_commands(
  File "/var/lib/juju/agents/unit-mysql-0/charm/lib/charms/tempo_k8s/v1/charm_tracing.py", line 647, in wrapped_function
    return callable(*args, **kwargs)  # type: ignore
  File "/var/lib/juju/agents/unit-mysql-0/charm/src/mysql_vm_helpers.py", line 571, in _execute_commands
    raise MySQLExecError from None
charms.mysql.v0.mysql.MySQLExecError
unit-mysql-0: 20:16:54 INFO unit.mysql/0.juju-log Uploading logs to S3 at bucket=mysql-backups-development, location=mysql-test/2024-08-05T20:16:52Z.backup.log
unit-mysql-0: 20:16:54 INFO unit.mysql/0.juju-log Uploading content to bucket=mysql-backups-development, path=mysql-test/2024-08-05T20:16:52Z.backup.log
unit-mysql-0: 20:16:54 ERROR unit.mysql/0.juju-log Backup failed: Error backing up the database
unit-mysql-0: 20:16:54 INFO unit.mysql/0.juju-log Deleting temp backup directory
unit-mysql-0: 20:16:54 INFO unit.mysql/0.juju-log Unsetting unit as offline after performing backup
unit-mysql-0: 20:16:54 INFO unit.mysql/0.juju-log Setting unit option tag:_hidden as false
```