### PR TITLE
DPE-5627 CC006 compliance

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,19 @@
+resource "juju_application" "machine_mysql" {
+  name  = var.app_name
+  model = var.juju_model_name
+
+  charm {
+    name     = "mysql"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  storage_directives = {
+    database = var.storage_size
+  }
+
+  units       = var.units
+  constraints = var.constraints
+  config      = var.config
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,17 @@
+output "application_name" {
+  value = juju_application.machine_mysql.name
+}
+
+output "provides" {
+  value = {
+    database  = "database",
+    cos_agent = "cos-agent",
+  }
+}
+
+output "requires" {
+  value = {
+    certificates  = "certificates"
+    s3_parameters = "s3-parameters"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,52 @@
+variable "juju_model_name" {
+  description = "Juju model name"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "mysql"
+}
+
+variable "channel" {
+  description = "Charm channel to use when deploying"
+  type        = string
+  default     = "8.0/stable"
+}
+
+variable "revision" {
+  description = "Revision number to deploy charm"
+  type        = number
+  default     = null
+}
+
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@22.04"
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "storage_size" {
+  description = "Storage size"
+  type        = string
+  default     = "10G"
+}
+
+variable "config" {
+  description = "Application configuration. Details at https://charmhub.io/mysql/configurations"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 0.14.0"
+    }
+  }
+}


### PR DESCRIPTION
Fully featured TF module, moved from is-devops repo to charm repo.
Following spec [CC006](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0)