### PR TITLE
DPE-5210 Add timeout to check call

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 69
+LIBPATCH = 70
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1536,7 +1536,9 @@ class MySQLBase(ABC):
         )
 
         try:
-            output = self._run_mysqlsh_script("\n".join(check_cluster_metadata_commands))
+            output = self._run_mysqlsh_script(
+                "\n".join(check_cluster_metadata_commands), timeout=10
+            )
         except MySQLClientError:
             logger.warning(f"Failed to check if cluster metadata exists {from_instance=}")
             return False

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -956,7 +956,7 @@ class TestMySQLBase(unittest.TestCase):
         _run_mysqlsh_script.return_value = "True\n"
 
         self.assertTrue(self.mysql.cluster_metadata_exists("1.2.3.4"))
-        _run_mysqlsh_script.assert_called_once_with(commands)
+        _run_mysqlsh_script.assert_called_once_with(commands, timeout=10)
 
         _run_mysqlsh_script.reset_mock()
         _run_mysqlsh_script.side_effect = MySQLClientError


### PR DESCRIPTION
## Issue

When charm checks for `cluster_initialized`, the property checks for cluster
metadata on any of the units. Case the first unit is unreachable (e.g. freeze test)
the call hangs, impairing charm operation for all units (not only the unreachable one).

And that's when the freeze test hangs, specially on k8s, i.e. when the first unit myqsld
is the one being stopped.

## Solution

Adds a 10s (scientific) timeout to the call.

