### PR TITLE
tests: don't patch private ops class

### DIFF
--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -3,29 +3,3 @@
 # See LICENSE file for licensing details.
 
 """Helper functions for writing tests."""
-
-from typing import Callable
-from unittest.mock import patch
-
-
-def patch_network_get(private_address="10.1.157.116") -> Callable:
-    def network_get(*args, **kwargs) -> dict:
-        """Patch for the not-yet-implemented testing backend needed for `bind_address`.
-
-        This patch decorator can be used for cases such as:
-        self.model.get_binding(event.relation).network.bind_address
-        """
-        return {
-            "bind-addresses": [
-                {
-                    "mac-address": "",
-                    "interface-name": "",
-                    "addresses": [{"hostname": "", "value": private_address, "cidr": ""}],
-                }
-            ],
-            "bind-address": private_address,
-            "egress-subnets": ["10.152.183.65/32"],
-            "ingress-addresses": ["10.152.183.65"],
-        }
-
-    return patch("ops.testing._TestingModelBackend.network_get", network_get)

--- a/tests/unit/test_async_replication.py
+++ b/tests/unit/test_async_replication.py
@@ -23,8 +23,6 @@ from constants import (
     SERVER_CONFIG_PASSWORD_KEY,
 )
 
-from .helpers import patch_network_get
-
 
 @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
 class TestAsyncRelation(unittest.TestCase):
