### PR TITLE
[DPE-6523] Remove AMD64-only test markers

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -317,31 +317,6 @@ async def app_name(ops_test: OpsTest) -> str:
     return None
 
 
-def cluster_name(unit: Unit, model_name: str) -> str:
-    """Returns the MySQL cluster name.
-
-    Args:
-        unit: A unit to get data from
-        model_name: The current model name
-    Returns:
-        The (str) mysql cluster name
-    """
-    output = subprocess.check_output([
-        "juju",
-        "show-unit",
-        unit.name,
-        "--format=json",
-        f"--model={model_name}",
-    ])
-    output = json.loads(output.decode("utf-8"))
-
-    for relation in output[unit.name]["relation-info"]:
-        if relation["endpoint"] == "database-peers":
-            return relation["application-data"]["cluster-name"]
-    logger.error(f"Failed to retrieve cluster name from unit {unit.name}")
-    raise ValueError("Failed to retrieve cluster name")
-
-
 async def get_model_logs(ops_test: OpsTest, log_level: str, log_lines: int = 100) -> str:
     """Return the juju logs from a specific model.
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -342,6 +342,25 @@ def cluster_name(unit: Unit, model_name: str) -> str:
     raise ValueError("Failed to retrieve cluster name")
 
 
+async def get_model_logs(ops_test: OpsTest, log_level: str, log_lines: int = 100) -> str:
+    """Return the juju logs from a specific model.
+
+    Args:
+        ops_test: The ops test object passed into every test case
+        log_level: The logging level to return messages from
+        log_lines: The maximum lines to return at once
+    """
+    _, output, _ = await ops_test.juju(
+        "debug-log",
+        f"--model={ops_test.model.info.name}",
+        f"--level={log_level}",
+        f"--lines={log_lines}",
+        "--no-tail",
+    )
+
+    return output
+
+
 async def get_process_pid(ops_test: OpsTest, unit_name: str, process: str) -> int:
     """Return the pid of a process running in a given unit.
 

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from .. import juju_, markers
+from .. import juju_
 from ..helpers import get_leader_unit, get_primary_unit_wrapper, retrieve_database_variable_value
 from .high_availability_helpers import (
     ensure_all_units_continuous_writes_incrementing,
@@ -23,7 +23,6 @@ TEST_APP_NAME = "mysql-test-app"
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_deploy_stable(ops_test: OpsTest) -> None:
     """Simple test to ensure that the mysql and application charms get deployed."""
@@ -55,7 +54,6 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
     """Test that the pre-upgrade-check action runs successfully."""
@@ -80,7 +78,6 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 async def test_upgrade_from_stable(ops_test: OpsTest):
     """Test updating from stable channel."""
     application = ops_test.model.applications[MYSQL_APP_NAME]

--- a/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -9,7 +9,6 @@ from time import sleep
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from .. import markers
 from .high_availability_helpers import (
     ensure_all_units_continuous_writes_incrementing,
     relate_mysql_and_application,
@@ -24,7 +23,6 @@ TEST_APP_NAME = "mysql-test-app"
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 @pytest.mark.abort_on_fail
 async def test_deploy_stable(ops_test: OpsTest) -> None:
     """Simple test to ensure that the mysql and application charms get deployed."""
@@ -57,7 +55,6 @@ async def test_deploy_stable(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 async def test_refresh_without_pre_upgrade_check(ops_test: OpsTest):
     """Test updating from stable channel."""
     application = ops_test.model.applications[MYSQL_APP_NAME]
@@ -90,7 +87,6 @@ async def test_refresh_without_pre_upgrade_check(ops_test: OpsTest):
 
 
 @pytest.mark.group(1)
-@markers.amd64_only  # TODO: remove after arm64 stable release
 async def test_rollback_without_pre_upgrade_check(ops_test: OpsTest):
     """Test refresh back to stable channel."""
     application = ops_test.model.applications[MYSQL_APP_NAME]


### PR DESCRIPTION
This PR cleans up multiple `@amd64_only` markers from the integration tests. There is an ARM64 stable release already.

### Additional notes:
- Not all `@amd64_only` markers could be removed, as there is no ARM64 MySQL snap breaking compatibility.
- Tests related to _rolling back when incompatibility_ have been improved to actually fail when they do not rollback.
- Tests helper [cluster_name](https://github.com/canonical/mysql-operator/blob/9530600dacc7a4c9c326c9bbf09f6670c245081b/tests/integration/helpers.py#L320-L342) has been removed (unused).