### PR TITLE
[DPE-7322] Support predefined roles

### DIFF
--- a/docs/reference/software-testing.md
+++ b/docs/reference/software-testing.md
@@ -36,13 +36,13 @@ juju run mysql-test-app/leader get-inserted-data
 # Start "continuous write" test:
 juju run mysql-test-app/leader start-continuous-writes
 export password=$(juju run mysql/leader get-password username=root | yq '.. | select(. | has("password")).password')
-watch -n1 -x juju ssh mysql/leader "mysql -h 127.0.0.1 -uroot -p${password} -e \"select count(*) from continuous_writes_database.data\""
+watch -n1 -x juju ssh mysql/leader "mysql -h 127.0.0.1 -uroot -p${password} -e \"select count(*) from continuous_writes.data\""
 
 # Watch the counter is growing!
 ```
 Expected results:
 
-* mysql-test-app continuously inserts records in database `continuous_writes_database` table `data`.
+* mysql-test-app continuously inserts records in database `continuous_writes` table `data`.
 * the counters (amount of records in table) are growing on all cluster members
 
 Hints:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1510,12 +1510,9 @@ class MySQLBase(ABC):
         """Create an application database."""
         role_name = f"charmed_dba_{database}"
 
-        if len(database) >= ROLE_MAX_LENGTH:
-            logger.error(f"Failed to create application database {database}")
-            raise MySQLCreateApplicationDatabaseError("Name longer than 32 characters")
         if len(role_name) >= ROLE_MAX_LENGTH:
-            logger.warning(f"Pruning application database role name {role_name}")
-            role_name = role_name[:ROLE_MAX_LENGTH]
+            logger.error(f"Failed to create application database {database}")
+            raise MySQLCreateApplicationDatabaseError("Role name longer than 32 characters")
 
         create_database_commands = (
             "shell.connect_to_primary()",

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -1212,12 +1212,13 @@ class MySQLBase(ABC):
             logger.debug(f"Missing MySQL role {role}")
             configure_role_commands = [
                 f"CREATE ROLE {role}",
-                f"GRANT CREATE USER ON *.* TO {role} WITH GRANT OPTION",
-                f"GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON mysql_innodb_cluster_metadata.* TO {role}",
-                f"GRANT SELECT ON mysql.user TO {role}",
-                f"GRANT SELECT ON performance_schema.replication_group_members TO {role}",
-                f"GRANT SELECT ON performance_schema.replication_group_member_stats TO {role}",
-                f"GRANT SELECT ON performance_schema.global_variables TO {role}",
+                f"GRANT CREATE ON *.* TO {role}",
+                f"GRANT CREATE USER ON *.* TO {role}",
+                # The granting of all privileges to the MySQL Router role
+                # can only be restricted when the privileges to the users
+                # created by such role are restricted as well
+                # https://github.com/canonical/mysql-router-operator/blob/main/src/mysql_shell/__init__.py#L134-L136
+                f"GRANT ALL ON *.* TO {role} WITH GRANT OPTION",
             ]
 
             try:

--- a/lib/charms/mysql/v0/mysql.py
+++ b/lib/charms/mysql/v0/mysql.py
@@ -127,7 +127,7 @@ LIBID = "8c1428f06b1b4ec8bf98b7d980a38a8c"
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
-LIBPATCH = 92
+LIBPATCH = 93
 
 UNIT_TEARDOWN_LOCKNAME = "unit-teardown"
 UNIT_ADD_LOCKNAME = "unit-add"
@@ -145,6 +145,24 @@ ADMIN_PORT = 33062
 # Labels are not confidential
 SECRET_INTERNAL_LABEL = "secret-id"  # noqa: S105
 SECRET_DELETED_LABEL = "None"  # noqa: S105
+
+ROLE_DBA = "charmed_dba"
+ROLE_DDL = "charmed_ddl"
+ROLE_DML = "charmed_dml"
+ROLE_READ = "charmed_read"
+ROLE_STATS = "charmed_stats"
+ROLE_BACKUP = "charmed_backup"
+ROLE_MAX_LENGTH = 32
+
+# TODO:
+#   Remove legacy role when migrating to MySQL 8.4
+#   (when breaking changes are allowed)
+LEGACY_ROLE_ROUTER = "mysqlrouter"
+MODERN_ROLE_ROUTER = "charmed_router"
+
+FORBIDDEN_EXTRA_ROLES = {
+    ROLE_BACKUP,
+}
 
 APP_SCOPE = "app"
 UNIT_SCOPE = "unit"
@@ -173,8 +191,16 @@ class Error(Exception):
         return f"<{type(self).__module__}.{type(self).__name__}>"
 
 
+class MySQLConfigureMySQLRolesError(Error):
+    """Exception raised when creating a role fails."""
+
+
 class MySQLConfigureMySQLUsersError(Error):
     """Exception raised when creating a user fails."""
+
+
+class MySQLListMySQLRolesError(Error):
+    """Exception raised when there is an issue listing database roles."""
 
 
 class MySQLCheckUserExistenceError(Error):
@@ -185,8 +211,12 @@ class MySQLConfigureRouterUserError(Error):
     """Exception raised when configuring the MySQLRouter user."""
 
 
-class MySQLCreateApplicationDatabaseAndScopedUserError(Error):
-    """Exception raised when creating application database and scoped user."""
+class MySQLCreateApplicationDatabaseError(Error):
+    """Exception raised when creating application database."""
+
+
+class MySQLCreateApplicationScopedUserError(Error):
+    """Exception raised when creating application scoped user."""
 
 
 class MySQLGetRouterUsersError(Error):
@@ -268,10 +298,6 @@ class MySQLGetClusterPrimaryAddressError(Error):
 
 class MySQLSetClusterPrimaryError(Error):
     """Exception raised when there is an issue setting the primary instance."""
-
-
-class MySQLGrantPrivilegesToUserError(Error):
-    """Exception raised when there is an issue granting privileges to user."""
 
 
 class MySQLNoMemberStateError(Error):
@@ -1032,6 +1058,7 @@ class MySQLBase(ABC):
         self.socket_uri = f"({socket_path})"
         self.cluster_name = cluster_name
         self.cluster_set_name = cluster_set_name
+        self.root_user = ROOT_USERNAME
         self.root_password = root_password
         self.server_config_user = server_config_user
         self.server_config_password = server_config_password
@@ -1133,8 +1160,8 @@ class MySQLBase(ABC):
         # the admin enables them manually
         config["mysqld"] = {
             # All interfaces bind expected
-            "bind-address": "0.0.0.0",  # noqa: S104
-            "mysqlx-bind-address": "0.0.0.0",  # noqa: S104
+            "bind_address": "0.0.0.0",  # noqa: S104
+            "mysqlx_bind_address": "0.0.0.0",  # noqa: S104
             "admin_address": self.instance_address,
             "report_host": self.instance_address,
             "max_connections": str(max_connections),
@@ -1150,6 +1177,7 @@ class MySQLBase(ABC):
             "loose-audit_log_file": f"{snap_common}/var/log/mysql/audit.log",
             "gtid_mode": "ON",
             "enforce_gtid_consistency": "ON",
+            "activate_all_roles_on_login": "ON",
         }
 
         if audit_log_enabled:
@@ -1174,51 +1202,137 @@ class MySQLBase(ABC):
             config.write(string_io)
             return string_io.getvalue(), dict(config["mysqld"])
 
-    def configure_mysql_users(self) -> None:
-        """Configure the MySQL users for the instance."""
+    def configure_mysql_router_roles(self) -> None:
+        """Configure the MySQL Router roles for the instance."""
+        for role in (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER):
+            existing_roles = self.list_mysql_roles(role)
+            if role in existing_roles:
+                continue
+
+            logger.debug(f"Missing MySQL role {role}")
+            configure_role_commands = [
+                f"CREATE ROLE {role}",
+                f"GRANT CREATE USER ON *.* TO {role} WITH GRANT OPTION",
+                f"GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON mysql_innodb_cluster_metadata.* TO {role}",
+                f"GRANT SELECT ON mysql.user TO {role}",
+                f"GRANT SELECT ON performance_schema.replication_group_members TO {role}",
+                f"GRANT SELECT ON performance_schema.replication_group_member_stats TO {role}",
+                f"GRANT SELECT ON performance_schema.global_variables TO {role}",
+            ]
+
+            try:
+                logger.debug(f"Configuring Router role for {self.instance_address}")
+                self._run_mysqlcli_script(
+                    configure_role_commands,
+                    user=self.root_user,
+                    password=self.root_password,
+                )
+            except MySQLClientError as e:
+                logger.error(f"Failed to configure Router role for {self.instance_address}")
+                raise MySQLConfigureMySQLRolesError from e
+
+    def configure_mysql_system_roles(self) -> None:
+        """Configure the MySQL system roles for the instance."""
+        role_to_queries = {
+            ROLE_READ: [
+                f"CREATE ROLE {ROLE_READ}",
+            ],
+            ROLE_DML: [
+                f"CREATE ROLE {ROLE_DML}",
+            ],
+            ROLE_STATS: [
+                f"CREATE ROLE {ROLE_STATS}",
+                f"GRANT SELECT ON performance_schema.* TO {ROLE_STATS}",
+                f"GRANT PROCESS, RELOAD, REPLICATION CLIENT ON *.* TO {ROLE_STATS}",
+            ],
+            ROLE_BACKUP: [
+                f"CREATE ROLE {ROLE_BACKUP}",
+                f"GRANT charmed_stats TO {ROLE_BACKUP}",
+                f"GRANT EXECUTE, LOCK TABLES, PROCESS, RELOAD ON *.* TO {ROLE_BACKUP}",
+                f"GRANT BACKUP_ADMIN, CONNECTION_ADMIN ON *.* TO {ROLE_BACKUP}",
+            ],
+            ROLE_DDL: [
+                f"CREATE ROLE {ROLE_DDL}",
+                f"GRANT charmed_dml TO {ROLE_DDL}",
+                f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TABLESPACE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, SHOW_ROUTINE, SHOW VIEW, TRIGGER ON *.* TO {ROLE_DDL}",
+            ],
+            ROLE_DBA: [
+                f"CREATE ROLE {ROLE_DBA}",
+                f"GRANT charmed_dml TO {ROLE_DBA}",
+                f"GRANT charmed_stats TO {ROLE_DBA}",
+                f"GRANT charmed_backup TO {ROLE_DBA}",
+                f"GRANT charmed_ddl TO {ROLE_DBA}",
+                f"GRANT EVENT, SHOW DATABASES, SHUTDOWN ON *.* TO {ROLE_DBA}",
+                f"GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON *.* TO {ROLE_DBA}",
+                f"GRANT AUDIT_ADMIN, CONNECTION_ADMIN, SYSTEM_VARIABLES_ADMIN ON *.* TO {ROLE_DBA}",
+            ],
+        }
+
+        configure_roles_commands = []
+        existing_roles = self.list_mysql_roles("charmed_%")
+
+        for role, queries in role_to_queries.items():
+            if role not in existing_roles:
+                logger.debug(f"Missing MySQL role {role}")
+                configure_roles_commands.extend(queries)
+
+        try:
+            logger.debug(f"Configuring MySQL roles for {self.instance_address}")
+            self._run_mysqlcli_script(
+                configure_roles_commands,
+                user=self.root_user,
+                password=self.root_password,
+            )
+        except MySQLClientError as e:
+            logger.error(f"Failed to configure roles for {self.instance_address}")
+            raise MySQLConfigureMySQLRolesError from e
+
+    def configure_mysql_system_users(self) -> None:
+        """Configure the MySQL system users for the instance."""
+        configure_users_commands = [
+            f"UPDATE mysql.user SET authentication_string=null WHERE User='{self.root_user}' and Host='localhost'",  # noqa: S608
+            f"ALTER USER '{self.root_user}'@'localhost' IDENTIFIED BY '{self.root_password}'",
+            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
+            f"CREATE USER '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
+            f"CREATE USER '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
+        ]
+
         # SYSTEM_USER and SUPER privileges to revoke from the root users
         # Reference: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_super
-        privileges_to_revoke = (
-            "SYSTEM_USER",
-            "SYSTEM_VARIABLES_ADMIN",
-            "SUPER",
-            "REPLICATION_SLAVE_ADMIN",
-            "GROUP_REPLICATION_ADMIN",
-            "BINLOG_ADMIN",
-            "SET_USER_ID",
-            "ENCRYPTION_KEY_ADMIN",
-            "VERSION_TOKEN_ADMIN",
-            "CONNECTION_ADMIN",
-        )
-
-        # privileges for the backups user:
-        #   https://docs.percona.com/percona-xtrabackup/8.0/using_xtrabackup/privileges.html#permissions-and-privileges-needed
-        # CONNECTION_ADMIN added to provide it privileges to connect to offline_mode node
-        configure_users_commands = (
-            f"CREATE USER '{self.server_config_user}'@'%' IDENTIFIED BY '{self.server_config_password}'",
+        configure_users_commands.extend([
             f"GRANT ALL ON *.* TO '{self.server_config_user}'@'%' WITH GRANT OPTION",
-            f"CREATE USER '{self.monitoring_user}'@'%' IDENTIFIED BY '{self.monitoring_password}' WITH MAX_USER_CONNECTIONS 3",
-            f"GRANT SYSTEM_USER, SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO '{self.monitoring_user}'@'%'",
-            f"CREATE USER '{self.backups_user}'@'%' IDENTIFIED BY '{self.backups_password}'",
-            f"GRANT CONNECTION_ADMIN, BACKUP_ADMIN, PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO '{self.backups_user}'@'%'",
-            f"GRANT SELECT ON performance_schema.log_status TO '{self.backups_user}'@'%'",
-            f"GRANT SELECT ON performance_schema.keyring_component_status TO '{self.backups_user}'@'%'",
-            f"GRANT SELECT ON performance_schema.replication_group_members TO '{self.backups_user}'@'%'",
-            "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost'",
-            f"ALTER USER 'root'@'localhost' IDENTIFIED BY '{self.root_password}'",
-            f"REVOKE {', '.join(privileges_to_revoke)} ON *.* FROM 'root'@'localhost'",
+            f"GRANT charmed_stats TO '{self.monitoring_user}'@'%'",
+            f"GRANT charmed_backup TO '{self.backups_user}'@'%'",
+            f"REVOKE BINLOG_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, REPLICATION_SLAVE_ADMIN, SET_USER_ID, SUPER, SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, VERSION_TOKEN_ADMIN ON *.* FROM '{self.root_user}'@'localhost'",
             "FLUSH PRIVILEGES",
-        )
+        ])
 
         try:
             logger.debug(f"Configuring MySQL users for {self.instance_address}")
             self._run_mysqlcli_script(
                 configure_users_commands,
+                user=self.root_user,
                 password=self.root_password,
             )
         except MySQLClientError as e:
             logger.error(f"Failed to configure users for: {self.instance_address}")
             raise MySQLConfigureMySQLUsersError from e
+
+    def list_mysql_roles(self, name_pattern: str) -> set[str]:
+        """Returns a set with the MySQL roles."""
+        try:
+            query_commands = (
+                f"SELECT User FROM mysql.user WHERE User LIKE '{name_pattern}'",  # noqa: S608
+            )
+            output = self._run_mysqlcli_script(
+                query_commands,
+                user=self.root_user,
+                password=self.root_password,
+            )
+            return {row[0] for row in output}
+        except MySQLClientError as e:
+            logger.error("Failed to list roles")
+            raise MySQLListMySQLRolesError from e
 
     def _plugin_file_exists(self, plugin_file_name: str) -> bool:
         """Check if the plugin file exists.
@@ -1320,6 +1434,7 @@ class MySQLBase(ABC):
         try:
             output = self._run_mysqlcli_script(
                 ("select name from mysql.plugin",),
+                user=self.root_user,
                 password=self.root_password,
             )
             return {
@@ -1390,51 +1505,89 @@ class MySQLBase(ABC):
             logger.error(f"Failed to configure mysqlrouter {username=}")
             raise MySQLConfigureRouterUserError from e
 
-    def create_application_database_and_scoped_user(
-        self,
-        database_name: str,
-        username: str,
-        password: str,
-        hostname: str,
-        *,
-        unit_name: str | None = None,
-        create_database: bool = True,
-    ) -> None:
-        """Create an application database and a user scoped to the created database."""
-        attributes = {}
-        if unit_name is not None:
-            attributes["unit_name"] = unit_name
+    def create_database(self, database: str) -> None:
+        """Create an application database."""
+        role_name = f"charmed_dba_{database}"
+
+        if len(database) >= ROLE_MAX_LENGTH:
+            logger.error(f"Failed to create application database {database}")
+            raise MySQLCreateApplicationDatabaseError("Name longer than 32 characters")
+        if len(role_name) >= ROLE_MAX_LENGTH:
+            logger.warning(f"Pruning application database role name {role_name}")
+            role_name = role_name[:ROLE_MAX_LENGTH]
+
+        create_database_commands = (
+            "shell.connect_to_primary()",
+            f'session.run_sql("CREATE DATABASE IF NOT EXISTS `{database}`;")',
+            f'session.run_sql("GRANT SELECT ON `{database}`.* TO {ROLE_READ};")',
+            f'session.run_sql("GRANT SELECT, INSERT, DELETE, UPDATE ON `{database}`.* TO {ROLE_DML};")',
+        )
+        create_dba_role_commands = (
+            f'session.run_sql("CREATE ROLE IF NOT EXISTS `{role_name}`;")',
+            f'session.run_sql("GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `{database}`.* TO {role_name};")',
+            f'session.run_sql("GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `{database}`.* TO {role_name};")',
+        )
+
         try:
-            # Using server_config_user as we are sure it has create database grants
-            connect_command = ("shell.connect_to_primary()",)
-            create_database_commands = (
-                f'session.run_sql("CREATE DATABASE IF NOT EXISTS `{database_name}`;")',
-            )
-
-            escaped_user_attributes = json.dumps(attributes).replace('"', r"\"")
-            # Using server_config_user as we are sure it has create user grants
-            create_scoped_user_commands = (
-                f"session.run_sql(\"CREATE USER `{username}`@`{hostname}` IDENTIFIED BY '{password}' ATTRIBUTE '{escaped_user_attributes}';\")",
-                f'session.run_sql("GRANT USAGE ON *.* TO `{username}`@`{hostname}`;")',
-                f'session.run_sql("GRANT ALL PRIVILEGES ON `{database_name}`.* TO `{username}`@`{hostname}`;")',
-            )
-
-            if create_database:
-                commands = connect_command + create_database_commands + create_scoped_user_commands
-            else:
-                commands = connect_command + create_scoped_user_commands
-
             self._run_mysqlsh_script(
-                "\n".join(commands),
+                "\n".join(create_database_commands + create_dba_role_commands),
                 user=self.server_config_user,
                 password=self.server_config_password,
                 host=self.instance_def(self.server_config_user),
             )
         except MySQLClientError as e:
-            logger.error(
-                f"Failed to create application database {database_name} and scoped user {username}@{hostname}"
+            logger.error(f"Failed to create application database {database}")
+            raise MySQLCreateApplicationDatabaseError(e.message) from e
+
+    def create_scoped_user(
+        self,
+        database: str,
+        username: str,
+        password: str,
+        hostname: str,
+        *,
+        unit_name: str | None = None,
+        extra_roles: list[str] | None = None,
+    ) -> None:
+        """Create an application user scoped to the created database."""
+        if extra_roles is not None and set(extra_roles) & FORBIDDEN_EXTRA_ROLES:
+            logger.error(f"Invalid extra user roles: {extra_roles}")
+            raise MySQLCreateApplicationScopedUserError("invalid role(s) for extra user roles")
+
+        attributes = {}
+        if unit_name is not None:
+            attributes = {"unit_name": unit_name}
+        if extra_roles is not None:
+            extra_roles = ", ".join(extra_roles)
+
+        create_scoped_user_attributes = json.dumps(attributes).replace('"', r"\"")
+        create_scoped_user_commands = (
+            "shell.connect_to_primary()",
+            f"session.run_sql(\"CREATE USER `{username}`@`{hostname}` IDENTIFIED BY '{password}' ATTRIBUTE '{create_scoped_user_attributes}';\")",
+        )
+
+        if extra_roles:
+            grant_scoped_user_commands = (
+                f'session.run_sql("GRANT {extra_roles} TO `{username}`@`{hostname}`;")',
             )
-            raise MySQLCreateApplicationDatabaseAndScopedUserError(e.message) from e
+        else:
+            # Legacy behaviour when no explicit roles were assigned to users
+            # (before system roles were introduced).
+            grant_scoped_user_commands = (
+                f'session.run_sql("GRANT USAGE ON *.* TO `{username}`@`{hostname}`;")',
+                f'session.run_sql("GRANT ALL PRIVILEGES ON `{database}`.* TO `{username}`@`{hostname}`;")',
+            )
+
+        try:
+            self._run_mysqlsh_script(
+                "\n".join(create_scoped_user_commands + grant_scoped_user_commands),
+                user=self.server_config_user,
+                password=self.server_config_password,
+                host=self.instance_def(self.server_config_user),
+            )
+        except MySQLClientError as e:
+            logger.error(f"Failed to create application scoped user {username}@{hostname}")
+            raise MySQLCreateApplicationScopedUserError(e.message) from e
 
     @staticmethod
     def _get_statements_to_delete_users_with_attribute(
@@ -1866,7 +2019,7 @@ class MySQLBase(ABC):
         try:
             output = self._run_mysqlcli_script(
                 (get_clusters_query,),
-                user=ROOT_USERNAME,
+                user=self.root_user,
                 password=self.root_password,
                 timeout=60,
                 exception_as_warning=True,
@@ -2743,29 +2896,6 @@ class MySQLBase(ABC):
             return None
 
         return matches.group(1)
-
-    def grant_privileges_to_user(
-        self, username, hostname, privileges, with_grant_option=False
-    ) -> None:
-        """Grants specified privileges to the provided database user."""
-        grant_privileges_commands = (
-            "shell.connect_to_primary()",
-            (
-                f"session.run_sql(\"GRANT {', '.join(privileges)} ON *.* TO '{username}'@'{hostname}'"
-                f'{" WITH GRANT OPTION" if with_grant_option else ""}")'
-            ),
-        )
-
-        try:
-            self._run_mysqlsh_script(
-                "\n".join(grant_privileges_commands),
-                user=self.server_config_user,
-                password=self.server_config_password,
-                host=self.instance_def(self.server_config_user),
-            )
-        except MySQLClientError as e:
-            logger.warning(f"Failed to grant privileges to user {username}@{hostname}")
-            raise MySQLGrantPrivilegesToUserError(e.message) from e
 
     def update_user_password(self, username: str, new_password: str, host: str = "%") -> None:
         """Updates user password in MySQL database."""
@@ -3761,7 +3891,7 @@ class MySQLBase(ABC):
     def _run_mysqlcli_script(
         self,
         script: tuple[Any, ...] | list[Any],
-        user: str = "root",
+        user: str = ROOT_USERNAME,
         password: str | None = None,
         timeout: int | None = None,
         exception_as_warning: bool = False,

--- a/src/mysql_vm_helpers.py
+++ b/src/mysql_vm_helpers.py
@@ -54,6 +54,7 @@ from constants import (
     MYSQLD_DEFAULTS_CONFIG_FILE,
     MYSQLD_SOCK_FILE,
     ROOT_SYSTEM_USER,
+    ROOT_USERNAME,
     XTRABACKUP_PLUGIN_DIR,
 )
 
@@ -819,7 +820,7 @@ class MySQL(MySQLBase):
     def _run_mysqlcli_script(
         self,
         script: tuple[Any, ...] | list[Any],
-        user: str = "root",
+        user: str = ROOT_USERNAME,
         password: str | None = None,
         timeout: int | None = None,
         exception_as_warning: bool = False,

--- a/src/relations/db_router.py
+++ b/src/relations/db_router.py
@@ -11,7 +11,8 @@ from collections import namedtuple
 from charms.mysql.v0.mysql import (
     MySQLCheckUserExistenceError,
     MySQLConfigureRouterUserError,
-    MySQLCreateApplicationDatabaseAndScopedUserError,
+    MySQLCreateApplicationDatabaseError,
+    MySQLCreateApplicationScopedUserError,
     MySQLDeleteUsersForUnitError,
     MySQLGetClusterPrimaryAddressError,
 )
@@ -124,8 +125,8 @@ class DBRouterRelation(Object):
         Raises:
             MySQLCheckUserExistenceError if there is an issue checking a user's existence
             MySQLConfigureRouterUserError if there is an issue configuring the mysqlrouter user
-            MySQLCreateApplicationDatabaseAndScopedUserError if there is an issue creating a
-                user or said user scoped database
+            MySQLCreateApplicationDatabaseError if there is an issue creating the database
+            MySQLCreateApplicationScopedUserError if there is an issue creating the database user
         """
         user_passwords = {}
         requested_user_applications = set()
@@ -141,7 +142,8 @@ class DBRouterRelation(Object):
                         requested_user.username, password, requested_user.hostname, user_unit_name
                     )
                 else:
-                    self.charm._mysql.create_application_database_and_scoped_user(
+                    self.charm._mysql.create_database(requested_user.database)
+                    self.charm._mysql.create_scoped_user(
                         requested_user.database,
                         requested_user.username,
                         password,
@@ -227,7 +229,8 @@ class DBRouterRelation(Object):
         except (
             MySQLCheckUserExistenceError,
             MySQLConfigureRouterUserError,
-            MySQLCreateApplicationDatabaseAndScopedUserError,
+            MySQLCreateApplicationDatabaseError,
+            MySQLCreateApplicationScopedUserError,
         ):
             self.charm.unit.status = BlockedStatus("Failed to create app user or scoped database")
             return

--- a/src/relations/mysql.py
+++ b/src/relations/mysql.py
@@ -10,7 +10,8 @@ import typing
 
 from charms.mysql.v0.mysql import (
     MySQLCheckUserExistenceError,
-    MySQLCreateApplicationDatabaseAndScopedUserError,
+    MySQLCreateApplicationDatabaseError,
+    MySQLCreateApplicationScopedUserError,
     MySQLDeleteUsersForUnitError,
     MySQLGetClusterPrimaryAddressError,
 )
@@ -195,7 +196,8 @@ class MySQLRelation(Object):
         password = self._get_or_set_password_in_peer_secrets(username)
 
         try:
-            self.charm._mysql.create_application_database_and_scoped_user(
+            self.charm._mysql.create_database(database)
+            self.charm._mysql.create_scoped_user(
                 database,
                 username,
                 password,
@@ -204,9 +206,9 @@ class MySQLRelation(Object):
             )
 
             primary_address = self.charm._mysql.get_cluster_primary_address()
-
         except (
-            MySQLCreateApplicationDatabaseAndScopedUserError,
+            MySQLCreateApplicationDatabaseError,
+            MySQLCreateApplicationScopedUserError,
             MySQLGetClusterPrimaryAddressError,
         ):
             self.charm.unit.status = BlockedStatus("Failed to initialize `mysql` relation")

--- a/tests/integration/high_availability/high_availability_helpers.py
+++ b/tests/integration/high_availability/high_availability_helpers.py
@@ -21,7 +21,7 @@ from ..helpers import (
 )
 
 # Copied these values from high_availability.application_charm.src.charm
-DATABASE_NAME = "continuous_writes_database"
+DATABASE_NAME = "continuous_writes"
 TABLE_NAME = "data"
 
 CLUSTER_NAME = "test_cluster"

--- a/tests/integration/relations/test_relation_mysql_legacy.py
+++ b/tests/integration/relations/test_relation_mysql_legacy.py
@@ -29,7 +29,7 @@ APPS = [DATABASE_APP_NAME, APPLICATION_APP_NAME]
 ENDPOINT = "mysql"
 
 TEST_USER = "testuser"
-TEST_DATABASE = "continuous_writes_database"
+TEST_DATABASE = "continuous_writes"
 TIMEOUT = 15 * 60
 
 

--- a/tests/integration/roles/__init__.py
+++ b/tests/integration/roles/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/roles/test_database_dba_role.py
+++ b/tests/integration/roles/test_database_dba_role.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from mysql.connector.errors import ProgrammingError
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..helpers import (
+    execute_queries_on_unit,
+    get_primary_unit,
+)
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+DATABASE_APP_NAME = METADATA["name"]
+INTEGRATOR_APP_NAME = "data-integrator"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Simple test to ensure that the mysql and data-integrator charms get deployed."""
+    async with ops_test.fast_forward("10s"):
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                application_name=DATABASE_APP_NAME,
+                num_units=3,
+                base="ubuntu@22.04",
+                config={"profile": "testing"},
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}1",
+                base="ubuntu@24.04",
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}2",
+                base="ubuntu@24.04",
+            ),
+        )
+
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME],
+        status="active",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"],
+        status="blocked",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_dba_role(ops_test: OpsTest):
+    """Test the database-level DBA role."""
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
+        "database-name": "preserved",
+        "extra-user-roles": "",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].set_config({
+        "database-name": "throwaway",
+        "extra-user-roles": "charmed_dba_preserved",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await primary_unit.get_public_address()
+
+    data_integrator_2_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].units[0]
+    results = await juju_.run_action(data_integrator_2_unit, "get-credentials")
+
+    logger.info("Checking that the database-level DBA role cannot create new databases")
+    with pytest.raises(ProgrammingError):
+        await execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            ["CREATE DATABASE IF NOT EXISTS test"],
+            commit=True,
+        )
+
+    logger.info("Checking that the database-level DBA role can see all databases")
+    await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        ["SHOW DATABASES"],
+        commit=True,
+    )
+
+    logger.info("Checking that the database-level DBA role can create a new table")
+    await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "CREATE TABLE preserved.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+        ],
+        commit=True,
+    )
+
+    logger.info("Checking that the database-level DBA role can write into an existing table")
+    await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "INSERT INTO preserved.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+        ],
+        commit=True,
+    )
+
+    logger.info("Checking that the database-level DBA role can read from an existing table")
+    rows = await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "SELECT `data` FROM preserved.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in preserved with charmed_dba_preserved role"

--- a/tests/integration/roles/test_instance_dba_role.py
+++ b/tests/integration/roles/test_instance_dba_role.py
@@ -50,7 +50,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
 async def test_charmed_dba_role(ops_test: OpsTest):
     """Test the instance-level DBA role."""
     await ops_test.model.applications[INTEGRATOR_APP_NAME].set_config({
-        "database-name": "charmed_dba_database",
+        "database-name": "charmed_dba_db",
         "extra-user-roles": "charmed_dba",
     })
     await ops_test.model.add_relation(INTEGRATOR_APP_NAME, DATABASE_APP_NAME)

--- a/tests/integration/roles/test_instance_dba_role.py
+++ b/tests/integration/roles/test_instance_dba_role.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..helpers import (
+    execute_queries_on_unit,
+    get_primary_unit,
+)
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+DATABASE_APP_NAME = METADATA["name"]
+INTEGRATOR_APP_NAME = "data-integrator"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Simple test to ensure that the mysql and data-integrator charms get deployed."""
+    async with ops_test.fast_forward("10s"):
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                application_name=DATABASE_APP_NAME,
+                num_units=3,
+                base="ubuntu@22.04",
+                config={"profile": "testing"},
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                base="ubuntu@24.04",
+            ),
+        )
+
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active")
+    await ops_test.model.wait_for_idle(apps=[INTEGRATOR_APP_NAME], status="blocked")
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_dba_role(ops_test: OpsTest):
+    """Test the instance-level DBA role."""
+    await ops_test.model.applications[INTEGRATOR_APP_NAME].set_config({
+        "database-name": "charmed_dba_database",
+        "extra-user-roles": "charmed_dba",
+    })
+    await ops_test.model.add_relation(INTEGRATOR_APP_NAME, DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[INTEGRATOR_APP_NAME, DATABASE_APP_NAME], status="active"
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await primary_unit.get_public_address()
+
+    data_integrator_unit = ops_test.model.applications[INTEGRATOR_APP_NAME].units[0]
+    results = await juju_.run_action(data_integrator_unit, "get-credentials")
+
+    logger.info("Checking that the instance-level DBA role can create new databases")
+    await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        ["CREATE DATABASE IF NOT EXISTS test"],
+        commit=True,
+    )
+
+    data_integrator_unit = ops_test.model.applications[INTEGRATOR_APP_NAME].units[0]
+    results = await juju_.run_action(data_integrator_unit, "get-credentials")
+
+    logger.info("Checking that the instance-level DBA role can see all databases")
+    rows = await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        ["SHOW DATABASES"],
+        commit=True,
+    )
+
+    assert "test" in rows, "Database is not visible to DBA user"

--- a/tests/integration/roles/test_instance_roles.py
+++ b/tests/integration/roles/test_instance_roles.py
@@ -64,7 +64,7 @@ async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
 async def test_charmed_read_role(ops_test: OpsTest):
     """Test the instance-level charmed_read role."""
     await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
-        "database-name": "charmed_read_database",
+        "database-name": "charmed_read_db",
         "extra-user-roles": "charmed_read",
     })
     await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
@@ -83,8 +83,8 @@ async def test_charmed_read_role(ops_test: OpsTest):
         server_config_credentials["username"],
         server_config_credentials["password"],
         [
-            "CREATE TABLE charmed_read_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
-            "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+            "CREATE TABLE charmed_read_db.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_read_db.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
         ],
         commit=True,
     )
@@ -98,14 +98,14 @@ async def test_charmed_read_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "SELECT `data` FROM charmed_read_database.test_table",
+            "SELECT `data` FROM charmed_read_db.test_table",
         ],
         commit=True,
     )
     assert sorted(rows) == sorted([
         "test_data_1",
         "test_data_2",
-    ]), "Unexpected data in charmed_read_database with charmed_read role"
+    ]), "Unexpected data in charmed_read_db with charmed_read role"
 
     logger.info("Checking that the charmed_read role cannot write into an existing table")
     with pytest.raises(ProgrammingError):
@@ -114,7 +114,7 @@ async def test_charmed_read_role(ops_test: OpsTest):
             results["mysql"]["username"],
             results["mysql"]["password"],
             [
-                "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_3')",
+                "INSERT INTO charmed_read_db.test_table (`data`) VALUES ('test_data_3')",
             ],
             commit=True,
         )
@@ -126,7 +126,7 @@ async def test_charmed_read_role(ops_test: OpsTest):
             results["mysql"]["username"],
             results["mysql"]["password"],
             [
-                "CREATE TABLE charmed_read_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+                "CREATE TABLE charmed_read_db.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
             ],
             commit=True,
         )
@@ -145,7 +145,7 @@ async def test_charmed_read_role(ops_test: OpsTest):
 async def test_charmed_dml_role(ops_test: OpsTest):
     """Test the instance-level charmed_dml role."""
     await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
-        "database-name": "charmed_dml_database",
+        "database-name": "charmed_dml_db",
         "extra-user-roles": "",
     })
     await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
@@ -177,16 +177,16 @@ async def test_charmed_dml_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "CREATE TABLE charmed_dml_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
-            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
-            "SELECT `data` FROM charmed_dml_database.test_table",
+            "CREATE TABLE charmed_dml_db.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_dml_db.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+            "SELECT `data` FROM charmed_dml_db.test_table",
         ],
         commit=True,
     )
     assert sorted(rows) == sorted([
         "test_data_1",
         "test_data_2",
-    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+    ]), "Unexpected data in charmed_dml_db with charmed_dml role"
 
     data_integrator_2_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].units[0]
     results = await juju_.run_action(data_integrator_2_unit, "get-credentials")
@@ -197,14 +197,14 @@ async def test_charmed_dml_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "SELECT `data` FROM charmed_dml_database.test_table",
+            "SELECT `data` FROM charmed_dml_db.test_table",
         ],
         commit=True,
     )
     assert sorted(rows) == sorted([
         "test_data_1",
         "test_data_2",
-    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+    ]), "Unexpected data in charmed_dml_db with charmed_dml role"
 
     logger.info("Checking that the charmed_dml role can write into an existing table")
     await execute_queries_on_unit(
@@ -212,7 +212,7 @@ async def test_charmed_dml_role(ops_test: OpsTest):
         results["mysql"]["username"],
         results["mysql"]["password"],
         [
-            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_3')",
+            "INSERT INTO charmed_dml_db.test_table (`data`) VALUES ('test_data_3')",
         ],
         commit=True,
     )
@@ -224,7 +224,7 @@ async def test_charmed_dml_role(ops_test: OpsTest):
             results["mysql"]["username"],
             results["mysql"]["password"],
             [
-                "CREATE TABLE charmed_dml_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+                "CREATE TABLE charmed_dml_db.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
             ],
             commit=True,
         )

--- a/tests/integration/roles/test_instance_roles.py
+++ b/tests/integration/roles/test_instance_roles.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+from mysql.connector.errors import ProgrammingError
+from pytest_operator.plugin import OpsTest
+
+from .. import juju_
+from ..helpers import (
+    execute_queries_on_unit,
+    get_primary_unit,
+    get_server_config_credentials,
+)
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+
+DATABASE_APP_NAME = METADATA["name"]
+INTEGRATOR_APP_NAME = "data-integrator"
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, charm) -> None:
+    """Simple test to ensure that the mysql and data-integrator charms get deployed."""
+    async with ops_test.fast_forward("10s"):
+        await asyncio.gather(
+            ops_test.model.deploy(
+                charm,
+                application_name=DATABASE_APP_NAME,
+                num_units=3,
+                base="ubuntu@22.04",
+                config={"profile": "testing"},
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}1",
+                base="ubuntu@24.04",
+            ),
+            ops_test.model.deploy(
+                INTEGRATOR_APP_NAME,
+                application_name=f"{INTEGRATOR_APP_NAME}2",
+                base="ubuntu@24.04",
+            ),
+        )
+
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME],
+        status="active",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"],
+        status="blocked",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_read_role(ops_test: OpsTest):
+    """Test the instance-level charmed_read role."""
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
+        "database-name": "charmed_read_database",
+        "extra-user-roles": "charmed_read",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await primary_unit.get_public_address()
+    server_config_credentials = await get_server_config_credentials(primary_unit)
+
+    await execute_queries_on_unit(
+        primary_unit_address,
+        server_config_credentials["username"],
+        server_config_credentials["password"],
+        [
+            "CREATE TABLE charmed_read_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+        ],
+        commit=True,
+    )
+
+    data_integrator_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].units[0]
+    results = await juju_.run_action(data_integrator_unit, "get-credentials")
+
+    logger.info("Checking that the charmed_read role can read from an existing table")
+    rows = await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "SELECT `data` FROM charmed_read_database.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in charmed_read_database with charmed_read role"
+
+    logger.info("Checking that the charmed_read role cannot write into an existing table")
+    with pytest.raises(ProgrammingError):
+        await execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            [
+                "INSERT INTO charmed_read_database.test_table (`data`) VALUES ('test_data_3')",
+            ],
+            commit=True,
+        )
+
+    logger.info("Checking that the charmed_read role cannot create a new table")
+    with pytest.raises(ProgrammingError):
+        await execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            [
+                "CREATE TABLE charmed_read_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            ],
+            commit=True,
+        )
+
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:database",
+        f"{INTEGRATOR_APP_NAME}1:mysql",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1"],
+        status="blocked",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_charmed_dml_role(ops_test: OpsTest):
+    """Test the instance-level charmed_dml role."""
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].set_config({
+        "database-name": "charmed_dml_database",
+        "extra-user-roles": "",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].set_config({
+        "database-name": "throwaway",
+        "extra-user-roles": "charmed_dml",
+    })
+    await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME],
+        status="active",
+    )
+
+    mysql_unit = ops_test.model.applications[DATABASE_APP_NAME].units[0]
+    primary_unit = await get_primary_unit(ops_test, mysql_unit, DATABASE_APP_NAME)
+    primary_unit_address = await primary_unit.get_public_address()
+
+    data_integrator_1_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}1"].units[0]
+    results = await juju_.run_action(data_integrator_1_unit, "get-credentials")
+
+    logger.info("Checking that when no role is specified the created user can do everything")
+    rows = await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "CREATE TABLE charmed_dml_database.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
+            "SELECT `data` FROM charmed_dml_database.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+
+    data_integrator_2_unit = ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].units[0]
+    results = await juju_.run_action(data_integrator_2_unit, "get-credentials")
+
+    logger.info("Checking that the charmed_dml role can read from an existing table")
+    rows = await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "SELECT `data` FROM charmed_dml_database.test_table",
+        ],
+        commit=True,
+    )
+    assert sorted(rows) == sorted([
+        "test_data_1",
+        "test_data_2",
+    ]), "Unexpected data in charmed_dml_database with charmed_dml role"
+
+    logger.info("Checking that the charmed_dml role can write into an existing table")
+    await execute_queries_on_unit(
+        primary_unit_address,
+        results["mysql"]["username"],
+        results["mysql"]["password"],
+        [
+            "INSERT INTO charmed_dml_database.test_table (`data`) VALUES ('test_data_3')",
+        ],
+        commit=True,
+    )
+
+    logger.info("Checking that the charmed_dml role cannot create a new table")
+    with pytest.raises(ProgrammingError):
+        await execute_queries_on_unit(
+            primary_unit_address,
+            results["mysql"]["username"],
+            results["mysql"]["password"],
+            [
+                "CREATE TABLE charmed_dml_database.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
+            ],
+            commit=True,
+        )
+
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:database",
+        f"{INTEGRATOR_APP_NAME}1:mysql",
+    )
+    await ops_test.model.applications[DATABASE_APP_NAME].remove_relation(
+        f"{DATABASE_APP_NAME}:database",
+        f"{INTEGRATOR_APP_NAME}2:mysql",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[f"{INTEGRATOR_APP_NAME}1", f"{INTEGRATOR_APP_NAME}2"],
+        status="blocked",
+    )

--- a/tests/spread/test_database_dba_role.py/task.yaml
+++ b/tests/spread/test_database_dba_role.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_database_dba_role.py
+environment:
+  TEST_MODULE: roles/test_database_dba_role.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_instance_dba_role.py/task.yaml
+++ b/tests/spread/test_instance_dba_role.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_instance_dba_role.py
+environment:
+  TEST_MODULE: roles/test_instance_dba_role.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_instance_roles.py/task.yaml
+++ b/tests/spread/test_instance_roles.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_instance_roles.py
+environment:
+  TEST_MODULE: roles/test_instance_roles.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -28,14 +28,16 @@ class TestDatabase(unittest.TestCase):
         return_value=("2.2.2.2:3306", "2.2.2.1:3306,2.2.2.3:3306", ""),
     )
     @patch("mysql_vm_helpers.MySQL.get_mysql_version", return_value="8.0.29-0ubuntu0.20.04.3")
-    @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
+    @patch("mysql_vm_helpers.MySQL.create_database")
+    @patch("mysql_vm_helpers.MySQL.create_scoped_user")
     @patch(
         "relations.mysql_provider.generate_random_password", return_value="super_secure_password"
     )
     def test_database_requested(
         self,
         _generate_random_password,
-        _create_application_database_and_scoped_user,
+        _create_scoped_user,
+        _create_database,
         _get_mysql_version,
         _get_cluster_endpoints,
         _cluster_initialized,
@@ -82,6 +84,7 @@ class TestDatabase(unittest.TestCase):
         )
 
         _generate_random_password.assert_called_once()
-        _create_application_database_and_scoped_user.assert_called_once()
+        _create_database.assert_called_once()
+        _create_scoped_user.assert_called_once()
         _get_cluster_endpoints.assert_called_once()
         _get_mysql_version.assert_called_once()

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -147,12 +147,9 @@ class TestMySQLBase(unittest.TestCase):
 
             _expected_configure_role_commands = [
                 f"CREATE ROLE {role}",
-                f"GRANT CREATE USER ON *.* TO {role} WITH GRANT OPTION",
-                f"GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON mysql_innodb_cluster_metadata.* TO {role}",
-                f"GRANT SELECT ON mysql.user TO {role}",
-                f"GRANT SELECT ON performance_schema.replication_group_members TO {role}",
-                f"GRANT SELECT ON performance_schema.replication_group_member_stats TO {role}",
-                f"GRANT SELECT ON performance_schema.global_variables TO {role}",
+                f"GRANT CREATE ON *.* TO {role}",
+                f"GRANT CREATE USER ON *.* TO {role}",
+                f"GRANT ALL ON *.* TO {role} WITH GRANT OPTION",
             ]
 
             self.mysql.configure_mysql_router_roles()

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -2610,8 +2610,8 @@ class TestMySQLBase(unittest.TestCase):
   File "/var/lib/juju/agents/unit-mysql-k8s-edge-0/charm/venv/lib/python3.10/site-packages/ops/pebble.py", line 1771, in wait_output
     raise ExecError[AnyStr](self._command, exit_code, out_value, err_value)
 ops.pebble.ExecError: non-zero exit code 1 executing ['/usr/bin/mysqlsh', '--passwords-from-stdin', '--uri=serverconfig@mysql-k8s-edge-0.mysql-k8s-edge-endpoints.stg-alutay-datasql-juju361.svc.cluster.local:33062', '--python', '--verbose=0', '-c', 'shell.options.set(\'useWizards\', False)\nprint(\'###\')\nsh$
-ll.connect_to_primary()\nsession.run_sql("CREATE DATABASE IF NOT EXISTS `continuous_writes_database`;")\nsession.run_sql("CREATE USER `relation-21_ff7306c7454f44`@`%` IDENTIFIED BY \'s1ffxPedAmX58aOdCRSzxEpm\' ATTRIBUTE \'{}\';")\nsession.run_sql("GRANT USAGE ON *.* TO `relation-21_ff7306c7454f44`@`%`;")\nses
-sion.run_sql("GRANT ALL PRIVILEGES ON `continuous_writes_database`.* TO `relation-21_ff7306c7454f44`@`%`;")'], stdout="\x1b[1mPlease provide the password for 'serverconfig@mysql-k8s-edge-0.mysql-k8s-edge-endpoints.stg-alutay-datasql-juju361.svc.cluster.local:33062': \x1b[0m###\n", stderr='Cannot set LC_ALL to
+ll.connect_to_primary()\nsession.run_sql("CREATE DATABASE IF NOT EXISTS `continuous_writes`;")\nsession.run_sql("CREATE USER `relation-21_ff7306c7454f44`@`%` IDENTIFIED BY \'s1ffxPedAmX58aOdCRSzxEpm\' ATTRIBUTE \'{}\';")\nsession.run_sql("GRANT USAGE ON *.* TO `relation-21_ff7306c7454f44`@`%`;")\nses
+sion.run_sql("GRANT ALL PRIVILEGES ON `continuous_writes`.* TO `relation-21_ff7306c7454f44`@`%`;")'], stdout="\x1b[1mPlease provide the password for 'serverconfig@mysql-k8s-edge-0.mysql-k8s-edge-endpoints.stg-alutay-datasql-juju361.svc.cluster.local:33062': \x1b[0m###\n", stderr='Cannot set LC_ALL to
  locale en_US.UTF-8: No such file or directory\n\x1b[36mNOTE: \x1b[0mAlready connected to a PRIMARY.\nTraceback (most recent call last):\n  File "<string>", line 5, in <module>\nmysqlsh.DBError: MySQL Error (1396): ClassicSession.run_sql: Operation CREATE USER failed for \'relation-21_ff7306c7454f44\'@\'%\'\n
 """
         output = self.mysql.strip_off_passwords(_input)

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -8,6 +8,14 @@ from unittest.mock import call, patch
 
 import tenacity
 from charms.mysql.v0.mysql import (
+    LEGACY_ROLE_ROUTER,
+    MODERN_ROLE_ROUTER,
+    ROLE_BACKUP,
+    ROLE_DBA,
+    ROLE_DDL,
+    ROLE_DML,
+    ROLE_READ,
+    ROLE_STATS,
     Error,
     MySQLAddInstanceToClusterError,
     MySQLBase,
@@ -15,9 +23,11 @@ from charms.mysql.v0.mysql import (
     MySQLClientError,
     MySQLClusterMetadataExistsError,
     MySQLConfigureInstanceError,
+    MySQLConfigureMySQLRolesError,
     MySQLConfigureMySQLUsersError,
     MySQLConfigureRouterUserError,
-    MySQLCreateApplicationDatabaseAndScopedUserError,
+    MySQLCreateApplicationDatabaseError,
+    MySQLCreateApplicationScopedUserError,
     MySQLCreateClusterError,
     MySQLCreateClusterSetError,
     MySQLCreateReplicaClusterError,
@@ -55,7 +65,7 @@ from charms.mysql.v0.mysql import (
     MySQLSetVariableError,
 )
 
-from constants import MYSQLD_SOCK_FILE
+from constants import MYSQLD_SOCK_FILE, ROOT_USERNAME
 
 SHORT_CLUSTER_STATUS = {
     "defaultreplicaset": {
@@ -124,40 +134,140 @@ class TestMySQLBase(unittest.TestCase):
             "backupspassword",
         )  # pyright: ignore
 
+    @patch("charms.mysql.v0.mysql.MySQLBase.list_mysql_roles")
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
-    def test_configure_mysql_users(self, _run_mysqlcli_script):
-        """Test successful configuration of MySQL users."""
+    def test_configure_mysql_router_roles(self, _run_mysqlcli_script, _list_mysql_roles):
+        """Test successful configuration of MySQL router role."""
+        router_roles = (LEGACY_ROLE_ROUTER, MODERN_ROLE_ROUTER)
+
+        for role in router_roles:
+            _list_mysql_roles.return_value = {next(r for r in router_roles if r != role)}
+            _run_mysqlcli_script.reset_mock()
+            _run_mysqlcli_script.return_value = b""
+
+            _expected_configure_role_commands = [
+                f"CREATE ROLE {role}",
+                f"GRANT CREATE USER ON *.* TO {role} WITH GRANT OPTION",
+                f"GRANT SELECT, INSERT, UPDATE, DELETE, EXECUTE ON mysql_innodb_cluster_metadata.* TO {role}",
+                f"GRANT SELECT ON mysql.user TO {role}",
+                f"GRANT SELECT ON performance_schema.replication_group_members TO {role}",
+                f"GRANT SELECT ON performance_schema.replication_group_member_stats TO {role}",
+                f"GRANT SELECT ON performance_schema.global_variables TO {role}",
+            ]
+
+            self.mysql.configure_mysql_router_roles()
+
+            _run_mysqlcli_script.assert_called_once_with(
+                _expected_configure_role_commands,
+                user=ROOT_USERNAME,
+                password="password",
+            )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase.list_mysql_roles")
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_configure_mysql_router_roles_fail(self, _run_mysqlcli_script, _list_mysql_roles):
+        """Test failure to configure the MySQL router role."""
+        _list_mysql_roles.return_value = set()
+        _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLConfigureMySQLRolesError):
+            self.mysql.configure_mysql_router_roles()
+
+    @patch("charms.mysql.v0.mysql.MySQLBase.list_mysql_roles")
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_configure_mysql_system_roles(self, _run_mysqlcli_script, _list_mysql_roles):
+        """Test successful configuration of MySQL system roles."""
+        _list_mysql_roles.return_value = {ROLE_DBA}
         _run_mysqlcli_script.return_value = b""
 
-        _expected_configure_user_commands = (
-            "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword'",
-            "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION",
-            "CREATE USER 'monitoring'@'%' IDENTIFIED BY 'monitoringpassword' WITH MAX_USER_CONNECTIONS 3",
-            "GRANT SYSTEM_USER, SELECT, PROCESS, SUPER, REPLICATION CLIENT, RELOAD ON *.* TO 'monitoring'@'%'",
-            "CREATE USER 'backups'@'%' IDENTIFIED BY 'backupspassword'",
-            "GRANT CONNECTION_ADMIN, BACKUP_ADMIN, PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO 'backups'@'%'",
-            "GRANT SELECT ON performance_schema.log_status TO 'backups'@'%'",
-            "GRANT SELECT ON performance_schema.keyring_component_status TO 'backups'@'%'",
-            "GRANT SELECT ON performance_schema.replication_group_members TO 'backups'@'%'",
-            "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost'",
-            "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password'",
-            "REVOKE SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, SUPER, REPLICATION_SLAVE_ADMIN, GROUP_REPLICATION_ADMIN, BINLOG_ADMIN, SET_USER_ID, ENCRYPTION_KEY_ADMIN, VERSION_TOKEN_ADMIN, CONNECTION_ADMIN ON *.* FROM 'root'@'localhost'",
-            "FLUSH PRIVILEGES",
-        )
+        _expected_configure_roles_commands = [
+            # Charmed read queries
+            f"CREATE ROLE {ROLE_READ}",
+            # Charmed DML queries
+            f"CREATE ROLE {ROLE_DML}",
+            # Charmed stats queries
+            f"CREATE ROLE {ROLE_STATS}",
+            f"GRANT SELECT ON performance_schema.* TO {ROLE_STATS}",
+            f"GRANT PROCESS, RELOAD, REPLICATION CLIENT ON *.* TO {ROLE_STATS}",
+            # Charmed backup queries
+            f"CREATE ROLE {ROLE_BACKUP}",
+            f"GRANT charmed_stats TO {ROLE_BACKUP}",
+            f"GRANT EXECUTE, LOCK TABLES, PROCESS, RELOAD ON *.* TO {ROLE_BACKUP}",
+            f"GRANT BACKUP_ADMIN, CONNECTION_ADMIN ON *.* TO {ROLE_BACKUP}",
+            # Charmed DDL queries
+            f"CREATE ROLE {ROLE_DDL}",
+            f"GRANT charmed_dml TO {ROLE_DDL}",
+            f"GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TABLESPACE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, SHOW_ROUTINE, SHOW VIEW, TRIGGER ON *.* TO {ROLE_DDL}",
+        ]
 
-        self.mysql.configure_mysql_users()
+        self.mysql.configure_mysql_system_roles()
 
         _run_mysqlcli_script.assert_called_once_with(
-            _expected_configure_user_commands, password="password"
+            _expected_configure_roles_commands,
+            user=ROOT_USERNAME,
+            password="password",
+        )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase.list_mysql_roles")
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_configure_mysql_system_roles_fail(self, _run_mysqlcli_script, _list_mysql_roles):
+        """Test failure to configure the MySQL system roles."""
+        _list_mysql_roles.return_value = set()
+        _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLConfigureMySQLRolesError):
+            self.mysql.configure_mysql_system_roles()
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_configure_mysql_system_users(self, _run_mysqlcli_script):
+        """Test successful configuration of MySQL system users."""
+        _run_mysqlcli_script.return_value = b""
+
+        _expected_configure_user_commands = [
+            "UPDATE mysql.user SET authentication_string=null WHERE User='root' and Host='localhost'",
+            "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password'",
+            "CREATE USER 'serverconfig'@'%' IDENTIFIED BY 'serverconfigpassword'",
+            "CREATE USER 'monitoring'@'%' IDENTIFIED BY 'monitoringpassword' WITH MAX_USER_CONNECTIONS 3",
+            "CREATE USER 'backups'@'%' IDENTIFIED BY 'backupspassword'",
+            "GRANT ALL ON *.* TO 'serverconfig'@'%' WITH GRANT OPTION",
+            "GRANT charmed_stats TO 'monitoring'@'%'",
+            "GRANT charmed_backup TO 'backups'@'%'",
+            "REVOKE BINLOG_ADMIN, CONNECTION_ADMIN, ENCRYPTION_KEY_ADMIN, GROUP_REPLICATION_ADMIN, REPLICATION_SLAVE_ADMIN, SET_USER_ID, SUPER, SYSTEM_USER, SYSTEM_VARIABLES_ADMIN, VERSION_TOKEN_ADMIN ON *.* FROM 'root'@'localhost'",
+            "FLUSH PRIVILEGES",
+        ]
+
+        self.mysql.configure_mysql_system_users()
+
+        _run_mysqlcli_script.assert_called_once_with(
+            _expected_configure_user_commands,
+            user=ROOT_USERNAME,
+            password="password",
         )
 
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
-    def test_configure_mysql_users_fail(self, _run_mysqlcli_script):
-        """Test failure to configure the MySQL users."""
+    def test_configure_mysql_system_users_fail(self, _run_mysqlcli_script):
+        """Test failure to configure the MySQL system users."""
         _run_mysqlcli_script.side_effect = MySQLClientError("Error on subprocess")
 
         with self.assertRaises(MySQLConfigureMySQLUsersError):
-            self.mysql.configure_mysql_users()
+            self.mysql.configure_mysql_system_users()
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
+    def test_list_mysql_roles(self, _run_mysqlcli_script):
+        """Test successful listing of MySQL roles."""
+        _run_mysqlcli_script.return_value = []
+
+        _expected_list_roles_commands = (
+            "SELECT User FROM mysql.user WHERE User LIKE 'charmed_%'",
+        )
+
+        self.mysql.list_mysql_roles("charmed_%")
+
+        _run_mysqlcli_script.assert_called_once_with(
+            _expected_list_roles_commands,
+            user=ROOT_USERNAME,
+            password="password",
+        )
 
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlcli_script")
     def test_does_mysql_user_exist(self, _run_mysqlcli_script):
@@ -250,24 +360,23 @@ class TestMySQLBase(unittest.TestCase):
             )
 
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
-    def test_create_application_database_and_scoped_user(self, _run_mysqlsh_script):
-        """Test the successful execution of create_application_database_and_scoped_user."""
+    def test_create_application_database(self, _run_mysqlsh_script):
+        """Test the successful execution of create_application_database."""
         _run_mysqlsh_script.return_value = ""
 
         _expected_create_scoped_user_commands = "\n".join((
             "shell.connect_to_primary()",
-            'session.run_sql("CREATE DATABASE IF NOT EXISTS `test-database`;")',
-            'session.run_sql("CREATE USER `test-username`@`1.1.1.1` IDENTIFIED BY \'test-password\' ATTRIBUTE \'{\\"unit_name\\": \\"app/0\\"}\';")',
-            'session.run_sql("GRANT USAGE ON *.* TO `test-username`@`1.1.1.1`;")',
-            'session.run_sql("GRANT ALL PRIVILEGES ON `test-database`.* TO `test-username`@`1.1.1.1`;")',
+            'session.run_sql("CREATE DATABASE IF NOT EXISTS `test_database`;")',
+            'session.run_sql("GRANT SELECT ON `test_database`.* TO charmed_read;")',
+            'session.run_sql("GRANT SELECT, INSERT, DELETE, UPDATE ON `test_database`.* TO charmed_dml;")',
+            'session.run_sql("CREATE ROLE IF NOT EXISTS `charmed_dba_test_database`;")',
+            'session.run_sql("GRANT SELECT, INSERT, DELETE, UPDATE, EXECUTE ON `test_database`.* TO charmed_dba_test_database;")',
+            'session.run_sql("GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DROP, INDEX, LOCK TABLES, REFERENCES, TRIGGER ON `test_database`.* TO charmed_dba_test_database;")',
         ))
 
-        self.mysql.create_application_database_and_scoped_user(
-            "test-database", "test-username", "test-password", "1.1.1.1", unit_name="app/0"
-        )
+        self.mysql.create_database("test_database")
 
         self.assertEqual(_run_mysqlsh_script.call_count, 1)
-
         self.assertEqual(
             _run_mysqlsh_script.mock_calls,
             [
@@ -280,18 +389,78 @@ class TestMySQLBase(unittest.TestCase):
             ],
         )
 
-    @patch("charms.mysql.v0.mysql.MySQLBase.get_cluster_primary_address")
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
-    def test_create_application_database_and_scoped_user_failure(
-        self, _run_mysqlsh_script, _get_cluster_primary_address
-    ):
+    def test_create_application_database_failure(self, _run_mysqlsh_script):
         """Test failure to create application database and scoped user."""
-        _get_cluster_primary_address.return_value = "2.2.2.2"
         _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
 
-        with self.assertRaises(MySQLCreateApplicationDatabaseAndScopedUserError):
-            self.mysql.create_application_database_and_scoped_user(
-                "test_database", "test_username", "test_password", "1.1.1.1", unit_name="app/.0"
+        with self.assertRaises(MySQLCreateApplicationDatabaseError):
+            self.mysql.create_database("test_database")
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_create_application_database_invalid(self, _run_mysqlsh_script):
+        """Test failure to create an invalid application database."""
+        with self.assertRaises(MySQLCreateApplicationDatabaseError):
+            self.mysql.create_database("extremely_extra_long_database_name")
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_create_application_scoped_user(self, _run_mysqlsh_script):
+        """Test the successful execution of create_application_scoped_user."""
+        _run_mysqlsh_script.return_value = ""
+
+        _expected_create_scoped_user_commands = "\n".join((
+            "shell.connect_to_primary()",
+            'session.run_sql("CREATE USER `test_username`@`1.1.1.1` IDENTIFIED BY \'test_password\' ATTRIBUTE \'{\\"unit_name\\": \\"app/0\\"}\';")',
+            'session.run_sql("GRANT USAGE ON *.* TO `test_username`@`1.1.1.1`;")',
+            'session.run_sql("GRANT ALL PRIVILEGES ON `test_database`.* TO `test_username`@`1.1.1.1`;")',
+        ))
+
+        self.mysql.create_scoped_user(
+            "test_database",
+            "test_username",
+            "test_password",
+            "1.1.1.1",
+            unit_name="app/0",
+        )
+
+        self.assertEqual(_run_mysqlsh_script.call_count, 1)
+        self.assertEqual(
+            _run_mysqlsh_script.mock_calls,
+            [
+                call(
+                    _expected_create_scoped_user_commands,
+                    user="serverconfig",
+                    password="serverconfigpassword",
+                    host="127.0.0.1:33062",
+                )
+            ],
+        )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_create_application_scoped_user_failure(self, _run_mysqlsh_script):
+        """Test failure to create application scoped user."""
+        _run_mysqlsh_script.side_effect = MySQLClientError("Error on subprocess")
+
+        with self.assertRaises(MySQLCreateApplicationScopedUserError):
+            self.mysql.create_scoped_user(
+                "test_database",
+                "test_username",
+                "test_password",
+                "1.1.1.1",
+                unit_name="app/0",
+            )
+
+    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
+    def test_create_application_scoped_user_invalid(self, _run_mysqlsh_script):
+        """Test failure to create an invalid application scoped user."""
+        with self.assertRaises(MySQLCreateApplicationScopedUserError):
+            self.mysql.create_scoped_user(
+                "test_database",
+                "test_username",
+                "test_password",
+                "1.1.1.1",
+                unit_name="app/0",
+                extra_roles=[ROLE_BACKUP],
             )
 
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
@@ -1049,41 +1218,6 @@ class TestMySQLBase(unittest.TestCase):
         _run_mysqlsh_script.side_effect = MySQLClientError
         with self.assertRaises(MySQLGetMySQLVersionError):
             self.mysql.get_mysql_version()
-
-    @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
-    def test_grant_privileges_to_user(self, _run_mysqlsh_script):
-        """Test the successful execution of grant_privileges_to_user."""
-        expected_commands = "\n".join((
-            "shell.connect_to_primary()",
-            "session.run_sql(\"GRANT CREATE USER ON *.* TO 'test_user'@'%' WITH GRANT OPTION\")",
-        ))
-
-        self.mysql.grant_privileges_to_user(
-            "test_user", "%", ["CREATE USER"], with_grant_option=True
-        )
-
-        _run_mysqlsh_script.assert_called_with(
-            expected_commands,
-            user="serverconfig",
-            password="serverconfigpassword",
-            host="127.0.0.1:33062",
-        )
-
-        _run_mysqlsh_script.reset_mock()
-
-        expected_commands = "\n".join((
-            "shell.connect_to_primary()",
-            "session.run_sql(\"GRANT SELECT, UPDATE ON *.* TO 'test_user'@'%'\")",
-        ))
-
-        self.mysql.grant_privileges_to_user("test_user", "%", ["SELECT", "UPDATE"])
-
-        _run_mysqlsh_script.assert_called_with(
-            expected_commands,
-            user="serverconfig",
-            password="serverconfigpassword",
-            host="127.0.0.1:33062",
-        )
 
     @patch("charms.mysql.v0.mysql.MySQLBase._run_mysqlsh_script")
     def test_update_user_password(self, _run_mysqlsh_script):
@@ -2075,8 +2209,8 @@ class TestMySQLBase(unittest.TestCase):
         _get_available_memory.return_value = 32341442560
 
         expected_config = {
-            "bind-address": "0.0.0.0",
-            "mysqlx-bind-address": "0.0.0.0",
+            "bind_address": "0.0.0.0",
+            "mysqlx_bind_address": "0.0.0.0",
             "admin_address": "127.0.0.1",
             "report_host": "127.0.0.1",
             "max_connections": "724",
@@ -2095,6 +2229,7 @@ class TestMySQLBase(unittest.TestCase):
             "innodb_buffer_pool_chunk_size": "2902458368",
             "gtid_mode": "ON",
             "enforce_gtid_consistency": "ON",
+            "activate_all_roles_on_login": "ON",
         }
         self.maxDiff = None
 

--- a/tests/unit/test_mysqlsh_helpers.py
+++ b/tests/unit/test_mysqlsh_helpers.py
@@ -317,8 +317,8 @@ class TestMySQL(unittest.TestCase):
 
         config = "\n".join((
             "[mysqld]",
-            "bind-address = 0.0.0.0",
-            "mysqlx-bind-address = 0.0.0.0",
+            "bind_address = 0.0.0.0",
+            "mysqlx_bind_address = 0.0.0.0",
             "admin_address = 127.0.0.1",
             "report_host = 127.0.0.1",
             "max_connections = 111",
@@ -334,6 +334,7 @@ class TestMySQL(unittest.TestCase):
             "loose-audit_log_file = /var/snap/charmed-mysql/common/var/log/mysql/audit.log",
             "gtid_mode = ON",
             "enforce_gtid_consistency = ON",
+            "activate_all_roles_on_login = ON",
             "loose-audit_log_format = JSON",
             "loose-audit_log_strategy = ASYNCHRONOUS",
             "innodb_buffer_pool_chunk_size = 5678",
@@ -353,39 +354,8 @@ class TestMySQL(unittest.TestCase):
         _open_mock.reset_mock()
         self.mysql.write_mysqld_config()
 
-        config = "\n".join((
-            "[mysqld]",
-            "bind-address = 0.0.0.0",
-            "mysqlx-bind-address = 0.0.0.0",
-            "admin_address = 127.0.0.1",
-            "report_host = 127.0.0.1",
-            "max_connections = 100",
-            "innodb_buffer_pool_size = 20971520",
-            "log_error_services = log_filter_internal;log_sink_internal",
-            "log_error = /var/snap/charmed-mysql/common/var/log/mysql/error.log",
-            "general_log = OFF",
-            "general_log_file = /var/snap/charmed-mysql/common/var/log/mysql/general.log",
-            "loose-group_replication_paxos_single_leader = ON",
-            "slow_query_log_file = /var/snap/charmed-mysql/common/var/log/mysql/slow.log",
-            "binlog_expire_logs_seconds = 604800",
-            "loose-audit_log_policy = LOGINS",
-            "loose-audit_log_file = /var/snap/charmed-mysql/common/var/log/mysql/audit.log",
-            "gtid_mode = ON",
-            "enforce_gtid_consistency = ON",
-            "loose-audit_log_format = JSON",
-            "loose-audit_log_strategy = ASYNCHRONOUS",
-            "innodb_buffer_pool_chunk_size = 1048576",
-            "performance-schema-instrument = 'memory/%=OFF'",
-            "loose-group_replication_message_cache_size = 134217728",
-            "\n",
-        ))
-
         self.assertTrue(
-            call(
-                f"{MYSQLD_CONFIG_DIRECTORY}/z-custom-mysqld.cnf",
-                "w",
-                encoding="utf-8",
-            )
+            call(f"{MYSQLD_CONFIG_DIRECTORY}/z-custom-mysqld.cnf", "w", encoding="utf-8")
             in _open_mock.mock_calls
         )
 

--- a/tests/unit/test_relation_mysql_legacy.py
+++ b/tests/unit/test_relation_mysql_legacy.py
@@ -29,10 +29,12 @@ class TestMariaDBRelation(unittest.TestCase):
         "relations.mysql.MySQLRelation._get_or_set_password_in_peer_secrets",
         return_value="super_secure_password",
     )
-    @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
+    @patch("mysql_vm_helpers.MySQL.create_database")
+    @patch("mysql_vm_helpers.MySQL.create_scoped_user")
     def test_maria_db_relation_created(
         self,
-        _create_application_database_and_scoped_user,
+        _create_scoped_user,
+        _create_database,
         _get_or_set_password_in_peer_secrets,
         _get_cluster_primary_address,
         _does_mysql_user_exist,
@@ -52,7 +54,10 @@ class TestMariaDBRelation(unittest.TestCase):
         self.harness.add_relation_unit(self.maria_db_relation_id, "other-app/0")
 
         self.assertEqual(_get_or_set_password_in_peer_secrets.call_count, 1)
-        _create_application_database_and_scoped_user.assert_called_once_with(
+        _create_database.assert_called_once_with(
+            "default_database",
+        )
+        _create_scoped_user.assert_called_once_with(
             "default_database",
             "mysql",
             "super_secure_password",
@@ -86,10 +91,12 @@ class TestMariaDBRelation(unittest.TestCase):
         "relations.mysql.MySQLRelation._get_or_set_password_in_peer_secrets",
         return_value="super_secure_password",
     )
-    @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
+    @patch("mysql_vm_helpers.MySQL.create_database")
+    @patch("mysql_vm_helpers.MySQL.create_scoped_user")
     def test_maria_db_relation_created_with_secrets(
         self,
-        _create_application_database_and_scoped_user,
+        _create_scoped_user,
+        _create_database,
         _get_or_set_password_in_peer_secrets,
         _get_cluster_primary_address,
         _does_mysql_user_exist,
@@ -109,7 +116,10 @@ class TestMariaDBRelation(unittest.TestCase):
         self.harness.add_relation_unit(self.maria_db_relation_id, "other-app/0")
 
         self.assertEqual(_get_or_set_password_in_peer_secrets.call_count, 1)
-        _create_application_database_and_scoped_user.assert_called_once_with(
+        _create_database.assert_called_once_with(
+            "default_database",
+        )
+        _create_scoped_user.assert_called_once_with(
             "default_database",
             "mysql",
             "super_secure_password",
@@ -146,10 +156,12 @@ class TestMariaDBRelation(unittest.TestCase):
         "relations.mysql.MySQLRelation._get_or_set_password_in_peer_secrets",
         return_value="super_secure_password",
     )
-    @patch("mysql_vm_helpers.MySQL.create_application_database_and_scoped_user")
+    @patch("mysql_vm_helpers.MySQL.create_database")
+    @patch("mysql_vm_helpers.MySQL.create_scoped_user")
     def test_maria_db_relation_departed(
         self,
-        _create_application_database_and_scoped_user,
+        _create_scoped_user,
+        _create_database,
         _get_or_set_password_in_peer_secrets,
         _delete_users_for_unit,
         _get_cluster_primary_address,


### PR DESCRIPTION
This PR implements the set of predefined roles proposed in [this specification](https://docs.google.com/document/d/1U1tAWx9a7eb0HvdiS7lnSJS8oHqcl6F9PnAoRdcMjmc/edit?tab=t.0).

In addition to the predefined roles proposed to be on sync with PostgreSQL 16 operators, there is an additional one in order to solve a long time standing time debt: `mysqlrouter`. This predefined role is proposed in order to stop treating _mysqlrouter_ as a magic word used to assign `ALL PRIVILEGES` to the created users whose `extra-user-roles` config argument contained such word. That exact name has been chosen to **preserve backwards compatibility**.

### Additional changes:
- Implemented MySQL lib [function](https://github.com/canonical/mysql-operator/blob/52b2c8fc3367e67fd0cdf750bda61e25b103d0a2/lib/charms/mysql/v0/mysql.py#L2693-L2709) to fully support the usage of `extra-user-roles` config argument.
- Harmonized MySQL config arguments to all user underscore (`_`) instead of mixing dashes and underscores.
- Removed unused MySQL config dictionary in the unit tests.