@@ -292,7 +290,6 @@ class TestAsyncRelation(unittest.TestCase):
             self.harness.get_relation_data(async_relation_id, self.charm.app.name),
         )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("ops.framework.EventBase.defer")
     @patch(
         "charms.mysql.v0.async_replication.MySQLAsyncReplicationConsumer.returning_cluster",

--- a/tests/unit/test_backups.py
+++ b/tests/unit/test_backups.py
@@ -30,8 +30,6 @@ from ops.testing import Harness
 from charm import MySQLOperatorCharm
 from lib.charms.mysql.v0.backups import S3_INTEGRATOR_RELATION_NAME
 
-from .helpers import patch_network_get
-
 
 class TestMySQLBackups(unittest.TestCase):
     def setUp(self):
@@ -150,7 +148,6 @@ test stderr"""
         event.set_results.assert_not_called()
         event.fail.assert_called_once_with("Missing relation with S3 integrator charm")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm._on_update_status")
     @patch("datetime.datetime")
     @patch(
@@ -205,7 +202,6 @@ Juju Version: 0.0.0
         event.set_results.assert_called_once_with({"backup-id": "2023-03-07%13:43:15Z"})
         event.fail.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("datetime.datetime")
     @patch(
         "charms.mysql.v0.backups.MySQLBackups._retrieve_s3_parameters",
@@ -313,7 +309,6 @@ Juju Version: 0.0.0
         event.fail.assert_called_once_with("Missing relation with S3 integrator charm")
         self.assertTrue(isinstance(self.harness.model.unit.status, ActiveStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.offline_mode_and_hidden_instance_exists", return_value=False)
     @patch("mysql_vm_helpers.MySQL.get_member_state", return_value=("online", "replica"))
     def test_can_unit_perform_backup(
@@ -326,7 +321,6 @@ Juju Version: 0.0.0
         self.assertTrue(success)
         self.assertIsNone(error_message)
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.offline_mode_and_hidden_instance_exists", return_value=False)
     @patch("mysql_vm_helpers.MySQL.get_member_state")
     @patch("python_hosts.Hosts.write")
@@ -378,7 +372,6 @@ Juju Version: 0.0.0
         self.assertFalse(success)
         self.assertEqual(error_message, "Unit is waiting to start or restart")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.set_instance_option")
     @patch("mysql_vm_helpers.MySQL.set_instance_offline_mode")
     @patch("python_hosts.Hosts.write")
@@ -403,7 +396,6 @@ Juju Version: 0.0.0
         self.assertTrue(success)
         self.assertIsNone(error_message)
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.set_instance_option")
     @patch("mysql_vm_helpers.MySQL.set_instance_offline_mode")
     def test_pre_backup_failure(
@@ -431,7 +423,6 @@ Juju Version: 0.0.0
         self.assertFalse(success)
         self.assertEqual(error_message, "Error setting instance option tag:_hidden")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.execute_backup_commands", return_value=("stdout", "stderr"))
     @patch("charms.mysql.v0.backups.MySQLBackups._upload_logs_to_s3")
     def test_backup(
@@ -452,7 +443,6 @@ Juju Version: 0.0.0
         self.assertIsNone(error_message)
         _upload_logs_to_s3.assert_called_once_with("stdout", "", "/path.backup.log", s3_params)
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.execute_backup_commands", return_value=("stdout", "stderr"))
     @patch("charms.mysql.v0.backups.MySQLBackups._upload_logs_to_s3")
     def test_backup_failure(
@@ -486,7 +476,6 @@ Juju Version: 0.0.0
             "", "failure backup", "/path.backup.log", s3_params
         )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.delete_temp_backup_directory")
     @patch("mysql_vm_helpers.MySQL.set_instance_offline_mode")
     @patch("mysql_vm_helpers.MySQL.set_instance_option")
@@ -501,7 +490,6 @@ Juju Version: 0.0.0
         self.assertTrue(success)
         self.assertIsNone(error_message)
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.delete_temp_backup_directory")
     @patch("mysql_vm_helpers.MySQL.set_instance_offline_mode")
     @patch("mysql_vm_helpers.MySQL.set_instance_option")
@@ -535,7 +523,6 @@ Juju Version: 0.0.0
         self.assertFalse(success)
         self.assertEqual(error_message, "Error deleting temp backup directory")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.is_server_connectable", return_value=True)
     @patch("charm.MySQLOperatorCharm.is_unit_busy", return_value=False)
     def test_pre_restore_checks(
@@ -548,7 +535,6 @@ Juju Version: 0.0.0
 
         self.assertTrue(self.mysql_backups._pre_restore_checks(event))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.is_server_connectable", return_value=True)
     @patch("charm.MySQLOperatorCharm.is_unit_busy", return_value=False)
     @patch("python_hosts.Hosts.write")
@@ -593,7 +579,6 @@ Juju Version: 0.0.0
 
         self.assertFalse(self.mysql_backups._pre_restore_checks(event))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm._on_update_status")
     @patch("charms.mysql.v0.backups.MySQLBackups._pre_restore_checks", return_value=True)
     @patch(
@@ -637,7 +622,6 @@ Juju Version: 0.0.0
         self.assertEqual(event.set_results.call_count, 1)
         self.assertEqual(event.fail.call_count, 0)
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charms.mysql.v0.backups.MySQLBackups._pre_restore_checks", return_value=True)
     @patch(
         "charms.mysql.v0.backups.MySQLBackups._retrieve_s3_parameters",
@@ -750,7 +734,6 @@ Juju Version: 0.0.0
         event.set_results.assert_not_called()
         event.fail.assert_not_called()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.set_instance_offline_mode")
     @patch("mysql_vm_helpers.MySQL.is_mysqld_running", return_value=True)
     @patch("mysql_vm_helpers.MySQL.kill_client_sessions")
@@ -768,7 +751,6 @@ Juju Version: 0.0.0
         _kill_client_sessions.assert_called_once()
         _set_instance_offline_mode.assert_called_once()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.set_instance_offline_mode")
     @patch("mysql_vm_helpers.MySQL.is_mysqld_running", return_value=True)
     @patch("mysql_vm_helpers.MySQL.kill_client_sessions")
@@ -784,7 +766,6 @@ Juju Version: 0.0.0
         self.assertFalse(success)
         self.assertEqual(error, "Failed to stop mysqld")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "mysql_vm_helpers.MySQL.retrieve_backup_with_xbcloud",
         return_value=("", "", "test/backup/location"),
@@ -813,7 +794,6 @@ Juju Version: 0.0.0
         self.assertTrue(recoverable)
         self.assertEqual(error, "")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "mysql_vm_helpers.MySQL.retrieve_backup_with_xbcloud",
         return_value=("", "", "test/backup/location"),
@@ -869,7 +849,6 @@ Juju Version: 0.0.0
         self.assertTrue(recoverable)
         self.assertEqual(error, "Failed to retrieve backup test-backup-id")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.start_mysqld")
     @patch("mysql_vm_helpers.MySQL.delete_temp_restore_directory")
     @patch("mysql_vm_helpers.MySQL.delete_temp_backup_directory")
@@ -880,7 +859,6 @@ Juju Version: 0.0.0
         self.assertTrue(success)
         self.assertEqual(error, "")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("mysql_vm_helpers.MySQL.start_mysqld")
     @patch("mysql_vm_helpers.MySQL.delete_temp_restore_directory")
     @patch("mysql_vm_helpers.MySQL.delete_temp_backup_directory")
@@ -909,7 +887,6 @@ Juju Version: 0.0.0
         self.assertFalse(success)
         self.assertEqual(error, "Failed to delete the temp restore directory")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "charms.mysql.v0.backups.MySQLBackups._clean_data_dir_and_start_mysqld",
         return_value=(True, None),
@@ -944,7 +921,6 @@ Juju Version: 0.0.0
         _initialize_juju_units_operations_table.assert_called_once()
         _rescan_cluster.assert_called_once()
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "charms.mysql.v0.backups.MySQLBackups._clean_data_dir_and_start_mysqld",
         return_value=(True, None),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -22,8 +22,6 @@ from mysql_vm_helpers import (
     MySQLResetRootPasswordAndStartMySQLDError,
 )
 
-from .helpers import patch_network_get
-
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
@@ -39,7 +37,6 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation_unit(self.peer_relation_id, "mysql/1")
         self.harness.add_relation("restart", "restart")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("upgrade.MySQLVMUpgrade.cluster_state", return_value="idle")
     @patch("socket.getfqdn", return_value="test-hostname")
     @patch("socket.gethostbyname", return_value="")
@@ -130,7 +127,6 @@ class TestCharm(unittest.TestCase):
         for key in expected_peer_relation_databag_keys:
             self.assertTrue(self.harness.charm.get_secret("app", key).isalnum())
 
-    @patch_network_get(private_address="1.1.1.1")
     def test_on_leader_elected_sets_config_cluster_name_in_peer_databag(self):
         # ensure that the peer relation databag is empty
         peer_relation_databag = self.harness.get_relation_data(
@@ -149,7 +145,6 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(peer_relation_databag["cluster-name"], "test-cluster")
 
-    @patch_network_get(private_address="1.1.1.1")
     def test_on_config_changed_sets_random_cluster_name_in_peer_databag(self):
         # ensure that the peer relation databag is empty
         peer_relation_databag = self.harness.get_relation_data(
@@ -194,7 +189,6 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.charm.unit_peer_data["member-role"], "secondary")
         self.assertEqual(self.charm.unit_peer_data["member-state"], "waiting")
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm._can_start", return_value=True)
     @patch("charm.MySQLOperatorCharm.create_cluster")
     @patch("charm.MySQLOperatorCharm.workload_initialise")
@@ -250,7 +244,6 @@ class TestCharm(unittest.TestCase):
         self.charm.on.start.emit()
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch(
         "charm.MySQLOperatorCharm.cluster_initialized",
         new_callable=PropertyMock(return_value=True),

--- a/tests/unit/test_charm_base.py
+++ b/tests/unit/test_charm_base.py
@@ -10,8 +10,6 @@ from charms.mysql.v0.mysql import MySQLCharmBase, MySQLSecretError
 from ops.testing import Harness
 from parameterized import parameterized
 
-from .helpers import patch_network_get
-
 
 class TestCharmBase(unittest.TestCase):
     @patch.multiple(MySQLCharmBase, __abstractmethods__=set())
@@ -27,7 +25,6 @@ class TestCharmBase(unittest.TestCase):
         self.peer_relation_id = self.harness.add_relation("database-peers", "mysql")
         self.harness.add_relation_unit(self.peer_relation_id, "mysql/1")
 
-    @patch_network_get(private_address="1.1.1.1")
     def test_get_secret_databag(self):
         self.harness.set_leader()
 
@@ -46,7 +43,6 @@ class TestCharmBase(unittest.TestCase):
         assert self.charm.get_secret("unit", "password") == "test-password"
 
     @pytest.mark.usefixtures("without_juju_secrets")
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm._on_leader_elected")
     def test_set_secret_databag(self, _):
         self.harness.set_leader()
@@ -72,7 +68,6 @@ class TestCharmBase(unittest.TestCase):
         )
 
     @parameterized.expand([("app"), ("unit")])
-    @patch_network_get(private_address="1.1.1.1")
     @pytest.mark.usefixtures("with_juju_secrets")
     def test_set_secret(self, scope):
         self.harness.set_leader()
@@ -93,7 +88,6 @@ class TestCharmBase(unittest.TestCase):
             self.charm.set_secret("not-a-scope", "password", "test")  # type: ignore
 
     @parameterized.expand([("app", True), ("unit", True), ("unit", False)])
-    @patch_network_get(private_address="1.1.1.1")
     @pytest.mark.usefixtures("with_juju_secrets")
     def test_set_reset_new_secret(self, scope, is_leader):
         """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
@@ -112,7 +106,6 @@ class TestCharmBase(unittest.TestCase):
         assert self.harness.charm.get_secret(scope, "new-secret2") == "blablabla"
 
     @parameterized.expand([("app", True), ("unit", True), ("unit", False)])
-    @patch_network_get(private_address="1.1.1.1")
     @pytest.mark.usefixtures("with_juju_secrets")
     def test_invalid_secret(self, scope, is_leader):
         # App has to be leader, unit can be either
@@ -129,7 +122,6 @@ class TestCharmBase(unittest.TestCase):
         ("unit", True, "key"),
         ("unit", False, "key"),
     ])
