### PR TITLE
[DPE-5711] Add warnings to destructive actions

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1548,8 +1548,12 @@ class MySQLBase(ABC):
             ),
         )
 
-        try:
+        if force:
+            logger.warning(f"Promoting {cluster_name=} to primary with {force=}")
+        else:
             logger.debug(f"Promoting {cluster_name=} to primary with {force=}")
+
+        try:
             self._run_mysqlsh_script("\n".join(commands))
         except MySQLClientError:
             logger.exception("Failed to promote cluster to primary")

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -831,6 +831,8 @@ class MySQL(MySQLBase):
     @staticmethod
     def reset_data_dir() -> None:
         """Reset the data directory."""
+        logger.warning(f"Resetting data directory: {MYSQL_DATA_DIR}")
+
         # Remove the data directory
         shutil.rmtree(MYSQL_DATA_DIR, ignore_errors=False)
 

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -218,7 +218,7 @@ class MySQLVMUpgrade(DataUpgrade):
                 self.set_unit_failed()
                 return
 
-            logger.info("Downgrade is incompatible. Resetting workload")
+            logger.warning("Downgrade is incompatible. Resetting workload")
             self._reset_on_unsupported_downgrade()
         except MySQLStopMySQLDError:
             logger.exception("Failed to stop MySQL server")


### PR DESCRIPTION
This PR adds warning level messages when a _destructive_ action is performed. The definition of _destructive_ seems to be associated with data loss, which I think it can only happen, from user action, whenever they force a primary failover without checking considering the health of such instance.

### Additional info
- Paulo confirmed that this ticket was created to familiarised myself with the codebases.
- Alex referenced this PostgreSQL operator [PR](https://github.com/canonical/postgresql-k8s-operator/pull/753) as the reason behind the need for warnings.
