### PR TITLE
[DPE-1531] Port changes from K8s PR to avoid --initialize-insecure

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -133,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 83
+LIBPATCH = 84
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -1027,7 +1027,7 @@ class MySQLBase(ABC):
             config.write(string_io)
             return string_io.getvalue(), dict(config["mysqld"])
 
-    def configure_mysql_users(self, password_needed: bool = True) -> None:
+    def configure_mysql_users(self) -> None:
         """Configure the MySQL users for the instance."""
         # SYSTEM_USER and SUPER privileges to revoke from the root users
         # Reference: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super
@@ -1065,13 +1065,10 @@ class MySQLBase(ABC):
 
         try:
             logger.debug(f"Configuring MySQL users for {self.instance_address}")
-            if password_needed:
-                self._run_mysqlcli_script(
-                    configure_users_commands,
-                    password=self.root_password,
-                )
-            else:
-                self._run_mysqlcli_script(configure_users_commands)
+            self._run_mysqlcli_script(
+                configure_users_commands,
+                password=self.root_password,
+            )
         except MySQLClientError:
             logger.error(f"Failed to configure users for: {self.instance_address}")
             raise MySQLConfigureMySQLUsersError

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -353,12 +353,6 @@ class MySQL(MySQLBase):
                 mode="w",
                 encoding="utf-8",
             ) as _sql_file:
-                _sql_file.write(
-                    f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}';\n"
-                    "FLUSH PRIVILEGES;"
-                )
-                _sql_file.flush()
-
                 try:
                     subprocess.check_output([
                         "sudo",
@@ -370,6 +364,12 @@ class MySQL(MySQLBase):
                     raise MySQLResetRootPasswordAndStartMySQLDError(
                         "Failed to change permissions for temp SQL file"
                     )
+
+                _sql_file.write(
+                    f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}';\n"
+                    "FLUSH PRIVILEGES;"
+                )
+                _sql_file.flush()
 
                 _custom_config_file.write(f"[mysqld]\ninit_file = {_sql_file.name}")
                 _custom_config_file.flush()


### PR DESCRIPTION
## Issue
There are changes in https://github.com/canonical/mysql-k8s-operator/pull/596/files which need to be ported over
Noticed that we are writing `ALTER USER` SQL queries before we change its permissions (leading to the password to be exposed if the chown command fails)

## Solution
Port changes
Chown the file first before writing queries to it