-    @patch_network_get(private_address="1.1.1.1")
     @pytest.mark.usefixtures("with_juju_secrets")
     def test_migration_from_databag(self, scope, is_leader, password_key):
         """Check if we're moving on to use secrets when live upgrade from databag to Secrets."""

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -9,8 +9,6 @@ from ops.testing import Harness
 from charm import MySQLOperatorCharm
 from constants import DB_RELATION_NAME
 
-from .helpers import patch_network_get
-
 
 class TestDatabase(unittest.TestCase):
     def setUp(self):
@@ -23,7 +21,6 @@ class TestDatabase(unittest.TestCase):
         self.harness.add_relation_unit(self.database_relation_id, "app/0")
         self.charm = self.harness.charm
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm.unit_initialized", new_callable=PropertyMock)
     @patch("charm.MySQLOperatorCharm.cluster_initialized", new_callable=PropertyMock)
     @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")

--- a/tests/unit/test_db_router.py
+++ b/tests/unit/test_db_router.py
@@ -14,8 +14,6 @@ from ops.testing import Harness
 
 from charm import MySQLOperatorCharm
 
-from .helpers import patch_network_get
-
 
 @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
 class TestDBRouter(unittest.TestCase):
@@ -29,7 +27,6 @@ class TestDBRouter(unittest.TestCase):
         self.harness.add_relation_unit(self.db_router_relation_id, "app/0")
         self.charm = self.harness.charm
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("relations.db_router.DBRouterRelation._on_leader_elected")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
     @patch("relations.db_router.generate_random_password", return_value="super_secure_password")
