### PR TITLE
DPE-5493 Skip tls reconfiguration on unit teardown

### DIFF
--- a/lib/charms/mysql/v0/tls.py
+++ b/lib/charms/mysql/v0/tls.py
@@ -166,6 +166,9 @@ class MySQLTLS(Object):
 
     def _on_tls_relation_broken(self, _) -> None:
         """Disable TLS when TLS relation broken."""
+        if self.charm.removing_unit:
+            logger.debug("Unit is being removed, skipping TLS cleanup.")
+            return
         try:
             if not ops.jujuversion.JujuVersion.from_environ().has_secrets:
                 self.charm.set_secret(SCOPE, "certificate-authority", None)
@@ -174,9 +177,6 @@ class MySQLTLS(Object):
         except KeyError:
             # ignore key error for unit teardown
             pass
-        if self.charm.removing_unit:
-            logger.debug("Unit is being removed, skipping TLS cleanup.")
-            return
         try:
             self.charm._mysql.tls_setup()
             self.charm.unit_peer_data.pop("tls")

--- a/lib/charms/mysql/v0/tls.py
+++ b/lib/charms/mysql/v0/tls.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "eb73947deedd4380a3a90d527e0878eb"
 LIBAPI = 0
-LIBPATCH = 7
+LIBPATCH = 8
 
 SCOPE = "unit"
 
@@ -174,6 +174,9 @@ class MySQLTLS(Object):
         except KeyError:
             # ignore key error for unit teardown
             pass
+        if self.charm.removing_unit:
+            logger.debug("Unit is being removed, skipping TLS cleanup.")
+            return
         try:
             self.charm._mysql.tls_setup()
             self.charm.unit_peer_data.pop("tls")


### PR DESCRIPTION
## Issue

Caught on tests, uncaught exception on unit teardown when related to a TLS operator

## Solution

Skip TLS reconfiguration on unit teardown
