### PR TITLE
DPE-5178 Upgrade fix for admin-address enabled charm

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 71
+LIBPATCH = 72
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -2247,8 +2247,9 @@ class MySQLBase(ABC):
 
     def verify_server_upgradable(self, instance: Optional[str] = None) -> None:
         """Wrapper for API check_for_server_upgrade."""
+        # use cluster admin user to enforce standard port usage
         check_command = [
-            f"shell.connect('{self.instance_def(self.server_config_user, host=instance)}')",
+            f"shell.connect('{self.instance_def(self.cluster_admin_user, host=instance)}')",
             "try:",
             "    util.check_for_server_upgrade(options={'outputFormat': 'JSON'})",
             "except ValueError:",  # ValueError is raised for same version check

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -1728,7 +1728,7 @@ xtrabackup/location --defaults-file=defaults/config/file
     def test_verify_server_upgradable(self, _run_mysqlsh_script):
         """Test is_server_upgradable."""
         commands = (
-            "shell.connect('serverconfig:serverconfigpassword@127.0.0.1:33062')",
+            "shell.connect('clusteradmin:clusteradminpassword@2.3.4.5:3306')",
             "try:\n    util.check_for_server_upgrade(options={'outputFormat': 'JSON'})",
             "except ValueError:",
             "    if session.run_sql('select @@version').fetch_all()[0][0].split('-')[0] == shell.version.split()[1]:",
@@ -1752,7 +1752,7 @@ xtrabackup/location --defaults-file=defaults/config/file
             '"detectedProblems": [] }],'
             '"manualChecks": []}'
         )
-        self.mysql.verify_server_upgradable()
+        self.mysql.verify_server_upgradable("2.3.4.5")
         _run_mysqlsh_script.assert_called_with("\n".join(commands))
         _run_mysqlsh_script.return_value = (
             '{"serverAddress": "10.1.148.145:33060",'


### PR DESCRIPTION
## Issue

When upgrading, the new charm will try to check for server "upgradability" using the admin_address/port of an unit not yet upgrade, i.e. it may not yet have the port open.

## Solution

Use `clusteradmin` user for the upgrade check, as it will default to standard port 3306.