@@ -120,7 +117,6 @@ class TestDBRouter(unittest.TestCase):
             },
         )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("relations.db_router.DBRouterRelation._on_leader_elected")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
     @patch("relations.db_router.generate_random_password", return_value="super_secure_password")

--- a/tests/unit/test_relation_mysql_legacy.py
+++ b/tests/unit/test_relation_mysql_legacy.py
@@ -10,8 +10,6 @@ from ops.testing import Harness
 from charm import MySQLOperatorCharm
 from constants import LEGACY_MYSQL, PEER
 
-from .helpers import patch_network_get
-
 
 @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
 class TestMariaDBRelation(unittest.TestCase):
@@ -24,10 +22,9 @@ class TestMariaDBRelation(unittest.TestCase):
         self.charm = self.harness.charm
 
     @pytest.mark.usefixtures("without_juju_secrets")
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
     @patch("mysql_vm_helpers.MySQL.does_mysql_user_exist", return_value=False)
-    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="1.1.1.1:3306")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="192.0.2.0:3306")
     @patch(
         "relations.mysql.MySQLRelation._get_or_set_password_in_peer_secrets",
         return_value="super_secure_password",
@@ -74,7 +71,7 @@ class TestMariaDBRelation(unittest.TestCase):
             maria_db_relation.data.get(self.charm.unit),
             {
                 "database": "default_database",
-                "host": "1.1.1.1",
+                "host": "192.0.2.0",
                 "password": "super_secure_password",
                 "port": "3306",
                 "root_password": peer_relation.data.get(self.charm.app)["root-password"],
@@ -82,10 +79,9 @@ class TestMariaDBRelation(unittest.TestCase):
             },
         )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
     @patch("mysql_vm_helpers.MySQL.does_mysql_user_exist", return_value=False)
