### PR TITLE
[MISC] Remove legacy test helper

### DIFF
--- a/tests/integration/backups.py
+++ b/tests/integration/backups.py
@@ -10,7 +10,6 @@ from . import juju_
 from .helpers import (
     execute_queries_on_unit,
     get_primary_unit_wrapper,
-    get_unit_ip,
     rotate_credentials,
 )
 from .high_availability.high_availability_helpers import (
@@ -111,7 +110,7 @@ async def pitr_operations(
         for unit in ops_test.model.applications[MYSQL_APPLICATION_NAME].units
         if unit.name != primary_unit.name
     ]
-    primary_ip = await get_unit_ip(ops_test, primary_unit.name)
+    primary_ip = await primary_unit.get_public_address()
 
     logger.info("Creating backup")
     results = await juju_.run_action(non_primary_units[0], "create-backup", **{"--wait": "5m"})

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -690,11 +690,10 @@ def is_machine_reachable_from(origin_machine: str, target_machine: str) -> bool:
         return False
 
 
-async def write_random_chars_to_test_table(ops_test: OpsTest, primary_unit: Unit) -> str:
+async def write_random_chars_to_test_table(primary_unit: Unit) -> str:
     """Writes to common test table.
 
     Args:
-        ops_test: The ops test framework instance
         primary_unit: the R/W unit to write the data
     Returns:
         The random chars(str) written to test table.
@@ -723,13 +722,10 @@ async def write_random_chars_to_test_table(ops_test: OpsTest, primary_unit: Unit
     return random_chars
 
 
-async def retrieve_database_variable_value(
-    ops_test: OpsTest, unit: Unit, variable_name: str
-) -> str:
+async def retrieve_database_variable_value(unit: Unit, variable_name: str) -> str:
     """Retrieve a database variable value as a string.
 
     Args:
-        ops_test: The ops test framework instance
         unit: The unit to retrieve the variable
         variable_name: The name of the variable to retrieve
     Returns:
@@ -749,10 +745,7 @@ async def retrieve_database_variable_value(
     return output[0]
 
 
-async def get_tls_ca(
-    ops_test: OpsTest,
-    unit_name: str,
-) -> str:
+async def get_tls_ca(ops_test: OpsTest, unit_name: str) -> str:
     """Returns the TLS CA used by the unit.
 
     Args:

--- a/tests/integration/high_availability/test_async_replication.py
+++ b/tests/integration/high_availability/test_async_replication.py
@@ -388,9 +388,11 @@ async def get_max_written_value(first_model: Model, second_model: Model) -> list
     logger.info("Querying max value on all units")
     for unit in first_model_units + second_model_units:
         address = await unit.get_public_address()
-        # address = await get_unit_ip(None, unit.name, unit.model)
         values = await execute_queries_on_unit(
-            address, credentials["username"], credentials["password"], select_max_written_value_sql
+            address,
+            credentials["username"],
+            credentials["password"],
+            select_max_written_value_sql,
         )
         results.append(values[0])
 

--- a/tests/integration/high_availability/test_replication_variables.py
+++ b/tests/integration/high_availability/test_replication_variables.py
@@ -35,5 +35,5 @@ async def test_custom_variables(ops_test: OpsTest, highly_available_cluster) -> 
         custom_vars["max_connections"] = 100
         for k, v in custom_vars.items():
             logger.info(f"Checking that {k} is set to {v} on {unit.name}")
-            value = await retrieve_database_variable_value(ops_test, unit, k)
+            value = await retrieve_database_variable_value(unit, k)
             assert value == v, f"Variable {k} is not set to {v}"

--- a/tests/integration/high_availability/test_self_healing_restart_forceful.py
+++ b/tests/integration/high_availability/test_self_healing_restart_forceful.py
@@ -14,7 +14,6 @@ from ..helpers import (
     execute_queries_on_unit,
     get_primary_unit_wrapper,
     get_system_user_password,
-    get_unit_ip,
     graceful_stop_server,
     is_unit_in_cluster,
 )
@@ -70,9 +69,14 @@ async def test_sst_test(ops_test: OpsTest, highly_available_cluster, continuous_
     for unit in all_units:
         if unit.name != primary_unit.name:
             logger.info(f"Purge binlogs on unit {unit.name}")
-            unit_ip = await get_unit_ip(ops_test, unit.name)
+            unit_address = await unit.get_public_address()
+
             await execute_queries_on_unit(
-                unit_ip, SERVER_CONFIG_USERNAME, server_config_password, purge_bin_log_sql, True
+                unit_address,
+                SERVER_CONFIG_USERNAME,
+                server_config_password,
+                purge_bin_log_sql,
+                commit=True,
             )
 
     async with ops_test.fast_forward():

--- a/tests/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/tests/integration/high_availability/test_self_healing_restart_graceful.py
@@ -14,7 +14,6 @@ from ..helpers import (
     execute_queries_on_unit,
     get_primary_unit_wrapper,
     get_system_user_password,
-    get_unit_ip,
     graceful_stop_server,
     is_connection_possible,
     start_server,
@@ -50,7 +49,7 @@ async def test_cluster_manual_rejoin(
     config = {
         "username": CLUSTER_ADMIN_USERNAME,
         "password": await get_system_user_password(primary_unit, CLUSTER_ADMIN_USERNAME),
-        "host": await get_unit_ip(ops_test, primary_unit.name),
+        "host": await primary_unit.get_public_address(),
     }
 
     queries = [

--- a/tests/integration/high_availability/test_self_healing_stop_all.py
+++ b/tests/integration/high_availability/test_self_healing_stop_all.py
@@ -13,7 +13,6 @@ from constants import CLUSTER_ADMIN_USERNAME
 
 from ..helpers import (
     get_system_user_password,
-    get_unit_ip,
     graceful_stop_server,
     is_connection_possible,
     start_server,
@@ -62,8 +61,7 @@ async def test_cluster_pause(ops_test: OpsTest, highly_available_cluster, contin
 
     # verify connection is not possible to any instance
     for unit in all_units:
-        unit_ip = await get_unit_ip(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = await unit.get_public_address()
         assert not is_connection_possible(
             config
         ), f"❌ connection to unit {unit.name} is still possible"

--- a/tests/integration/high_availability/test_self_healing_stop_primary.py
+++ b/tests/integration/high_availability/test_self_healing_stop_primary.py
@@ -78,7 +78,7 @@ async def test_replicate_data_on_restart(
     )
 
     logger.info("Write to new primary")
-    random_chars = await write_random_chars_to_test_table(ops_test, new_primary_unit)
+    random_chars = await write_random_chars_to_test_table(new_primary_unit)
 
     # restart server on old primary
     logger.info(f"Re starting server on unit {primary_unit.name}")

--- a/tests/integration/high_availability/test_upgrade.py
+++ b/tests/integration/high_availability/test_upgrade.py
@@ -78,7 +78,7 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 
     logger.info("Assert slow shutdown is enabled")
     for unit in mysql_units:
-        value = await retrieve_database_variable_value(ops_test, unit, "innodb_fast_shutdown")
+        value = await retrieve_database_variable_value(unit, "innodb_fast_shutdown")
         assert value == 0, f"innodb_fast_shutdown not 0 at {unit.name}"
 
     primary_unit = await get_primary_unit_wrapper(ops_test, MYSQL_APP_NAME)

--- a/tests/integration/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/high_availability/test_upgrade_from_stable.py
@@ -66,7 +66,7 @@ async def test_pre_upgrade_check(ops_test: OpsTest) -> None:
 
     logger.info("Assert slow shutdown is enabled")
     for unit in mysql_units:
-        value = await retrieve_database_variable_value(ops_test, unit, "innodb_fast_shutdown")
+        value = await retrieve_database_variable_value(unit, "innodb_fast_shutdown")
         assert value == 0, f"innodb_fast_shutdown not 0 at {unit.name}"
 
     primary_unit = await get_primary_unit_wrapper(ops_test, MYSQL_APP_NAME)

--- a/tests/integration/test_backup_aws.py
+++ b/tests/integration/test_backup_aws.py
@@ -16,7 +16,6 @@ from .helpers import (
     execute_queries_on_unit,
     get_primary_unit_wrapper,
     get_server_config_credentials,
-    get_unit_ip,
     rotate_credentials,
     scale_application,
 )
@@ -201,7 +200,7 @@ async def test_restore_on_same_cluster(
 
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
-    mysql_unit_address = await get_unit_ip(ops_test, mysql_unit.name)
+    mysql_unit_address = await mysql_unit.get_public_address()
     server_config_credentials = await get_server_config_credentials(mysql_unit)
 
     select_values_sql = [f"SELECT id FROM `{DATABASE_NAME}`.`{TABLE_NAME}`"]
@@ -274,7 +273,7 @@ async def test_restore_on_same_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_ip(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = await execute_queries_on_unit(
             unit_address,
@@ -322,7 +321,7 @@ async def test_restore_on_new_cluster(
 
     primary_mysql = ops_test.model.units[f"{new_mysql_application_name}/0"]
     assert primary_mysql
-    primary_unit_address = await get_unit_ip(ops_test, primary_mysql.name)
+    primary_unit_address = await primary_mysql.get_public_address()
 
     await rotate_credentials(
         primary_mysql, username=CLUSTER_ADMIN_USER, password=CLUSTER_ADMIN_PASSWORD

--- a/tests/integration/test_backup_ceph.py
+++ b/tests/integration/test_backup_ceph.py
@@ -20,7 +20,6 @@ from .helpers import (
     execute_queries_on_unit,
     get_primary_unit_wrapper,
     get_server_config_credentials,
-    get_unit_ip,
     rotate_credentials,
     scale_application,
 )
@@ -260,7 +259,7 @@ async def test_restore_on_same_cluster(
 
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
-    mysql_unit_address = await get_unit_ip(ops_test, mysql_unit.name)
+    mysql_unit_address = await mysql_unit.get_public_address()
     server_config_credentials = await get_server_config_credentials(mysql_unit)
 
     select_values_sql = [f"SELECT id FROM `{DATABASE_NAME}`.`{TABLE_NAME}`"]
@@ -333,7 +332,7 @@ async def test_restore_on_same_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_ip(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = await execute_queries_on_unit(
             unit_address,
@@ -381,7 +380,7 @@ async def test_restore_on_new_cluster(
 
     primary_mysql = ops_test.model.units[f"{new_mysql_application_name}/0"]
     assert primary_mysql
-    primary_unit_address = await get_unit_ip(ops_test, primary_mysql.name)
+    primary_unit_address = await primary_mysql.get_public_address()
 
     await rotate_credentials(
         primary_mysql, username=CLUSTER_ADMIN_USER, password=CLUSTER_ADMIN_PASSWORD

--- a/tests/integration/test_backup_gcp.py
+++ b/tests/integration/test_backup_gcp.py
@@ -16,7 +16,6 @@ from .helpers import (
     execute_queries_on_unit,
     get_primary_unit_wrapper,
     get_server_config_credentials,
-    get_unit_ip,
     rotate_credentials,
     scale_application,
 )
@@ -201,7 +200,7 @@ async def test_restore_on_same_cluster(
 
     mysql_unit = ops_test.model.units[f"{mysql_application_name}/0"]
     assert mysql_unit
-    mysql_unit_address = await get_unit_ip(ops_test, mysql_unit.name)
+    mysql_unit_address = await mysql_unit.get_public_address()
     server_config_credentials = await get_server_config_credentials(mysql_unit)
 
     select_values_sql = [f"SELECT id FROM `{DATABASE_NAME}`.`{TABLE_NAME}`"]
@@ -274,7 +273,7 @@ async def test_restore_on_same_cluster(
             timeout=TIMEOUT,
         )
 
-        unit_address = await get_unit_ip(ops_test, unit.name)
+        unit_address = await unit.get_public_address()
 
         values = await execute_queries_on_unit(
             unit_address,
@@ -322,7 +321,7 @@ async def test_restore_on_new_cluster(
 
     primary_mysql = ops_test.model.units[f"{new_mysql_application_name}/0"]
     assert primary_mysql
-    primary_unit_address = await get_unit_ip(ops_test, primary_mysql.name)
+    primary_unit_address = await primary_mysql.get_public_address()
 
     await rotate_credentials(
         primary_mysql, username=CLUSTER_ADMIN_USER, password=CLUSTER_ADMIN_PASSWORD

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -16,7 +16,6 @@ from .helpers import (
     app_name,
     get_system_user_password,
     get_tls_ca,
-    get_unit_ip,
     is_connection_possible,
     unit_file_md5,
 )
@@ -66,8 +65,7 @@ async def test_connection_before_tls(ops_test: OpsTest) -> None:
     # Before relating to TLS charm both encrypted and unencrypted connection should be possible
     logger.info("Asserting connections before relation")
     for unit in all_units:
-        unit_ip = await get_unit_ip(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = await unit.get_public_address()
 
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
@@ -106,8 +104,7 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
     # After relating to only encrypted connection should be possible
     logger.info("Asserting connections after relation")
     for unit in all_units:
-        unit_ip = await get_unit_ip(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = await unit.get_public_address()
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
         ), f"❌ Encrypted connection not possible to unit {unit.name} with enabled TLS"
@@ -166,8 +163,7 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
     # Asserting only encrypted connection should be possible
     logger.info("Asserting connections after relation")
     for unit in all_units:
-        unit_ip = await get_unit_ip(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = await unit.get_public_address()
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
         ), f"❌ Encrypted connection not possible to unit {unit.name} with enabled TLS"
@@ -193,8 +189,7 @@ async def test_disable_tls(ops_test: OpsTest) -> None:
 
     # After relation removal both encrypted and unencrypted connection should be possible
     for unit in all_units:
-        unit_ip = await get_unit_ip(ops_test, unit.name)
-        config["host"] = unit_ip
+        config["host"] = await unit.get_public_address()
         assert is_connection_possible(
             config, **{"ssl_disabled": False}
         ), f"❌ Encrypted connection not possible to unit {unit.name} after relation removal"


### PR DESCRIPTION
This PR removes the legacy `get_unit_ip` test helper, in order to rely on Juju's `get_public_address` method (see [source](https://github.com/juju/python-libjuju/blob/d61ea7dde28f41766a917fd818816d53aa73e8c2/juju/unit.py#L118-L131)).

Judging by GIT blame, the `get_unit_ip` helper was defined a long time ago, in 2022, probably in a time where the Juju library did not have a method to get the public address of a unit object. We should use the mechanisms that Juju natively provides in order to avoid doing something unexpected.