### PR TITLE
Remove leftover MySQLBase methods

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -133,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 76
+LIBPATCH = 77
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -2027,13 +2027,6 @@ xtrabackup/location --defaults-file=defaults/config/file
         self.assertTrue(self.mysql.is_cluster_replica())
 
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_set_status")
-    def test_cluster_set_cluster_count(self, _get_cluster_set_status):
-        """Test cluster_set_cluster_count."""
-        _get_cluster_set_status.return_value = CLUSTER_SET_STATUS
-
-        self.assertEqual(self.mysql.cluster_set_cluster_count(), 2)
-
-    @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_set_status")
     def test_get_cluster_set_name(self, _get_cluster_set_status):
         """Test cluster_set_name."""
         _get_cluster_set_status.return_value = CLUSTER_SET_STATUS


### PR DESCRIPTION
This PR removes unused methods from the `MySQLBase` class.

I have validated that no Canonical project is using any of these methods, by performing an [org-level search](https://github.com/search?q=org%3Acanonical%20%22get_cluster_members_addresses%22%20OR%20%22cluster_set_cluster_count%22&type=code) on GitHub. Please, if you know of any **non-Canonical** project using the `mysql` public library, let me know.

### Additional considerations
I have bumped up the `mysql` library patch version. Please, let me know whether this is actually necessary.
