### PR TITLE
[MISC] Ignore paths on GHA workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,6 @@ concurrency:
 on:
   pull_request:
     paths-ignore:
-      - '.gitignore'
-      - '.jujuignore'
-      - 'LICENSE'
       - '**.md'
       - '.github/renovate.json5'
       - '.github/workflows/sync_docs.yaml'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,13 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - '.jujuignore'
+      - 'LICENSE'
+      - '**.md'
+      - '.github/renovate.json5'
+      - '.github/workflows/sync_docs.yaml'
   schedule:
     - cron: '53 0 * * *'  # Daily at 00:53 UTC
   # Triggered on push to branch "main" by .github/workflows/release.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '.github/renovate.json5'
-      - '.github/workflows/ci.yaml'
       - '.github/workflows/check_libs.yaml'
       - '.github/workflows/sync_docs.yaml'
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '.github/renovate.json5'
+      - '.github/workflows/ci.yaml'
+      - '.github/workflows/check_libs.yaml'
+      - '.github/workflows/sync_docs.yaml'
 
 jobs:
   ci-tests:


### PR DESCRIPTION
This PR follows the example of PostgreSQL operator workflows (see [VM CI](https://github.com/canonical/postgresql-operator/blob/main/.github/workflows/ci.yaml), [K8s CI](https://github.com/canonical/postgresql-k8s-operator/blob/main/.github/workflows/ci.yaml), [VM release](https://github.com/canonical/postgresql-operator/blob/main/.github/workflows/release.yaml) and [K8s release](https://github.com/canonical/postgresql-k8s-operator/blob/main/.github/workflows/release.yaml)), in order to make our GHA workflows smarter. The only different with respect to those, are:

- I have removed the `tests/**` rule, as discussed with Carl in the _SQL Technical Sync_ meeting.
- I have removed the `pyproject.toml` rule, as discussed with Paulo privately over Mattermost.

---

Addresses [this comment](https://github.com/canonical/mysql-k8s-operator/pull/605#issuecomment-2761094914).