### PR TITLE
[DPE-5588] Create architecture helpers lib

### DIFF
--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -35,6 +35,7 @@ import pathlib
 import platform
 import sys
 
+import yaml
 from ops import BlockedStatus, CharmBase
 
 # The unique Charmhub library identifier, never change it
@@ -42,7 +43,7 @@ LIBID = "827e04542dba4c2a93bdc70ae40afdb1"
 LIBAPI = 0
 LIBPATCH = 1
 
-PYDEPS = ["ops>=2.0.0"]
+PYDEPS = ["ops>=2.0.0", "pyyaml>=5.0"]
 
 
 logger = logging.getLogger(__name__)
@@ -67,12 +68,12 @@ def is_wrong_architecture() -> bool:
         logger.error("Cannot check architecture: manifest file not found in %s", manifest_path)
         return False
 
-    with open(manifest_path, "r") as file:
-        manifest = file.read()
+    manifest = yaml.safe_load(manifest_path.read_text())
+    manifest_arch = [arch for base in manifest["bases"] for arch in base["architectures"]]
+    hardware_arch = platform.machine()
 
-    hw_arch = platform.machine()
-    if ("amd64" in manifest and hw_arch == "x86_64") or (
-        "arm64" in manifest and hw_arch == "aarch64"
+    if ("amd64" in manifest_arch and hardware_arch == "x86_64") or (
+        "arm64" in manifest_arch and hardware_arch == "aarch64"
     ):
         logger.debug("Charm architecture matches")
         return False

--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -1,0 +1,80 @@
+# Copyright 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library to provide hardware architecture checks for VMs and K8s charms.
+
+The WrongArchitectureWarningCharm class is designed to be used alongside
+the is-wrong-architecture helper function, as follows:
+
+```python
+import sys
+
+from ops import main
+from charms.mysql.v0.architecture import WrongArchitectureWarningCharm, is_wrong_architecture
+
+if __name__ == "__main__":
+    if is_wrong_architecture():
+        main(WrongArchitectureWarningCharm)
+        sys.exit(1)
+```
+"""
+
+import logging
+import os
+import sys
+
+from ops import BlockedStatus, CharmBase
+
+# The unique Charmhub library identifier, never change it
+LIBID = "827e04542dba4c2a93bdc70ae40afdb1"
+LIBAPI = 0
+LIBPATCH = 1
+
+PYDEPS = ["ops>=2.0.0"]
+
+
+logger = logging.getLogger(__name__)
+
+
+class WrongArchitectureWarningCharm(CharmBase):
+    """A fake charm class that only signals a wrong architecture deploy."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        hw_arch = os.uname().machine
+        self.unit.status = BlockedStatus(f"Error: Charm incompatible with {hw_arch} architecture")
+        sys.exit(0)
+
+
+def is_wrong_architecture() -> bool:
+    """Checks if charm was deployed on wrong architecture."""
+    manifest_path = f"{os.environ.get('CHARM_DIR')}/manifest.yaml"
+
+    if not os.path.exists(manifest_path):
+        logger.error("Cannot check architecture: manifest file not found in %s", manifest_path)
+        return False
+
+    with open(manifest_path, "r") as file:
+        manifest = file.read()
+
+    hw_arch = os.uname().machine
+    if ("amd64" in manifest and hw_arch == "x86_64") or (
+        "arm64" in manifest and hw_arch == "aarch64"
+    ):
+        logger.info("Charm architecture matches")
+        return False
+
+    logger.error("Charm architecture does not match")
+    return True

--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -31,6 +31,8 @@ if __name__ == "__main__":
 
 import logging
 import os
+import pathlib
+import platform
 import sys
 
 from ops import BlockedStatus, CharmBase
@@ -52,27 +54,27 @@ class WrongArchitectureWarningCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        hw_arch = os.uname().machine
+        hw_arch = platform.machine()
         self.unit.status = BlockedStatus(f"Error: Charm incompatible with {hw_arch} architecture")
         sys.exit(0)
 
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    manifest_path = f"{os.environ.get('CHARM_DIR')}/manifest.yaml"
+    manifest_path = pathlib.Path(os.environ["CHARM_DIR"], "manifest.yaml")
 
-    if not os.path.exists(manifest_path):
+    if not manifest_path.exists():
         logger.error("Cannot check architecture: manifest file not found in %s", manifest_path)
         return False
 
     with open(manifest_path, "r") as file:
         manifest = file.read()
 
-    hw_arch = os.uname().machine
+    hw_arch = platform.machine()
     if ("amd64" in manifest and hw_arch == "x86_64") or (
         "arm64" in manifest and hw_arch == "aarch64"
     ):
-        logger.info("Charm architecture matches")
+        logger.debug("Charm architecture matches")
         return False
 
     logger.error("Charm architecture does not match")

--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -69,11 +69,15 @@ def is_wrong_architecture() -> bool:
         return False
 
     manifest = yaml.safe_load(manifest_path.read_text())
-    manifest_arch = [arch for base in manifest["bases"] for arch in base["architectures"]]
-    hardware_arch = platform.machine()
 
-    if ("amd64" in manifest_arch and hardware_arch == "x86_64") or (
-        "arm64" in manifest_arch and hardware_arch == "aarch64"
+    manifest_archs = []
+    for base in manifest["bases"]:
+        base_archs = base.get("architectures", [])
+        manifest_archs.extend(base_archs)
+
+    hardware_arch = platform.machine()
+    if ("amd64" in manifest_archs and hardware_arch == "x86_64") or (
+        "arm64" in manifest_archs and hardware_arch == "aarch64"
     ):
         logger.debug("Charm architecture matches")
         return False

--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -26,7 +26,6 @@ from charms.mysql.v0.architecture import WrongArchitectureWarningCharm, is_wrong
 if __name__ == "__main__":
     if is_wrong_architecture():
         main(WrongArchitectureWarningCharm)
-        sys.exit(1)
 ```
 """
 

--- a/tests/unit/test_architecture.py
+++ b/tests/unit/test_architecture.py
@@ -11,8 +11,8 @@ from charms.mysql.v0.architecture import is_wrong_architecture
 def test_wrong_architecture_file_not_found():
     """Tests if the function returns False when the charm file doesn't exist."""
     with (
-        patch("os.environ.get", return_value="/tmp"),
-        patch("os.path.exists", return_value=False),
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=False),
     ):
         assert not is_wrong_architecture()
 
@@ -20,26 +20,26 @@ def test_wrong_architecture_file_not_found():
 def test_wrong_architecture_amd64():
     """Tests if the function correctly identifies arch when charm is AMD."""
     with (
-        patch("os.environ.get", return_value="/tmp"),
-        patch("os.path.exists", return_value=True),
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=True),
         patch("builtins.open", mock.mock_open(read_data="amd64\n")),
-        patch("os.uname") as _uname,
+        patch("platform.machine") as machine,
     ):
-        _uname.return_value = mock.Mock(machine="x86_64")
+        machine.return_value = "x86_64"
         assert not is_wrong_architecture()
-        _uname.return_value = mock.Mock(machine="aarch64")
+        machine.return_value = "aarch64"
         assert is_wrong_architecture()
 
 
 def test_wrong_architecture_arm64():
     """Tests if the function correctly identifies arch when charm is ARM."""
     with (
-        patch("os.environ.get", return_value="/tmp"),
-        patch("os.path.exists", return_value=True),
+        patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
+        patch("pathlib.Path.exists", return_value=True),
         patch("builtins.open", mock.mock_open(read_data="arm64\n")),
-        patch("os.uname") as _uname,
+        patch("platform.machine") as machine,
     ):
-        _uname.return_value = mock.Mock(machine="x86_64")
+        machine.return_value = "x86_64"
         assert is_wrong_architecture()
-        _uname.return_value = mock.Mock(machine="aarch64")
+        machine.return_value = "aarch64"
         assert not is_wrong_architecture()

--- a/tests/unit/test_architecture.py
+++ b/tests/unit/test_architecture.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest.mock as mock
+from unittest.mock import patch
+
+from charms.mysql.v0.architecture import is_wrong_architecture
+
+
+def test_wrong_architecture_file_not_found():
+    """Tests if the function returns False when the charm file doesn't exist."""
+    with (
+        patch("os.environ.get", return_value="/tmp"),
+        patch("os.path.exists", return_value=False),
+    ):
+        assert not is_wrong_architecture()
+
+
+def test_wrong_architecture_amd64():
+    """Tests if the function correctly identifies arch when charm is AMD."""
+    with (
+        patch("os.environ.get", return_value="/tmp"),
+        patch("os.path.exists", return_value=True),
+        patch("builtins.open", mock.mock_open(read_data="amd64\n")),
+        patch("os.uname") as _uname,
+    ):
+        _uname.return_value = mock.Mock(machine="x86_64")
+        assert not is_wrong_architecture()
+        _uname.return_value = mock.Mock(machine="aarch64")
+        assert is_wrong_architecture()
+
+
+def test_wrong_architecture_arm64():
+    """Tests if the function correctly identifies arch when charm is ARM."""
+    with (
+        patch("os.environ.get", return_value="/tmp"),
+        patch("os.path.exists", return_value=True),
+        patch("builtins.open", mock.mock_open(read_data="arm64\n")),
+        patch("os.uname") as _uname,
+    ):
+        _uname.return_value = mock.Mock(machine="x86_64")
+        assert is_wrong_architecture()
+        _uname.return_value = mock.Mock(machine="aarch64")
+        assert not is_wrong_architecture()

--- a/tests/unit/test_architecture.py
+++ b/tests/unit/test_architecture.py
@@ -2,10 +2,17 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest.mock as mock
 from unittest.mock import patch
 
 from charms.mysql.v0.architecture import is_wrong_architecture
+
+TEST_MANIFEST = """
+    bases:
+        - architectures:
+            - {arch}
+          channel: '22.04'
+          name: ubuntu
+"""
 
 
 def test_wrong_architecture_file_not_found():
@@ -22,7 +29,7 @@ def test_wrong_architecture_amd64():
     with (
         patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
         patch("pathlib.Path.exists", return_value=True),
-        patch("builtins.open", mock.mock_open(read_data="amd64\n")),
+        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="amd64")),
         patch("platform.machine") as machine,
     ):
         machine.return_value = "x86_64"
@@ -36,7 +43,7 @@ def test_wrong_architecture_arm64():
     with (
         patch("os.environ", return_value={"CHARM_DIR": "/tmp"}),
         patch("pathlib.Path.exists", return_value=True),
-        patch("builtins.open", mock.mock_open(read_data="arm64\n")),
+        patch("pathlib.Path.read_text", return_value=TEST_MANIFEST.format(arch="arm64")),
         patch("platform.machine") as machine,
     ):
         machine.return_value = "x86_64"


### PR DESCRIPTION
This PR proposes the creation of a new _MySQL specific_ lib to define all architecture related helpers. So far, it only contains what is necessary to warn a charm user that they are trying to deploy a charm in the wrong architecture (see doc-string).

Once this PR gets approved, I will start adding the check in all MySQL / MySQL-router operators.

### Additional info
- Most of the code proposed was originally created by @lucasgameiroborges in this PostgreSQL K8S [PR](https://github.com/canonical/postgresql-k8s-operator/pull/613).
- Ideally, I would like for all this logic to be moved to [data-platform helpers](https://github.com/canonical/data-platform-helpers), so other charms could use it as well.