### PR TITLE
[DPE-5908] Support old bucket endpoints format

### DIFF
--- a/tests/unit/test_s3_helpers.py
+++ b/tests/unit/test_s3_helpers.py
@@ -12,7 +12,7 @@ class TestS3Helpers(unittest.TestCase):
         self.s3_parameters = {
             "access-key": "AK",
             "secret-key": "SK",
-            "region": "AS-1",
+            "region": "us-east-1",
             "bucket": "balde",
             "endpoint": "http://localhost:9000",
         }
@@ -44,16 +44,50 @@ class TestS3Helpers(unittest.TestCase):
         mock_session.resource.return_value = mock_resource
         mock_resource.Bucket.return_value = mock_bucket
 
-        s3_parameters = {
-            "access-key": "AK",
-            "secret-key": "SK",
-            "region": "AS-1",
-            "bucket": "balde",
-            "endpoint": "http://localhost:9000",
-            "tls-ca-chain": ["Zm9vYmFy"],
-        }
+        s3_parameters = self.s3_parameters
+        s3_parameters["tls-ca-chain"] = ["Zm9vYmFy"]
 
         upload_content_to_s3("content", "key", s3_parameters)
 
         mock_bucket.upload_file.assert_called_once()
         mock_session.resource.assert_called_once()
+
+    @patch("lib.charms.mysql.v0.s3_helpers.boto3")
+    def test_upload_content_with_new_bucket_endpoint(self, mock_boto):
+        mock_session = MagicMock()
+        mock_resource = MagicMock()
+        mock_bucket = MagicMock()
+
+        mock_boto.session.Session.return_value = mock_session
+        mock_session.resource.return_value = mock_resource
+        mock_resource.Bucket.return_value = mock_bucket
+
+        s3_parameters = self.s3_parameters
+        s3_parameters["endpoint"] = "https://s3.us-east-1.amazonaws.com"
+
+        upload_content_to_s3("content", "key", s3_parameters)
+
+        mock_bucket.upload_file.assert_called_once()
+        mock_session.resource.assert_called_with(
+            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=True
+        )
+
+    @patch("lib.charms.mysql.v0.s3_helpers.boto3")
+    def test_upload_content_with_old_bucket_endpoint(self, mock_boto):
+        mock_session = MagicMock()
+        mock_resource = MagicMock()
+        mock_bucket = MagicMock()
+
+        mock_boto.session.Session.return_value = mock_session
+        mock_session.resource.return_value = mock_resource
+        mock_resource.Bucket.return_value = mock_bucket
+
+        s3_parameters = self.s3_parameters
+        s3_parameters["endpoint"] = "https://s3.amazonaws.com"
+
+        upload_content_to_s3("content", "key", s3_parameters)
+
+        mock_bucket.upload_file.assert_called_once()
+        mock_session.resource.assert_called_with(
+            "s3", endpoint_url="https://s3.us-east-1.amazonaws.com", verify=True
+        )


### PR DESCRIPTION
This PR ports PostgreSQL operator `_construct_endpoint` helper function ([see code](https://github.com/canonical/postgresql-operator/blob/c5c916d41d00849da5ae657cba4c97c46cb3caad/src/backups.py#L229-L249)) , in order to support the specification of the old S3 endpoints format (i.e. `https://s3.amazonaws.com`), stated in the [charm docs](https://charmhub.io/mysql/docs/h-configure-s3-aws).

I decided to port the helper, instead of updating the docs, in order to make MySQL operator support as similar to PostgreSQL operator as possible. If we eventually decide to stop supporting the old S3 endpoints format, we will do so across our repositories, and not across a sub-set of them.

---

Closes issue https://github.com/canonical/mysql-operator/issues/545