### PR TITLE
[DPE-6666] Remove async-replication test workaround

### DIFF
--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -300,14 +300,6 @@ async def test_remove_relation_and_relate(
     first_model: Model, second_model: Model, continuous_writes
 ) -> None:
     """Test removing and re-relating the two mysql clusters."""
-    logger.info("Stopping continuous writes after 5s")
-    # part 1/2 of workaround for https://github.com/canonical/mysql-k8s-operator/issues/399
-    # sleep is need to ensure there is enough time for the `continuous_writes` database be
-    # created/populated (by the fixture) before stopping the continuous writes
-    sleep(5)
-    application_unit = first_model.applications[APPLICATION_APP_NAME].units[0]
-    await juju_.run_action(application_unit, "stop-continuous-writes")
-
     logger.info("Remove async relation")
     await second_model.applications[MYSQL_APP2].remove_relation(
         f"{MYSQL_APP2}:replication", MYSQL_APP1
@@ -369,9 +361,6 @@ async def test_remove_relation_and_relate(
             timeout=10 * MINUTE,
         ),
     )
-
-    # part 2/2 of workaround for https://github.com/canonical/mysql-k8s-operator/issues/399
-    await juju_.run_action(application_unit, "start-continuous-writes")
 
     results = await get_max_written_value(first_model, second_model)
     assert len(results) == 6, f"Expected 6 results, got {len(results)}"

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -135,35 +135,6 @@ async def test_async_relate(first_model: Model, second_model: Model) -> None:
 
 @juju3
 @pytest.mark.abort_on_fail
-async def test_create_replication(first_model: Model, second_model: Model) -> None:
-    """Run the create replication and wait for the applications to settle."""
-    logger.info("Running create replication action")
-    leader_unit = await get_leader_unit(None, MYSQL_APP1, first_model)
-    assert leader_unit is not None, "No leader unit found"
-
-    await juju_.run_action(
-        leader_unit,
-        "create-replication",
-        **{"--wait": "5m"},
-    )
-
-    logger.info("Waiting for the applications to settle")
-    await gather(
-        first_model.wait_for_idle(
-            apps=[MYSQL_APP1],
-            status="active",
-            timeout=5 * MINUTE,
-        ),
-        second_model.wait_for_idle(
-            apps=[MYSQL_APP2],
-            status="active",
-            timeout=5 * MINUTE,
-        ),
-    )
-
-
-@juju3
-@pytest.mark.abort_on_fail
 async def test_deploy_router_and_app(first_model: Model) -> None:
     """Deploy the router and the test application."""
     logger.info("Deploying router and application")
@@ -193,6 +164,35 @@ async def test_deploy_router_and_app(first_model: Model) -> None:
 
     await first_model.block_until(
         lambda: first_model.applications[APPLICATION_APP_NAME].units[0].workload_status == "active"
+    )
+
+
+@juju3
+@pytest.mark.abort_on_fail
+async def test_create_replication(first_model: Model, second_model: Model) -> None:
+    """Run the create replication and wait for the applications to settle."""
+    logger.info("Running create replication action")
+    leader_unit = await get_leader_unit(None, MYSQL_APP1, first_model)
+    assert leader_unit is not None, "No leader unit found"
+
+    await juju_.run_action(
+        leader_unit,
+        "create-replication",
+        **{"--wait": "5m"},
+    )
+
+    logger.info("Waiting for the applications to settle")
+    await gather(
+        first_model.wait_for_idle(
+            apps=[MYSQL_APP1],
+            status="active",
+            timeout=5 * MINUTE,
+        ),
+        second_model.wait_for_idle(
+            apps=[MYSQL_APP2],
+            status="active",
+            timeout=5 * MINUTE,
+        ),
     )
 
 


### PR DESCRIPTION
This PR removes a work-around present in the async-replication tests, to circumvent a bug that old versions of MySQL had, where under continuous write conditions, a _follower_ cluster could not scale up its replicas.

Even if the official [MySQL bug](http://bugs.mysql.com/114624) is not marked as solved, the issue is no longer reproducible on MySQL 8.0.41.