### PR TITLE
[DPE-5941] Trying to start Group replication while waiting for upgrade

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 75
+LIBPATCH = 76
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -2471,9 +2471,22 @@ class MySQLBase(ABC):
             "    session.run_sql('STOP GROUP_REPLICATION')",
         )
         try:
+            logger.debug("Stoping Group Replication for unit")
             self._run_mysqlsh_script("\n".join(stop_gr_command))
         except MySQLClientError:
-            logger.debug("Failed to stop Group Replication for unit")
+            logger.warning("Failed to stop Group Replication for unit")
+
+    def start_group_replication(self) -> None:
+        """Start Group replication on the instance."""
+        start_gr_command = (
+            f"shell.connect('{self.instance_def(self.server_config_user)}')",
+            "session.run_sql('START GROUP_REPLICATION')",
+        )
+        try:
+            logger.debug("Starting Group Replication for unit")
+            self._run_mysqlsh_script("\n".join(start_gr_command))
+        except MySQLClientError:
+            logger.warning("Failed to start Group Replication for unit")
 
     def reboot_from_complete_outage(self) -> None:
         """Wrapper for reboot_cluster_from_complete_outage command."""

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -271,6 +271,7 @@ class MySQLVMUpgrade(DataUpgrade):
                             "Instance not yet back in the cluster."
                             f" Retry {attempt.retry_state.attempt_number}/{RECOVER_ATTEMPTS}"
                         )
+                        self.charm._mysql.start_group_replication()
                         raise Exception
         except RetryError:
             raise


### PR DESCRIPTION
## Issue
MySQL rarely failing on `juju refresh` on timeout waiting for unit re-join the cluster on reboot:
> Instance not yet back in the cluster. Retry 30/30

Normally it happens on CPU straggling environment (CI/CD) when the default mysqld timeouts are not enough to start GR.
See the detailed descrition in https://warthogs.atlassian.net/browse/DPE-5941

## Solution
Start MySQL Group replication after reboot additional for auto-start GR mysqld logic.

Fixes: https://warthogs.atlassian.net/browse/DPE-5941