### PR TITLE
DPE-5628 Skip set unknown config keys

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -322,6 +322,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             # if only dynamic config changed, apply it
             logger.info("Configuration does not requires restart")
             for config in dynamic_config:
+                if config not in new_config_dict:
+                    # skip removed configs
+                    continue
                 self._mysql.set_dynamic_variable(config, new_config_dict[config])
 
     def _on_start(self, event: StartEvent) -> None:

--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import logging
+import subprocess
 from time import sleep
 
 import pytest
@@ -71,7 +72,7 @@ async def test_refresh_without_pre_upgrade_check(ops_test: OpsTest):
     #   2. Rolling restart, if there's a configuration change
     # for both, operations should continue to work
     # and there's a mismatch between the charm and the snap
-    logger.info("Wait for rolling restart OR continue to writes")
+    logger.info("Wait (120s) for rolling restart OR continue to writes")
     count = 0
     while count < 2 * 60:
         if "maintenance" in {unit.workload_status for unit in application.units}:
@@ -85,5 +86,34 @@ async def test_refresh_without_pre_upgrade_check(ops_test: OpsTest):
             count += 1
             sleep(1)
 
-    logger.info("Ensure continuous_writes")
+    await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+
+@pytest.mark.group(1)
+@markers.amd64_only  # TODO: remove after arm64 stable release
+async def test_rollback_without_pre_upgrade_check(ops_test: OpsTest):
+    """Test refresh back to stable channel."""
+    application = ops_test.model.applications[MYSQL_APP_NAME]
+
+    logger.info("Refresh the charm back to stable channel")
+    # pylibjuju refresh dont work for switch:
+    # https://github.com/juju/python-libjuju/issues/924
+    subprocess.check_output(
+        f"juju refresh {MYSQL_APP_NAME} --switch ch:{MYSQL_APP_NAME} --channel 8.0/stable".split()
+    )
+
+    logger.info("Wait (120s) for rolling restart OR continue to writes")
+    count = 0
+    while count < 2 * 60:
+        if "maintenance" in {unit.workload_status for unit in application.units}:
+            # Case when refresh triggers a rolling restart
+            logger.info("Waiting for rolling restart to complete")
+            await ops_test.model.wait_for_idle(
+                apps=[MYSQL_APP_NAME], status="active", idle_period=30, timeout=TIMEOUT
+            )
+            break
+        else:
+            count += 1
+            sleep(1)
+
     await ensure_all_units_continuous_writes_incrementing(ops_test)


### PR DESCRIPTION
## Issue

1. When rolling back to revisions with subset of known configuration, the unknown keys are wrongly tried to be dynamically set, which will break the rendered config dict.
2. Configuration is not always being persisted to disk

## Solution

1. Test config keys for existence in rendered config dict before trying to set them.
2. Always persist configuration to disk on config change

Tests to follow once this revision get promoted to stable 
