### PR TITLE
Separate IP address observer into separate script

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -19,6 +19,8 @@ parts:
       - -requirements.txt
     prime:
       - snap_revisions.json
+      - scripts
+      - templates
   charm:
     build-snaps:
       - rustup

--- a/scripts/ip_address_dispatcher.py
+++ b/scripts/ip_address_dispatcher.py
@@ -1,0 +1,59 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Dispatch event if IP address changes."""
+
+import subprocess
+import logging
+import socket
+import sys
+import time
+
+logger = logging.getLogger(__name__)
+
+def dispatch(run_command, unit, charm_directory):
+    """Use the juju-run command to dispatch :class:`IPAddressChangeEvent`."""
+    dispatch_sub_command = "JUJU_DISPATCH_PATH=hooks/ip_address_change {}/dispatch"
+    subprocess.run([run_command, "-u", unit, dispatch_sub_command.format(charm_directory)])
+
+
+def main():
+    """Main watch and dispatch loop.
+
+    Determine the host IP address every 30 seconds, and dispatch and event if it
+    changes.
+    """
+    run_command, unit, charm_directory = sys.argv[1:]
+
+    def _get_local_ip():
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(0)
+
+        try:
+            s.connect(("10.10.10.10", 1))
+            ip = s.getsockname()[0]
+        except Exception:
+            logger.exception("Unable to get local IP address")
+            ip = "127.0.0.1"
+
+        return ip
+
+    previous_ip_address = None
+    while True:
+        ip_address = _get_local_ip()
+
+        if not previous_ip_address:
+            print(f"Setting initial ip address to {ip_address}")
+            sys.stdout.flush()
+            previous_ip_address = ip_address
+        elif ip_address != previous_ip_address:
+            print(f"Detected ip address change from {previous_ip_address} to {ip_address}")
+            sys.stdout.flush()
+            previous_ip_address = ip_address
+            dispatch(run_command, unit, charm_directory)
+
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ip_address_observer.py
+++ b/src/ip_address_observer.py
@@ -1,15 +1,12 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""IP address changes observer."""
+"""Set up IP address changes observer."""
 
 import logging
 import os
 import signal
-import socket
 import subprocess
-import sys
-import time
 import typing
 
 from ops.charm import CharmEvents
@@ -74,7 +71,7 @@ class IPAddressObserver(Object):
         process = subprocess.Popen(
             [
                 "/usr/bin/python3",
-                "src/ip_address_observer.py",
+                "scripts/ip_address_dispatcher.py",
                 juju_command,
                 self.charm.unit.name,
                 self.charm.charm_dir,
@@ -110,51 +107,3 @@ def check_pid(pid: int) -> bool:
         return False
     else:
         return True
-
-
-def dispatch(run_command, unit, charm_directory):
-    """Use the juju-run command to dispatch :class:`IPAddressChangeEvent`."""
-    dispatch_sub_command = "JUJU_DISPATCH_PATH=hooks/ip_address_change {}/dispatch"
-    subprocess.run([run_command, "-u", unit, dispatch_sub_command.format(charm_directory)])
-
-
-def main():
-    """Main watch and dispatch loop.
-
-    Determine the host IP address every 30 seconds, and dispatch and event if it
-    changes.
-    """
-    run_command, unit, charm_directory = sys.argv[1:]
-
-    def _get_local_ip():
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.settimeout(0)
-
-        try:
-            s.connect(("10.10.10.10", 1))
-            ip = s.getsockname()[0]
-        except Exception:
-            logger.exception("Unable to get local IP address")
-            ip = "127.0.0.1"
-
-        return ip
-
-    previous_ip_address = None
-    while True:
-        ip_address = _get_local_ip()
-
-        if not previous_ip_address:
-            print(f"Setting initial ip address to {ip_address}")
-            sys.stdout.flush()
-            previous_ip_address = ip_address
-        elif ip_address != previous_ip_address:
-            print(f"Detected ip address change from {previous_ip_address} to {ip_address}")
-            sys.stdout.flush()
-            previous_ip_address = ip_address
-            dispatch(run_command, unit, charm_directory)
-
-        time.sleep(30)
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Before, ip_addresss_observer.py simultaneously solved two different concerns, one to provide imports used in charm.py and one to call charm.py itself (via juju-run).

Now, those two concerns are separated.

Fixes issue where ops import caused `juju-run` script to fail because ops is not available from /usr/bin/python3 when using a full virtual environment (needed for charmcraft 3 poetry plugin migration)—now `juju-run` script does not import ops since it never needed it

Context: https://chat.canonical.com/canonical/pl/drhbrt84y3yc7xwc5431a1o5de
