### PR TITLE
[DPE-4375] Add cluster manual re-join handler

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -133,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 80
+LIBPATCH = 81
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -2605,6 +2605,31 @@ class MySQLBase(ABC):
 
         raise MySQLNoMemberStateError("No member state retrieved")
 
+    def is_cluster_auto_rejoin_ongoing(self):
+        """Check if the instance is performing a cluster auto rejoin operation."""
+        cluster_auto_rejoin_command = (
+            "cursor = session.run_sql(\"SELECT work_completed, work_estimated FROM performance_schema.events_stages_current WHERE event_name LIKE '%auto-rejoin%'\")",
+            "result = cursor.fetch_one() or [0,0]",
+            "print(f'<COMPLETED_ATTEMPTS>{result[0]}</COMPLETED_ATTEMPTS>')",
+            "print(f'<ESTIMATED_ATTEMPTS>{result[1]}</ESTIMATED_ATTEMPTS>')",
+        )
+
+        try:
+            output = self._run_mysqlsh_script(
+                "\n".join(cluster_auto_rejoin_command),
+                user=self.server_config_user,
+                password=self.server_config_password,
+                host=self.instance_def(self.server_config_user),
+            )
+        except MySQLClientError as e:
+            logger.error("Failed to get cluster auto-rejoin information", exc_info=e)
+            raise
+
+        completed_matches = re.search(r"<COMPLETED_ATTEMPTS>(\d)</COMPLETED_ATTEMPTS>", output)
+        estimated_matches = re.search(r"<ESTIMATED_ATTEMPTS>(\d)</ESTIMATED_ATTEMPTS>", output)
+
+        return int(completed_matches.group(1)) < int(estimated_matches.group(1))
+
     def is_cluster_replica(self, from_instance: Optional[str] = None) -> Optional[bool]:
         """Check if this cluster is a replica in a cluster set."""
         cs_status = self.get_cluster_set_status(extended=0, from_instance=from_instance)

--- a/src/charm.py
+++ b/src/charm.py
@@ -459,6 +459,14 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                 except MySQLRebootFromCompleteOutageError:
                     logger.error("Failed to reboot cluster from complete outage.")
                     self.unit.status = BlockedStatus("failed to recover cluster.")
+                finally:
+                    return
+
+            if self._mysql.is_cluster_auto_rejoin_ongoing():
+                logger.info("Cluster auto-rejoin attempts are still ongoing.")
+            else:
+                logger.info("Cluster auto-rejoin attempts are exhausted. Attempting manual rejoin")
+                self._execute_manual_rejoin()
 
         if state == "unreachable":
             try:
@@ -470,6 +478,30 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
                     self.unit.status = BlockedStatus("Unable to recover from an unreachable state")
             except SnapServiceOperationError as e:
                 self.unit.status = BlockedStatus(e.message)
