### PR TITLE
[DEP-5588] Fix architecture lib helpers

### DIFF
--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -54,8 +54,8 @@ class WrongArchitectureWarningCharm(CharmBase):
 
         raise RuntimeError(
             f"Incompatible architecture: this charm revision does not support {platform.machine()}. "
-            f"If the application is being refreshed, rollback with instructions from Charmhub docs. "
-            f"If the application is being deployed for the first time, remove it and deploy it again "
+            f"If this app is being refreshed, rollback with instructions from Charmhub docs. "
+            f"If this app is being deployed for the first time, remove it and deploy it again "
             f"using a compatible revision."
         )
 

--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -33,7 +33,8 @@ import pathlib
 import platform
 
 import yaml
-from ops import CharmBase
+from ops.charm import CharmBase
+from ops.model import BlockedStatus
 
 # The unique Charmhub library identifier, never change it
 LIBID = "827e04542dba4c2a93bdc70ae40afdb1"
@@ -52,8 +53,10 @@ class WrongArchitectureWarningCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
+        hw_arch = platform.machine()
+        self.unit.status = BlockedStatus(f"Error: Charm incompatible with {hw_arch} architecture")
         raise RuntimeError(
-            f"Incompatible architecture: this charm revision does not support {platform.machine()}. "
+            f"Incompatible architecture: this charm revision does not support {hw_arch}. "
             f"If this app is being refreshed, rollback with instructions from Charmhub docs. "
             f"If this app is being deployed for the first time, remove it and deploy it again "
             f"using a compatible revision."

--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -54,7 +54,10 @@ class WrongArchitectureWarningCharm(CharmBase):
         super().__init__(*args)
 
         hw_arch = platform.machine()
-        self.unit.status = BlockedStatus(f"Error: Charm incompatible with {hw_arch} architecture")
+        self.unit.status = BlockedStatus(
+            f"Charm incompatible with {hw_arch} architecture. "
+            f"If this app is being refreshed, rollback"
+        )
         raise RuntimeError(
             f"Incompatible architecture: this charm revision does not support {hw_arch}. "
             f"If this app is being refreshed, rollback with instructions from Charmhub docs. "

--- a/lib/charms/mysql/v0/architecture.py
+++ b/lib/charms/mysql/v0/architecture.py
@@ -18,8 +18,6 @@ The WrongArchitectureWarningCharm class is designed to be used alongside
 the is-wrong-architecture helper function, as follows:
 
 ```python
-import sys
-
 from ops import main
 from charms.mysql.v0.architecture import WrongArchitectureWarningCharm, is_wrong_architecture
 
@@ -33,10 +31,9 @@ import logging
 import os
 import pathlib
 import platform
-import sys
 
 import yaml
-from ops import BlockedStatus, CharmBase
+from ops import CharmBase
 
 # The unique Charmhub library identifier, never change it
 LIBID = "827e04542dba4c2a93bdc70ae40afdb1"
@@ -55,14 +52,18 @@ class WrongArchitectureWarningCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        hw_arch = platform.machine()
-        self.unit.status = BlockedStatus(f"Error: Charm incompatible with {hw_arch} architecture")
-        sys.exit(0)
+        raise RuntimeError(
+            f"Incompatible architecture: this charm revision does not support {platform.machine()}. "
+            f"If the application is being refreshed, rollback with instructions from Charmhub docs. "
+            f"If the application is being deployed for the first time, remove it and deploy it again "
+            f"using a compatible revision."
+        )
 
 
 def is_wrong_architecture() -> bool:
     """Checks if charm was deployed on wrong architecture."""
-    manifest_path = pathlib.Path(os.environ["CHARM_DIR"], "manifest.yaml")
+    charm_path = os.environ.get("CHARM_DIR", "")
+    manifest_path = pathlib.Path(charm_path, "manifest.yaml")
 
     if not manifest_path.exists():
         logger.error("Cannot check architecture: manifest file not found in %s", manifest_path)


### PR DESCRIPTION
This PR fixes a couple of issues discovered when integrating the _arch mismatch check_ into MySQL charm codebases.

- It makes the [`WrongArchitectureWarningCharm`](https://github.com/canonical/mysql-operator/blob/f1cce241dc11eed4ee31aba2a3cfb638c4c03edb/lib/charms/mysql/v0/architecture.py#L52-L60) class to raise an exception, instead of exiting with error code `0`. As briefly discussed on 11-12-2024 Technical Sync meeting, there is an edge-case where, if the charm user is _refreshing the revision_ to an arch-incompatible one, some events may be lost in the rollback process if the charm just exits.
- It makes the [`is_wrong_architecture`](https://github.com/canonical/mysql-operator/blob/f1cce241dc11eed4ee31aba2a3cfb638c4c03edb/lib/charms/mysql/v0/architecture.py#L63-L86) helper func resilient to environments where the `CHARM_DIR` variable is not set (i.e. when running unit tests).
