### PR TITLE
Stabilize integration tests; avoid using equality for comparison of units and compare unit names instead

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -486,7 +486,7 @@ async def get_primary_unit_wrapper(ops_test: OpsTest, app_name: str, unit_exclud
     units = ops_test.model.applications[app_name].units
 
     for unit in units:
-        if unit == unit_excluded:
+        if unit.name == unit_excluded.name:
             continue
         try:
             primary_unit = await get_primary_unit(ops_test, unit, app_name)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -486,7 +486,7 @@ async def get_primary_unit_wrapper(ops_test: OpsTest, app_name: str, unit_exclud
     units = ops_test.model.applications[app_name].units
 
     for unit in units:
-        if unit.name == unit_excluded.name:
+        if unit_excluded and unit.name == unit_excluded.name:
             continue
         try:
             primary_unit = await get_primary_unit(ops_test, unit, app_name)

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -203,8 +203,12 @@ async def test_network_cut(ops_test: OpsTest, highly_available_cluster, continuo
                     "host": new_unit_ip,
                 }
 
-                logger.debug(f"Waiting until connection possible after network restore on {new_unit_ip}")
-                assert is_connection_possible(new_unit_config), "❌ Connection is not possible after network restore"
+                logger.debug(
+                    f"Waiting until connection possible after network restore on {new_unit_ip}"
+                )
+                assert is_connection_possible(
+                    new_unit_config
+                ), "❌ Connection is not possible after network restore"
 
         logger.info(f"Waiting for {primary_unit.name} to enter active")
         await ops_test.model.block_until(

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -153,10 +153,11 @@ async def test_network_cut(ops_test: OpsTest, highly_available_cluster, continuo
     logger.info(f"Unit {primary_unit.name} it's on machine {primary_hostname} ✅")
 
     primary_unit_ip = await get_unit_ip(ops_test, primary_unit.name)
+    cluster_admin_password = await get_system_user_password(primary_unit, CLUSTER_ADMIN_USERNAME)
 
     config = {
         "username": CLUSTER_ADMIN_USERNAME,
-        "password": await get_system_user_password(primary_unit, CLUSTER_ADMIN_USERNAME),
+        "password": cluster_admin_password,
         "host": primary_unit_ip,
     }
 
@@ -193,10 +194,18 @@ async def test_network_cut(ops_test: OpsTest, highly_available_cluster, continuo
     # ensure continuous writes still incrementing for all units
     async with ops_test.fast_forward():
         # wait for the unit to be ready
-        logger.info(f"Waiting for {primary_unit.name} to enter maintenance")
-        await ops_test.model.block_until(
-            lambda: primary_unit.workload_status in ["maintenance"], timeout=30 * 60
-        )
+        for attempt in Retrying(stop=stop_after_attempt(60), wait=wait_fixed(10)):
+            with attempt:
+                new_unit_ip = await get_unit_ip(ops_test, primary_unit.name)
+                new_unit_config = {
+                    "username": CLUSTER_ADMIN_USERNAME,
+                    "password": cluster_admin_password,
+                    "host": new_unit_ip,
+                }
+
+                logger.debug(f"Waiting until connection possible after network restore on {new_unit_ip}")
+                assert is_connection_possible(new_unit_config), "❌ Connection is not possible after network restore"
+
         logger.info(f"Waiting for {primary_unit.name} to enter active")
         await ops_test.model.block_until(
             lambda: primary_unit.workload_status == "active", timeout=40 * 60


### PR DESCRIPTION
## Issue
Network cut test: https://github.com/canonical/mysql-operator/actions/runs/10397182320/job/28792633963
Replicate data on restart test: https://github.com/canonical/mysql-operator/actions/runs/10397182320/job/28792634154#step:28:425

Both of the above tests fail on retrieving a cluster primary when the old primary is stopped or cut from the network. The reason for this, I believe, is the usage of `==` to compare units. Despite the `unit` and `unit_excluded` is the same, the unit is not excluded (the condition does not hold true). This is why the tests above fail to get primary from the "old primary unit" which does not have a running mysqld.

## Solution
Compare unit names instead