+
+    def _execute_manual_rejoin(self) -> None:
+        """Executes an instance manual rejoin.
+
+        It is supposed to be called when the MySQL 8.0.21+ auto-rejoin attempts have been exhausted,
+        on an OFFLINE replica that still belongs to the cluster
+        """
+        if not self._mysql.is_instance_in_cluster(self.unit_label):
+            logger.warning("Instance does not belong to the cluster. Cannot perform manual rejoin")
+            return
+
+        cluster_primary = self._get_primary_from_online_peer()
+        if not cluster_primary:
+            logger.warning("Instance does not have ONLINE peers. Cannot perform manual rejoin")
+            return
+
+        self._mysql.remove_instance(
+            unit_label=self.unit_label,
+        )
+        self._mysql.add_instance_to_cluster(
+            instance_address=self.unit_address,
+            instance_unit_label=self.unit_label,
+            from_instance=cluster_primary,
+        )
 
     def _on_update_status(self, _) -> None:  # noqa: C901
         """Handle update status.

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -450,3 +450,65 @@ async def test_sst_test(ops_test: OpsTest, highly_available_cluster, continuous_
     database_name, table_name = "test-forceful-restart", "data"
     await insert_data_into_mysql_and_validate_replication(ops_test, database_name, table_name)
     await clean_up_database_and_table(ops_test, database_name, table_name)
+
+
+@pytest.mark.group(7)
+@pytest.mark.abort_on_fail
+async def test_cluster_manual_rejoin(
+    ops_test: OpsTest, highly_available_cluster, continuous_writes
+):
+    """The cluster manual re-join test.
+
+    A graceful restart is performed in one of the instances (choosing Primary to make it painful).
+    In order to verify that the instance can come back ONLINE, after disabling automatic re-join
+    """
+    # Ensure continuous writes still incrementing for all units
+    await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+    mysql_app_name = get_application_name(ops_test, "mysql")
+    primary_unit = await get_primary_unit_wrapper(ops_test, mysql_app_name)
+
+    config = {
+        "username": CLUSTER_ADMIN_USERNAME,
+        "password": await get_system_user_password(primary_unit, CLUSTER_ADMIN_USERNAME),
+        "host": await get_unit_ip(ops_test, primary_unit.name),
+    }
+
+    queries = [
+        "SET PERSIST group_replication_autorejoin_tries=0",
+    ]
+
+    # Disable automatic re-join procedure
+    await execute_queries_on_unit(
+        unit_address=config["host"],
+        username=config["username"],
+        password=config["password"],
+        queries=queries,
+        commit=True,
+    )
+
+    logger.info(f"Stopping server on unit {primary_unit.name}")
+    await graceful_stop_server(ops_test, primary_unit.name)
+
+    # Verify connection is not possible
+    assert not is_connection_possible(config), "❌ Connection is possible after instance stop"
+
+    logger.info(f"Re starting server on unit {primary_unit.name}")
+    await start_server(ops_test, primary_unit.name)
+
+    # Verify unit comes back active
+    async with ops_test.fast_forward():
+        logger.info("Waiting unit to enter in maintenance.")
+        await ops_test.model.block_until(
+            lambda: primary_unit.workload_status == "maintenance",
+            timeout=WAIT_TIMEOUT,
+        )
+
+        logger.info("Waiting unit to be back online.")
+        await ops_test.model.block_until(
+            lambda: primary_unit.workload_status == "active",
+            timeout=WAIT_TIMEOUT,
+        )
+
+    # Ensure continuous writes still incrementing for all units
+    await ensure_all_units_continuous_writes_incrementing(ops_test)

--- a/tests/integration/high_availability/test_self_healing.py
+++ b/tests/integration/high_availability/test_self_healing.py
@@ -498,12 +498,6 @@ async def test_cluster_manual_rejoin(
 
     # Verify unit comes back active
     async with ops_test.fast_forward():
-        logger.info("Waiting unit to enter in maintenance.")
-        await ops_test.model.block_until(
-            lambda: primary_unit.workload_status == "maintenance",
-            timeout=WAIT_TIMEOUT,
-        )
-
         logger.info("Waiting unit to be back online.")
         await ops_test.model.block_until(
             lambda: primary_unit.workload_status == "active",

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -2283,6 +2283,26 @@ xtrabackup/location --defaults-file=defaults/config/file
         with self.assertRaises(MySQLGetClusterPrimaryAddressError):
             self.mysql.get_cluster_set_global_primary_address()
 
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_is_cluster_auto_rejoin_ongoing(self, _run_mysqlsh_script):
+        """Test is_cluster_auto_rejoin_ongoing."""
+        _run_mysqlsh_script.return_value = (
+            "<COMPLETED_ATTEMPTS>1</COMPLETED_ATTEMPTS>\n"
+            "<ESTIMATED_ATTEMPTS>3</ESTIMATED_ATTEMPTS>\n"
+        )
+        assert self.mysql.is_cluster_auto_rejoin_ongoing() is True
+
+        _run_mysqlsh_script.return_value = (
+            "<COMPLETED_ATTEMPTS>3</COMPLETED_ATTEMPTS>\n"
+            "<ESTIMATED_ATTEMPTS>3</ESTIMATED_ATTEMPTS>\n"
+        )
+        assert self.mysql.is_cluster_auto_rejoin_ongoing() is False
+
+        _run_mysqlsh_script.return_value = ""
+        _run_mysqlsh_script.side_effect = MySQLClientError
+        with self.assertRaises(MySQLClientError):
+            self.mysql.is_cluster_auto_rejoin_ongoing()
+
     @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_set_status")
     def test_is_cluster_replica(self, _get_cluster_set_status):
         """Test is_cluster_replica."""


### PR DESCRIPTION
This PR adds logic to manually re-join a MySQL replica that has gone `OFFLINE`, to the cluster, whenever MySQL 8.0.21+ [auto re-join](https://dev.mysql.com/doc/refman/8.0/en/group-replication-responses-failure-rejoin.html) attempts have been exhausted.

### Description

There are edge cases where a MySQL instance that has lost connection to the cluster it originally belong to (i.e. `OFFLINE`), exhaust its automatic retries (by default 3 retries, with 5 mins between each, starting with MySQL 8.0.21). For those cases, a manual re-join should be performed.

