### PR TITLE
[DPE-7412] Spaces support

### DIFF
--- a/lib/charms/mysql/v0/async_replication.py
+++ b/lib/charms/mysql/v0/async_replication.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 # The unique Charmhub library identifier, never change it
 LIBID = "4de21f1a022c4e2c87ac8e672ec16f6a"
 LIBAPI = 0
-LIBPATCH = 6
+LIBPATCH = 7
 
 RELATION_OFFER = "replication-offer"
 RELATION_CONSUMER = "replication"
@@ -553,7 +553,7 @@ class MySQLAsyncReplicationOffer(MySQLAsyncReplication):
             unit_label = remote_data["node-label"]
 
             logger.debug("Looking for a donor node")
-            _, ro, _ = self._charm._mysql.get_cluster_endpoints(get_ips=False)
+            _, ro, _ = self._charm.get_cluster_endpoints(self.relation.name)
 
             if not ro:
                 logger.debug(f"Adding replica {cluster=} with {endpoint=}. Primary is the donor")
@@ -716,15 +716,16 @@ class MySQLAsyncReplicationConsumer(MySQLAsyncReplication):
         secret = self._obtain_secret()
         return secret.peek_content()
 
-    def _get_endpoint(self) -> str:
+    def _get_endpoint(self) -> Optional[str]:
         """Get endpoint to be used by the primary cluster.
 
         This is the address in which the unit must be reachable from the primary cluster.
         Not necessarily the locally resolved address, but an ingress address.
         """
-        # TODO: devise method to inform the real address
-        # using unit informed address (fqdn or ip)
-        return self._charm.unit_address
+        if self.relation.name == RELATION_CONSUMER:
+            return self._charm.get_unit_address(self._charm.unit, RELATION_CONSUMER)
+        if self.relation.name == RELATION_OFFER:
+            return self._charm.get_unit_address(self._charm.unit, RELATION_OFFER)
 
     def _on_consumer_relation_created(self, event):
         """Handle the async_replica relation being created on the leader unit."""

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -663,7 +663,7 @@ class MySQLCharmBase(CharmBase, ABC):
         for unit in self.app_units:
             total_online_cluster_nodes += self._mysql.get_cluster_node_count(
                 from_instance=self.get_unit_address(unit, PEER),
-                node_status=MySQLMemberState["ONLINE"],
+                node_status=MySQLMemberState.ONLINE,
             )
 
         return total_cluster_nodes == 1 and total_online_cluster_nodes == 0
@@ -674,7 +674,7 @@ class MySQLCharmBase(CharmBase, ABC):
 
         Fully initialized means that all unit that can be joined are joined.
         """
-        return self._mysql.get_cluster_node_count(node_status=MySQLMemberState["ONLINE"]) == min(
+        return self._mysql.get_cluster_node_count(node_status=MySQLMemberState.ONLINE) == min(
             GR_MAX_MEMBERS, self.app.planned_units()
         )
 

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -74,7 +74,6 @@ import json
 import logging
 import os
 import re
-import socket
 import sys
 import time
 from abc import ABC, abstractmethod
@@ -134,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 87
+LIBPATCH = 88
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -495,10 +494,15 @@ class MySQLCharmBase(CharmBase, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_unit_address(self, unit: Unit) -> str:
+    def get_unit_address(self, unit: Unit, relation_name: str) -> str:
         """Return unit address."""
         # each platform has its own way to get an arbitrary unit address
         raise NotImplementedError
+
+    @staticmethod
+    def get_unit_label(unit: Unit) -> str:
+        """Return unit label."""
+        return unit.name.replace("/", "-")
 
     def _on_get_password(self, event: ActionEvent) -> None:
         """Action used to retrieve the system user's password."""
@@ -633,7 +637,7 @@ class MySQLCharmBase(CharmBase, ABC):
         for unit in self.app_units:
             try:
                 if unit != self.unit and self._mysql.cluster_metadata_exists(
-                    self.get_unit_address(unit)
+                    self.get_unit_address(unit, PEER)
                 ):
                     return True
                 elif self._mysql.cluster_metadata_exists():
