### PR TITLE
Loosen the manual server shell compatibility check to allow for shell 8.0.38 built for 8.0.39

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -134,7 +134,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 76
+LIBPATCH = 77
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -2311,7 +2311,7 @@ class MySQLBase(ABC):
             "try:",
             "    util.check_for_server_upgrade(options={'outputFormat': 'JSON'})",
             "except ValueError:",  # ValueError is raised for same version check
-            "    if session.run_sql('select @@version').fetch_all()[0][0].split('-')[0] == shell.version.split()[1]:",
+            "    if session.run_sql('select @@version').fetch_all()[0][0].split('-')[0] in shell.version:",
             "        print('SAME_VERSION')",
             "    else:",
             "        raise",

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -1746,7 +1746,7 @@ xtrabackup/location --defaults-file=defaults/config/file
             "shell.connect('clusteradmin:clusteradminpassword@2.3.4.5:3306')",
             "try:\n    util.check_for_server_upgrade(options={'outputFormat': 'JSON'})",
             "except ValueError:",
-            "    if session.run_sql('select @@version').fetch_all()[0][0].split('-')[0] == shell.version.split()[1]:",
+            "    if session.run_sql('select @@version').fetch_all()[0][0].split('-')[0] in shell.version:",
             "        print('SAME_VERSION')",
             "    else:",
             "        raise",


### PR DESCRIPTION
## Issue
```
 MySQL  127.0.0.1:33060+ ssl  Py > util.check_for_server_upgrade(options={'outputFormat': 'JSON'})
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: Util.check_for_server_upgrade: Detected MySQL Server version is 8.0.39. MySQL Shell cannot check MySQL server instances for upgrade if they are at a version the same as or higher than the MySQL Shell version.

 MySQL  127.0.0.1:33060+ ssl  Py > session.run_sql('select @@version').fetch_all()[0][0].split('-')[0] == shell.version.split()[1]
false
 MySQL  127.0.0.1:33060+ ssl  Py > session.run_sql('select @@version').fetch_all()[0][0].split('-')
[
    "8.0.39", 
    "0ubuntu0.22.04.1"
]
 MySQL  127.0.0.1:33060+ ssl  Py > shell.version
Ver 8.0.38 for Linux on x86_64 - for MySQL 8.0.39 (Source distribution)
```

Shell here is 8.0.38 (but built for 8.0.39). This fails the manual shell server compatibility check, resulting in [the following test run failure](https://github.com/canonical/mysql-k8s-operator/actions/runs/12018816518/job/33540066803?pr=488)

## Solution
Loosen the check to allow for shell 8.0.39 which is built for 8.0.39
