### PR TITLE
DPE-5540 Skip plugin install for not file found

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,7 @@ class MySQLConfig:
         "log_error",
         "loose-audit_log_strategy",
         "loose-audit_log_format",
+        "admin_address",
     }
 
     def __init__(self, config_file_path: str):

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -793,6 +793,10 @@ class MySQL(MySQLBase):
         except FileNotFoundError:
             return False
 
+    def _file_exists(self, path: str) -> bool:
+        """Check if file exists."""
+        return os.path.exists(path)
+
     @staticmethod
     def write_content_to_file(
         path: str,

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -356,10 +356,9 @@ async def ensure_all_units_continuous_writes_incrementing(
     )
 
     async with ops_test.fast_forward(fast_interval="15s"):
-        for attempt in Retrying(reraise=True, stop=stop_after_delay(5 * 60), wait=wait_fixed(10)):
-            with attempt:
-                # ensure that all units are up to date (including the previous primary)
-                for unit in mysql_units:
+        for unit in mysql_units:
+            for attempt in Retrying(reraise=True, stop=stop_after_delay(5 * 60), wait=wait_fixed(10)):
+                with attempt:
                     # ensure the max written value is incrementing (continuous writes is active)
                     max_written_value = await get_max_written_value_in_database(
                         ops_test, unit, server_config_credentials

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -357,7 +357,9 @@ async def ensure_all_units_continuous_writes_incrementing(
 
     async with ops_test.fast_forward(fast_interval="15s"):
         for unit in mysql_units:
-            for attempt in Retrying(reraise=True, stop=stop_after_delay(5 * 60), wait=wait_fixed(10)):
+            for attempt in Retrying(
+                reraise=True, stop=stop_after_delay(5 * 60), wait=wait_fixed(10)
+            ):
                 with attempt:
                     # ensure the max written value is incrementing (continuous writes is active)
                     max_written_value = await get_max_written_value_in_database(

--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -1,0 +1,90 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from time import sleep
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_, markers
+from ..helpers import get_leader_unit, get_primary_unit_wrapper, retrieve_database_variable_value
+from .high_availability_helpers import (
+    ensure_all_units_continuous_writes_incrementing,
+    relate_mysql_and_application,
+)
+
+logger = logging.getLogger(__name__)
+
+TIMEOUT = 20 * 60
+
+MYSQL_APP_NAME = "mysql"
+TEST_APP_NAME = "mysql-test-app"
+
+
+@pytest.mark.group(1)
+@markers.amd64_only  # TODO: remove after arm64 stable release
+@pytest.mark.abort_on_fail
+async def test_deploy_stable(ops_test: OpsTest) -> None:
+    """Simple test to ensure that the mysql and application charms get deployed."""
+    await asyncio.gather(
+        ops_test.model.deploy(
+            MYSQL_APP_NAME,
+            application_name=MYSQL_APP_NAME,
+            num_units=3,
+            channel="8.0/stable",
+            base="ubuntu@22.04",
+            config={"profile": "testing"},
+        ),
+        ops_test.model.deploy(
+            TEST_APP_NAME,
+            application_name=TEST_APP_NAME,
+            num_units=1,
+            channel="latest/edge",
+            base="ubuntu@22.04",
+            config={"sleep_interval": 50},
+        ),
+    )
+    await relate_mysql_and_application(ops_test, MYSQL_APP_NAME, TEST_APP_NAME)
+    logger.info("Wait for applications to become active")
+    await ops_test.model.wait_for_idle(
+        apps=[MYSQL_APP_NAME, TEST_APP_NAME],
+        status="active",
+        timeout=TIMEOUT,
+    )
+    assert len(ops_test.model.applications[MYSQL_APP_NAME].units) == 3
+
+
+@pytest.mark.group(1)
+@markers.amd64_only  # TODO: remove after arm64 stable release
+async def test_refresh_without_pre_upgrade_check(ops_test: OpsTest):
+    """Test updating from stable channel."""
+    application = ops_test.model.applications[MYSQL_APP_NAME]
+    logger.info("Build charm locally")
+    charm = await ops_test.build_charm(".")
+
+    logger.info("Refresh the charm")
+    await application.refresh(path=charm)
+
+    # Refresh without pre-upgrade-check can have two immediate effects:
+    #   1. None, if there's no configuration change
+    #   2. Rolling restart, if there's a configuration change
+    # for both, operations should continue to work
+    # and there's a mismatch between the charm and the snap
+    logger.info("Wait for rolling restart OR continue to writes")
+    count = 0
+    while count < 2 * 60:
+        if "maintenance" in {unit.workload_status for unit in application.units}:
+            # Case when refresh triggers a rolling restart
+            logger.info("Waiting for rolling restart to complete")
+            await ops_test.model.wait_for_idle(
+                apps=[MYSQL_APP_NAME], status="active", idle_period=30, timeout=TIMEOUT
+            )
+            break
+        else:
+            count += 1
+            sleep(1)
+
+    logger.info("Ensure continuous_writes")
+    await ensure_all_units_continuous_writes_incrementing(ops_test)

--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -8,8 +8,7 @@ from time import sleep
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from .. import juju_, markers
-from ..helpers import get_leader_unit, get_primary_unit_wrapper, retrieve_database_variable_value
+from .. import markers
 from .high_availability_helpers import (
     ensure_all_units_continuous_writes_incrementing,
     relate_mysql_and_application,

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -2040,6 +2040,7 @@ xtrabackup/location --defaults-file=defaults/config/file
 
         self.assertEqual(self.mysql.get_cluster_set_name(), self.mysql.cluster_set_name)
 
+    @patch("charms.mysql.v0.mysql.MySQLBase._file_exists", return_value=True)
     @patch("charms.mysql.v0.mysql.MySQLBase.get_variable_value")
     @patch("charms.mysql.v0.mysql.MySQLBase._get_installed_plugins")
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
@@ -2048,6 +2049,7 @@ xtrabackup/location --defaults-file=defaults/config/file
         _run_mysqlcli_script,
         _get_installed_plugins,
         _get_variable_value,
+        _file_exists,
     ):
         """Test install_plugin."""
         _get_variable_value.return_value = "ON"


### PR DESCRIPTION
## Issue

1. `config_change` hook will try to install plugins if configuration diff so indicates, even if plugins files are not available.
2. admin address enabled charms revisions will fail to connect to mysqld case it's not restarted

Case:
  `refresh` ran without `pre-upgrade-check` - so snap is not updated (no plugin files) but config changed is triggered.

## Solution
1. Check for plugin file before try install. Skip if file not found
2. Ensure mysqld restarts on post refresh `config_change` event
