### PR TITLE
DPE-5582 Timeout node count query

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 74
+LIBPATCH = 75
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1937,7 +1937,7 @@ class MySQLBase(ABC):
         )
 
         try:
-            output = self._run_mysqlsh_script("\n".join(size_commands))
+            output = self._run_mysqlsh_script("\n".join(size_commands), timeout=30)
         except MySQLClientError:
             logger.warning("Failed to get node count")
             return 0

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -2006,7 +2006,7 @@ xtrabackup/location --defaults-file=defaults/config/file
             'print(f"<NODES>{result.fetch_one()[0]}</NODES>")',
         )
         self.mysql.get_cluster_node_count(node_status=MySQLMemberState.ONLINE)
-        _run_mysqlsh_script.assert_called_with("\n".join(commands))
+        _run_mysqlsh_script.assert_called_with("\n".join(commands), timeout=30)
 
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
     def test_get_cluster_set_global_primary(self, _run_mysqlsh_script):


### PR DESCRIPTION
## Issue

Recent PR #518 introduced new method on update status for the k8s charm.
The method calls node_count method that fails on all units if there's one unresponsive unit, causing regression in freeze db tests, due responsive units not being able to relabel pods.

## Solution

Add timeout on node_count method to avoid hanging due unresponsive unit(s).
