### PR TITLE
[MISC] Fix Juju Spaces lack of addresses

### DIFF
--- a/src/relations/mysql_provider.py
+++ b/src/relations/mysql_provider.py
@@ -157,6 +157,8 @@ class MySQLProvider(Object):
             relation_id (int): The id of the relation
             remote_app (str): The name of the remote application
         """
+        self.charm.update_endpoint_addresses()
+
         try:
             rw_endpoints, ro_endpoints, _ = self.charm.get_cluster_endpoints(DB_RELATION_NAME)
 


### PR DESCRIPTION
This PR fixes issue https://github.com/canonical/mysql-operator/issues/654 by updating the relation endpoints within the MySQL provider `_update_endpoints` [method](https://github.com/canonical/mysql-operator/blob/cb6707bc9ddef57629dea517155fd46bf0dab05f/src/relations/mysql_provider.py#L153-L178). This way, we ensure that the databag fields are set before accessing them in the `get_cluster_endpoints` method.

This approach is an alternative to moving the Juju Spaces addresses update to the `config_changed` hook, as that has proven challenging given current unit tests configuration.