-    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="1.1.1.1:3306")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="192.0.2.0:3306")
     @patch(
         "relations.mysql.MySQLRelation._get_or_set_password_in_peer_secrets",
         return_value="super_secure_password",
@@ -134,7 +130,7 @@ class TestMariaDBRelation(unittest.TestCase):
             maria_db_relation.data.get(self.charm.unit),
             {
                 "database": "default_database",
-                "host": "1.1.1.1",
+                "host": "192.0.2.0",
                 "password": "super_secure_password",
                 "port": "3306",
                 "root_password": root_pw,
@@ -142,10 +138,9 @@ class TestMariaDBRelation(unittest.TestCase):
             },
         )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
     @patch("mysql_vm_helpers.MySQL.does_mysql_user_exist", return_value=False)
-    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="1.1.1.1:3306")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="192.0.2.0:3306")
     @patch("mysql_vm_helpers.MySQL.delete_users_for_unit")
     @patch(
         "relations.mysql.MySQLRelation._get_or_set_password_in_peer_secrets",

--- a/tests/unit/test_shared_db.py
+++ b/tests/unit/test_shared_db.py
@@ -11,8 +11,6 @@ from ops.testing import Harness
 from charm import MySQLOperatorCharm
 from constants import LEGACY_DB_SHARED
 
-from .helpers import patch_network_get
-
 
 @patch("charms.rolling_ops.v0.rollingops.RollingOpsManager._on_process_locks")
 class TestSharedDBRelation(unittest.TestCase):
@@ -26,9 +24,8 @@ class TestSharedDBRelation(unittest.TestCase):
         self.harness.add_relation_unit(self.shared_db_relation_id, "other-app/0")
         self.charm = self.harness.charm
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
-    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="1.1.1.1")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="192.0.2.0")
     @patch("relations.shared_db.generate_random_password", return_value="super_secure_password")
     @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
     def test_shared_db_relation_changed(
@@ -80,7 +77,7 @@ class TestSharedDBRelation(unittest.TestCase):
         self.assertEqual(
             shared_db_relation.data.get(self.charm.unit),
             {
-                "db_host": "1.1.1.1",
+                "db_host": "192.0.2.0",
                 "db_port": "3306",
                 "wait_timeout": "28800",
                 "password": "super_secure_password",
@@ -88,7 +85,6 @@ class TestSharedDBRelation(unittest.TestCase):
             },
         )
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
     @patch("relations.shared_db.SharedDBRelation._on_leader_elected")
     @patch("utils.generate_random_password", return_value="super_secure_password")
@@ -121,9 +117,8 @@ class TestSharedDBRelation(unittest.TestCase):
 
         self.assertTrue(isinstance(self.harness.model.unit.status, BlockedStatus))
 
-    @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MySQLOperatorCharm.unit_initialized", return_value=True)
-    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="1.1.1.1:3306")
+    @patch("mysql_vm_helpers.MySQL.get_cluster_primary_address", return_value="192.0.2.0:3306")
     @patch("mysql_vm_helpers.MySQL.delete_users_for_unit")
     @patch("relations.shared_db.generate_random_password", return_value="super_secure_password")
     @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")


### PR DESCRIPTION
## Issue

The tests currently patch a private ops class. The private names have no compatibility guarantee, and this will stop working in an upcoming ops release.

## Solution

Remove the patching, which is not required in modern ops. Also update the expect default IP (from Cloudflare's DNS server, which we shouldn't be using anyway).