### PR TITLE
[DPE-7648] Fix access to not populated instance label

### DIFF
--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -133,7 +133,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 88
+LIBPATCH = 89
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -795,6 +795,11 @@ class MySQLCharmBase(CharmBase, ABC):
         rw_endpoints = set()
 
         for k, v in repl_topology.items():
+            # When a replica instance is catching up with the primary instance,
+            # the custom label assigned by the operator code has not yet been applied.
+            if v["status"] == MySQLMemberState.RECOVERING:
+                continue
+
             address = f"{self.get_unit_address(unit_labels[k], relation_name)}:3306"
 
             if v["status"] != MySQLMemberState.ONLINE:


### PR DESCRIPTION
This PR aims to fix an intermittent [error](https://github.com/canonical/mysql-k8s-operator/actions/runs/15968330351/job/45048983537#step:12:715) Paulo Machado and I saw when a multiple-unit cluster is starting.

The symptom is that a specific unit calling the get_cluster_endpoints method (`mysql-k8s-1` from the error trace) is unable to find the key corresponding to another unit (`mysql-k8s-2` from the error trace), within the dictionary of Juju unit labels. The root cause seems to be the time lapse between a MySQL replica instance starting to replicate transactions, and the time where it is fully caught up, time where the custom label gets applied.

![image](https://github.com/user-attachments/assets/cb99d80a-4b50-4d27-a4af-7da836d6a7c3)