@@ -652,13 +656,14 @@ class MySQLCharmBase(CharmBase, ABC):
         total_cluster_nodes = 0
         for unit in self.app_units:
             total_cluster_nodes += self._mysql.get_cluster_node_count(
-                from_instance=self.get_unit_address(unit)
+                from_instance=self.get_unit_address(unit, PEER)
             )
 
         total_online_cluster_nodes = 0
         for unit in self.app_units:
             total_online_cluster_nodes += self._mysql.get_cluster_node_count(
-                from_instance=self.get_unit_address(unit), node_status=MySQLMemberState["ONLINE"]
+                from_instance=self.get_unit_address(unit, PEER),
+                node_status=MySQLMemberState["ONLINE"],
             )
 
         return total_cluster_nodes == 1 and total_online_cluster_nodes == 0
@@ -677,7 +682,8 @@ class MySQLCharmBase(CharmBase, ABC):
     def unit_configured(self) -> bool:
         """Check if the unit is configured to be part of the cluster."""
         return self._mysql.is_instance_configured_for_innodb(
-            self.get_unit_address(self.unit), self.unit_label
+            self.get_unit_address(self.unit, PEER),
+            self.unit_label,
         )
 
     @property
@@ -707,7 +713,7 @@ class MySQLCharmBase(CharmBase, ABC):
     @property
     def unit_label(self):
         """Return unit label."""
-        return self.unit.name.replace("/", "-")
+        return self.get_unit_label(self.unit)
 
     @property
     def _is_peer_data_set(self) -> bool:
@@ -773,6 +779,37 @@ class MySQLCharmBase(CharmBase, ABC):
             return self.peer_relation_app
         elif scope == UNIT_SCOPE:
             return self.peer_relation_unit
