### PR TITLE
fix: use juju provided ip (DPE-6105)

### DIFF
--- a/src/hostname_resolution.py
+++ b/src/hostname_resolution.py
@@ -50,14 +50,7 @@ class MySQLMachineHostnameResolution(Object):
         hostname = socket.gethostname()
         fqdn = socket.getfqdn()
 
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.settimeout(0)
-        try:
-            s.connect(("10.10.10.10", 1))
-            ip = s.getsockname()[0]
-        except Exception:
-            logger.exception("Unable to get local IP address")
-            ip = "127.0.0.1"
+        ip = str(self.model.get_binding(PEER).network.bind_address)
 
         host_details = {"names": [hostname, fqdn], "address": ip}
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,6 +10,7 @@ import yaml
 from ops.testing import Harness
 
 from charm import MySQLOperatorCharm
+from constants import PEER
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 def harness():
     harness = Harness(MySQLOperatorCharm, meta=METADATA, config=CONFIG, actions=ACTIONS)
     harness.add_relation("restart", "mysql")
+    harness.add_relation(PEER, "mysql")
     harness.begin()
     return harness
 


### PR DESCRIPTION
## Issue

On environments with multiple interfaces/networks, retrieving IP from a DNS may lead to unreachable address.

## Solution

Use juju provided bind address for hostname/ip map, instead of DNS returned address.