+
+    def get_cluster_endpoints(self, relation_name: str) -> Tuple[str, str, str]:
+        """Return (rw, ro, offline) endpoints tuple names or IPs."""
+        repl_topology = self._mysql.get_cluster_topology()
+        repl_cluster = self._mysql.is_cluster_replica()
+
+        if not repl_topology:
+            raise MySQLGetClusterEndpointsError("Failed to get endpoints from cluster topology")
+
+        unit_labels = {self.get_unit_label(unit): unit for unit in self.app_units}
+
+        no_endpoints = set()
+        ro_endpoints = set()
+        rw_endpoints = set()
+
+        for k, v in repl_topology.items():
+            address = f"{self.get_unit_address(unit_labels[k], relation_name)}:3306"
+
+            if v["status"] != MySQLMemberState.ONLINE:
+                no_endpoints.add(address)
+            if v["status"] == MySQLMemberState.ONLINE and v["mode"] == "r/o":
+                ro_endpoints.add(address)
+            if v["status"] == MySQLMemberState.ONLINE and v["mode"] == "r/w" and not repl_cluster:
+                rw_endpoints.add(address)
+
+        # Replica return global primary address
+        if repl_cluster:
+            primary_address = f"{self._mysql.get_cluster_set_global_primary_address()}:3306"
+            rw_endpoints.add(primary_address)
+
+        return ",".join(rw_endpoints), ",".join(ro_endpoints), ",".join(no_endpoints)
 
     def get_secret(
         self,
@@ -2144,51 +2181,6 @@ class MySQLBase(ABC):
 
         return int(matches.group(1)) if matches else 0
 
-    def get_cluster_endpoints(self, get_ips: bool = True) -> Tuple[str, str, str]:
-        """Return (rw, ro, ofline) endpoints tuple names or IPs."""
-        status = self.get_cluster_status()
-
-        if not status:
-            raise MySQLGetClusterEndpointsError("Failed to get endpoints from cluster status")
-
-        topology = status["defaultreplicaset"]["topology"]
-
-        def _get_host_ip(host: str) -> str:
-            try:
-                port = None
-                if ":" in host:
-                    host, port = host.split(":")
-
-                host_ip = socket.gethostbyname(host)
-                return f"{host_ip}:{port}" if port else host_ip
-            except socket.gaierror:
-                raise MySQLGetClusterEndpointsError(f"Failed to query IP for host {host}")
-
-        ro_endpoints = {
-            _get_host_ip(v["address"]) if get_ips else v["address"]
-            for v in topology.values()
-            if v["mode"] == "r/o" and v["status"] == MySQLMemberState.ONLINE
-        }
-
-        if self.is_cluster_replica():
-            # replica return global primary address
-            global_primary = self.get_cluster_set_global_primary_address()
-            if not global_primary:
-                raise MySQLGetClusterEndpointsError("Failed to get global primary address")
-            rw_endpoints = {_get_host_ip(global_primary) if get_ips else global_primary}
-        else:
-            rw_endpoints = {
-                _get_host_ip(v["address"]) if get_ips else v["address"]
-                for v in topology.values()
-                if v["mode"] == "r/w" and v["status"] == MySQLMemberState.ONLINE
-            }
-        # won't get offline endpoints to IP as they maybe unreachable
-        no_endpoints = {
-            v["address"] for v in topology.values() if v["status"] != MySQLMemberState.ONLINE
-        }
-
-        return ",".join(rw_endpoints), ",".join(ro_endpoints), ",".join(no_endpoints)
-
     def execute_remove_instance(
         self, connect_instance: Optional[str] = None, force: bool = False
     ) -> None:
@@ -2478,12 +2470,21 @@ class MySQLBase(ABC):
 
         return address
 
-    def get_primary_label(self) -> Optional[str]:
-        """Get the label of the cluster's primary."""
+    def get_cluster_topology(self) -> Optional[dict]:
+        """Get the cluster topology."""
         status = self.get_cluster_status()
         if not status:
             return None
-        for label, value in status["defaultreplicaset"]["topology"].items():
+
+        return status["defaultreplicaset"]["topology"]
+
+    def get_primary_label(self) -> Optional[str]:
+        """Get the label of the cluster's primary."""
+        topology = self.get_cluster_topology()
+        if not topology:
+            return None
+
+        for label, value in topology.items():
             if value["memberrole"] == "primary":
                 return label
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -772,12 +772,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if workload_version := self._mysql.get_mysql_version():
             self.unit.set_workload_version(workload_version)
 
-    def get_unit_address(self, unit: Unit, relation_name: str) -> Optional[str]:
+    def get_unit_address(self, unit: Unit, relation_name: str) -> str:
         """Get the IP address of a specific unit."""
         try:
             return str(self.peers.data[unit].get(f"{relation_name}-address", ""))
         except KeyError:
-            return None
+            return ""
 
     def _open_ports(self) -> None:
         """Open ports.

--- a/src/charm.py
+++ b/src/charm.py
@@ -22,6 +22,8 @@ from charms.data_platform_libs.v0.data_models import TypedCharmBase
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider, charm_tracing_config
 from charms.mysql.v0.async_replication import (
+    RELATION_CONSUMER,
+    RELATION_OFFER,
     MySQLAsyncReplicationConsumer,
     MySQLAsyncReplicationOffer,
 )
@@ -80,6 +82,7 @@ from constants import (
     CLUSTER_ADMIN_PASSWORD_KEY,
     CLUSTER_ADMIN_USERNAME,
     COS_AGENT_RELATION_NAME,
+    DB_RELATION_NAME,
     GR_MAX_MEMBERS,
     MONITORING_PASSWORD_KEY,
     MONITORING_USERNAME,
@@ -368,6 +371,9 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             event.defer()
             return
 
+        # Update endpoint addresses
+        self.update_endpoint_addresses()
+
         if self._is_unit_waiting_to_join_cluster():
             self.join_unit_to_cluster()
             for port in ["3306", "33060"]:
@@ -405,7 +411,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             if leader_unit := _get_leader_unit():
                 try:
                     self._mysql.set_cluster_primary(
-                        new_primary_address=self.get_unit_address(leader_unit)
+                        new_primary_address=self.get_unit_address(leader_unit, PEER)
                     )
                 except MySQLSetClusterPrimaryError:
                     logger.warning("Failed to switch primary to leader unit")
@@ -667,7 +673,22 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
     @property
     def unit_address(self) -> str:
         """Returns the unit's address."""
-        return self.get_unit_address(self.unit)
+        return str(self.model.get_binding(PEER).network.bind_address)
+
+    @property
+    def database_address(self) -> str:
+        """Database endpoint address."""
+        return str(self.model.get_binding(DB_RELATION_NAME).network.bind_address)
+
+    @property
+    def replication_offer_address(self) -> str:
+        """Async replication offer endpoint address."""
+        return str(self.model.get_binding(RELATION_OFFER).network.bind_address)
+
+    @property
+    def replication_consumer_address(self) -> str:
+        """Async replication consumer endpoint address."""
+        return str(self.model.get_binding(RELATION_CONSUMER).network.bind_address)
 
     @property
     def text_logs(self) -> list:
@@ -679,6 +700,17 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             text_logs.append("audit")
 
         return text_logs
+
+    def update_endpoint_addresses(self) -> None:
+        """Update ip addresses for relation endpoints on unit peer databag."""
+        logger.debug("Updating relation endpoints addresses")
+
+        self.unit_peer_data.update({
+            f"{PEER}-address": self.unit_address,
+            f"{DB_RELATION_NAME}-address": self.database_address,
+            f"{RELATION_OFFER}-address": self.replication_offer_address,
+            f"{RELATION_CONSUMER}-address": self.replication_consumer_address,
+        })
 
     def install_workload(self) -> bool:
         """Exponential backoff retry to install and configure MySQL.
@@ -740,12 +772,12 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
         if workload_version := self._mysql.get_mysql_version():
             self.unit.set_workload_version(workload_version)
 
-    def get_unit_address(self, unit: Unit) -> str:
+    def get_unit_address(self, unit: Unit, relation_name: str) -> Optional[str]:
         """Get the IP address of a specific unit."""
-        if unit == self.unit:
-            return str(self.model.get_binding(PEER).network.bind_address)
-
-        return str(self.peers.data[unit].get("private-address"))
+        try:
+            return str(self.peers.data[unit].get(f"{relation_name}-address", ""))
+        except KeyError:
+            return None
 
     def _open_ports(self) -> None:
         """Open ports.
@@ -823,7 +855,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
             if self.peers.data[unit].get("member-state") == "online":
                 try:
                     return self._mysql.get_cluster_primary_address(
-                        connect_instance_address=self.get_unit_address(unit)
+                        connect_instance_address=self.get_unit_address(unit, PEER)
                     )
                 except MySQLGetClusterPrimaryAddressError:
                     # try next unit
@@ -834,8 +866,8 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         Try to join the unit from the primary unit.
         """
-        instance_label = self.unit.name.replace("/", "-")
-        instance_address = self.get_unit_address(self.unit)
+        instance_label = self.unit_label
+        instance_address = self.unit_address
 
         if not self._mysql.is_instance_in_cluster(instance_label):
             # Add new instance to the cluster
@@ -931,7 +963,7 @@ class MySQLOperatorCharm(MySQLCharmBase, TypedCharmBase[CharmConfig]):
 
         if self.app.planned_units() > 1 and self._mysql.is_unit_primary(self.unit_label):
             try:
-                new_primary = self.get_unit_address(self.peers.units.pop())
+                new_primary = self.get_unit_address(self.peers.units.pop(), PEER)
                 logger.debug(f"Switching primary to {new_primary}")
                 self._mysql.set_cluster_primary(new_primary)
             except MySQLSetClusterPrimaryError:

--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -95,12 +95,12 @@ class MySQLProvider(Object):
         if self.charm.unit.name == event.departing_unit.name:
             return
 
-        # get unit name that departed
-        dep_unit_name = event.departing_unit.name.replace("/", "-")
+        # get unit label that departed
+        dep_unit_label = self.charm.get_unit_label(event.departing_unit)
 
         # defer if the added unit is still in the cluster
-        if self.charm._mysql.is_instance_in_cluster(dep_unit_name):
-            logger.debug(f"Departing unit {dep_unit_name} is still in the cluster!")
+        if self.charm._mysql.is_instance_in_cluster(dep_unit_label):
+            logger.debug(f"Departing unit {dep_unit_label} is still in the cluster!")
             event.defer()
             return
 
@@ -128,8 +128,8 @@ class MySQLProvider(Object):
             logger.debug("Waiting cluster to be initialized")
             return
 
-        # get unit name that joined
-        event_unit_label = event.unit.name.replace("/", "-")
+        # get unit label that joined
+        event_unit_label = self.charm.get_unit_label(event.unit)
 
         # defer if upgrading
         if not self.charm.upgrade.idle:
@@ -158,7 +158,7 @@ class MySQLProvider(Object):
             remote_app (str): The name of the remote application
         """
         try:
-            rw_endpoints, ro_endpoints, _ = self.charm._mysql.get_cluster_endpoints()
+            rw_endpoints, ro_endpoints, _ = self.charm.get_cluster_endpoints(DB_RELATION_NAME)
 
             # check if endpoints need update
             relation = self.model.get_relation(DB_RELATION_NAME, relation_id)
@@ -230,7 +230,7 @@ class MySQLProvider(Object):
 
         try:
             db_version = self.charm._mysql.get_mysql_version()
-            rw_endpoints, ro_endpoints, _ = self.charm._mysql.get_cluster_endpoints()
+            rw_endpoints, ro_endpoints, _ = self.charm.get_cluster_endpoints(DB_RELATION_NAME)
             self.database.set_database(relation_id, db_name)
             self.database.set_credentials(relation_id, db_user, db_pass)
             self.database.set_endpoints(relation_id, rw_endpoints)

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -31,7 +31,7 @@ from ops.model import BlockedStatus, MaintenanceStatus, Unit
 from pydantic import BaseModel
 from typing_extensions import override
 
-from constants import CHARMED_MYSQL_COMMON_DIRECTORY
+from constants import CHARMED_MYSQL_COMMON_DIRECTORY, PEER
 
 if TYPE_CHECKING:
     from charm import MySQLOperatorCharm
@@ -278,11 +278,11 @@ class MySQLVMUpgrade(DataUpgrade):
         """
         if self.charm._mysql.get_primary_label() != self.charm.unit_label:
             # set the primary to the leader unit for switchover mitigation
-            self.charm._mysql.set_cluster_primary(self.charm.get_unit_address(self.charm.unit))
+            self.charm._mysql.set_cluster_primary(self.charm.unit_address)
 
         # set slow shutdown on all instances
         for unit in self.app_units:
-            unit_address = self.charm.get_unit_address(unit)
+            unit_address = self.charm.get_unit_address(unit, PEER)
             self.charm._mysql.set_dynamic_variable(
                 variable="innodb_fast_shutdown", value="0", instance_address=unit_address
             )
@@ -309,7 +309,7 @@ class MySQLVMUpgrade(DataUpgrade):
             leader_unit_ordinal = self.upgrade_stack[0]
             for unit in self.peer_relation.units:
                 if unit.name == f"{self.charm.app.name}/{leader_unit_ordinal}":
-                    return self.charm.get_unit_address(unit)
+                    return self.charm.get_unit_address(unit, PEER)
             return ""
 
         try:

--- a/tests/integration/spaces/__init__.py
+++ b/tests/integration/spaces/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/spaces/conftest.py
+++ b/tests/integration/spaces/conftest.py
@@ -1,0 +1,100 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import os
+import subprocess
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+DEFAULT_LXD_NETWORK = "lxdbr0"
+RAW_DNSMASQ = """
+dhcp-option=3
+dhcp-option=6
+"""
+
+logger = logging.getLogger(__name__)
+
+
+def _lxd_network_up(name: str, subnet: str, external: bool = True):
+    try:
+        process = subprocess.run(
+            [
+                "sudo",
+                "lxc",
+                "network",
+                "create",
+                name,
+                "--type=bridge",
+                f"ipv4.address={subnet}",
+                f"ipv4.nat={external}".lower(),
+                "ipv6.address=none",
+                "dns.mode=none",
+            ],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+        )
+        logger.info(f"LXD network created: {process.stdout}")
+
+        process = subprocess.run(
+            ["sudo", "lxc", "network", "show", name],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+        )
+        logger.debug(f"LXD network status: {process.stdout}")
+
+        if not external:
+            subprocess.check_output(
+                ["sudo", "lxc", "network", "set", name, "raw.dnsmasq", RAW_DNSMASQ],
+            )
+
+        subprocess.check_output(["sudo", "ip", "link", "set", "up", "dev", name])
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Error creating LXD network {name} with: {e.returncode} {e.stderr}")
+        raise
+
+
+def _lxd_network_down(name: str):
+    try:
+        subprocess.check_output(["sudo", "lxc", "network", "delete", name])
+    except subprocess.CalledProcessError as e:
+        logger.warning(f"Error deleting LXD network with: {e.returncode} {e.stderr}")
+
+
+@pytest.hookimpl()
+def pytest_sessionstart(session):
+    subprocess.run(
+        ["sudo", "lxc", "network", "set", DEFAULT_LXD_NETWORK, "dns.mode=none"],
+        check=True,
+    )
+
+    _lxd_network_up("client", "10.0.0.1/24", True)
+    _lxd_network_up("peers", "10.10.10.1/24", False)
+    _lxd_network_up("isolated", "10.20.20.1/24", False)
+
+
+@pytest.hookimpl()
+def pytest_sessionfinish(session, exitstatus):
+    # Nothing to do, as this is a temp runner only
+    if os.environ.get("CI").lower() == "true":
+        return
+
+    _lxd_network_down("client")
+    _lxd_network_down("peers")
+    _lxd_network_down("isolated")
+
+    subprocess.run(
+        ["sudo", "lxc", "network", "unset", DEFAULT_LXD_NETWORK, "dns.mode=none"],
+        check=True,
+    )
+
+
+@pytest.fixture(scope="module")
+async def lxd_spaces(ops_test: OpsTest):
+    await ops_test.juju("reload-spaces")
+    await ops_test.model.add_space("client", cidrs=["10.0.0.0/24"])
+    await ops_test.model.add_space("peers", cidrs=["10.10.10.0/24"])
+    await ops_test.model.add_space("isolated", cidrs=["10.20.20.0/24"])

--- a/tests/integration/spaces/test_spaced_db.py
+++ b/tests/integration/spaces/test_spaced_db.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..high_availability.high_availability_helpers import (
+    ensure_all_units_continuous_writes_incrementing,
+)
+
+DB_METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+DATABASE_APP_NAME = DB_METADATA["name"]
+APPLICATION_APP_NAME = "mysql-test-app"
+
+TIMEOUT = 15 * 60
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy(ops_test: OpsTest, lxd_spaces, charm) -> None:
+    """Build the charm and deploy 3 units to ensure a cluster is formed."""
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=DATABASE_APP_NAME,
+            constraints={"spaces": ["client", "peers"]},
+            bind={"database-peers": "peers", "database": "client"},
+            num_units=3,
+            base="ubuntu@22.04",
+        ),
+        ops_test.model.deploy(
+            APPLICATION_APP_NAME,
+            application_name=APPLICATION_APP_NAME,
+            constraints={"spaces": ["client"]},
+            bind={"database": "client"},
+            num_units=1,
+            base="ubuntu@22.04",
+            channel="latest/edge",
+        ),
+    )
+
+    # Reduce the update_status frequency until the cluster is deployed
+    async with ops_test.fast_forward("60s"):
+        await ops_test.model.block_until(
+            lambda: len(ops_test.model.applications[DATABASE_APP_NAME].units) == 3,
+            lambda: len(ops_test.model.applications[APPLICATION_APP_NAME].units) == 1,
+        )
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(
+                apps=[DATABASE_APP_NAME],
+                status="active",
+                raise_on_blocked=True,
+                timeout=TIMEOUT,
+            ),
+            ops_test.model.wait_for_idle(
+                apps=[APPLICATION_APP_NAME],
+                status="waiting",
+                raise_on_blocked=True,
+                timeout=TIMEOUT,
+            ),
+        )
+
+
+async def test_integrate_with_spaces(ops_test: OpsTest):
+    """Relate the database to the application."""
+    await ops_test.model.relate(
+        f"{DATABASE_APP_NAME}",
+        f"{APPLICATION_APP_NAME}:database",
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME, APPLICATION_APP_NAME],
+        status="active",
+        timeout=TIMEOUT,
+    )
+
+    app = ops_test.model.applications[APPLICATION_APP_NAME]
+    unit = app.units[0]
+
+    # Remove default route on client so traffic can't be routed through default interface
+    logger.info("Flush default routes on client")
+    await unit.run("sudo ip route flush default")
+
+    logger.info("Starting continuous writes")
+    await juju_.run_action(unit, "start-continuous-writes")
+
+    # Ensure continuous writes still incrementing for all units
+    await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+    await ops_test.model.remove_application(APPLICATION_APP_NAME, block_until_done=True)
+
+
+async def test_integrate_with_isolated_space(ops_test: OpsTest):
+    """Relate the database to the application."""
+    isolated_app_name = "isolated-test-app"
+
+    await ops_test.model.deploy(
+        APPLICATION_APP_NAME,
+        application_name=isolated_app_name,
+        constraints={"spaces": ["isolated"]},
+        bind={"database": "isolated"},
+        channel="latest/edge",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[isolated_app_name],
+        status="waiting",
+        timeout=TIMEOUT,
+    )
+
+    # Relate the database to the application
+    await ops_test.model.relate(
+        f"{DATABASE_APP_NAME}",
+        f"{isolated_app_name}:database",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME, isolated_app_name],
+        status="active",
+        timeout=TIMEOUT,
+    )
+
+    app = ops_test.model.applications[isolated_app_name]
+    unit = app.units[0]
+
+    # Remove default route on client so traffic can't be routed through default interface
+    logger.info("Flush default routes on client")
+    await unit.run("sudo ip route flush default")
+
+    logger.info("Starting continuous writes")
+    await juju_.run_action(unit, "start-continuous-writes")
+
+    # Ensure continuous writes do not increment for all units
+    with pytest.raises(AssertionError):
+        await ensure_all_units_continuous_writes_incrementing(ops_test)
+
+    await ops_test.model.remove_application(isolated_app_name, block_until_done=True)

--- a/tests/spread/test_spaced_db.py/task.yaml
+++ b/tests/spread/test_spaced_db.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_spaced_db.py
+environment:
+  TEST_MODULE: spaces/test_spaced_db.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -23,11 +23,11 @@ class TestDatabase(unittest.TestCase):
 
     @patch("charm.MySQLOperatorCharm.unit_initialized")
     @patch("charm.MySQLOperatorCharm.cluster_initialized", new_callable=PropertyMock)
-    @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
     @patch(
-        "mysql_vm_helpers.MySQL.get_cluster_endpoints",
+        "charm.MySQLOperatorCharm.get_cluster_endpoints",
         return_value=("2.2.2.2:3306", "2.2.2.1:3306,2.2.2.3:3306", ""),
     )
+    @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
     @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
     @patch(
         "relations.mysql_provider.generate_random_password", return_value="super_secure_password"
@@ -36,8 +36,8 @@ class TestDatabase(unittest.TestCase):
         self,
         _generate_random_password,
         _create_application_database_and_scoped_user,
-        _get_cluster_endpoints,
         _get_mysql_version,
+        _get_cluster_endpoints,
         _cluster_initialized,
         _unit_initialized,
     ):

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -1103,21 +1103,6 @@ class TestMySQLBase(unittest.TestCase):
             host="1.1.1.1:33062",
         )
 
-    @patch("charms.mysql.v0.mysql.MySQLBase.is_cluster_replica", return_value=False)
-    @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_status", return_value=SHORT_CLUSTER_STATUS)
-    def test_get_cluster_endpoints(self, _, _is_cluster_replica):
-        """Test get_cluster_endpoints() method."""
-        endpoints = self.mysql.get_cluster_endpoints(get_ips=False)
-
-        self.assertEqual(
-            endpoints,
-            (
-                "mysql-k8s-1.mysql-k8s-endpoints:3306",
-                "mysql-k8s-0.mysql-k8s-endpoints:3306",
-                "mysql-k8s-2.mysql-k8s-endpoints:3306",
-            ),
-        )
-
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
     def test_cluster_metadata_exists(self, _run_mysqlcli_script, _run_mysqlsh_script):


### PR DESCRIPTION
This PR add Juju spaces support to the operator.

The contents have been ported from the PostgreSQL-operator support [PR](https://github.com/canonical/postgresql-operator/pull/857/files).

### Key considerations:
- In order to keep a centralized logic, the `get_cluster_endpoints` function was moved side-ways within the class hierarchy (`MySQLBase` -> `MySQLCharmBase`), and its argument changed. Therefore, the proposed `mysql`  charm lib is **not compatible** with existing users (i.e. mysql-k8s-operator). A small adaptation will be needed.

### Additional changes:

- A centralized way to turn juju unit names into mysql instance labels was created (see [method](https://github.com/canonical/mysql-operator/blob/08356d04350e98056a876ba9e5265f146e948481/lib/charms/mysql/v0/mysql.py#L502-L505)).