### PR TITLE
Add redirects to new RTD slugs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -216,7 +216,7 @@ sitemap_show_lastmod = True
 
 # redirects = {}
 
-# rediraffe_redirects = "redirects.txt"
+rediraffe_redirects = "redirects.txt"
 
 ###########################
 # Link checker exceptions #
@@ -283,6 +283,7 @@ extensions = [
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
+    "sphinxext.rediraffe"
 ]
 
 # Excludes files or directories from processing

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,97 @@
+# The redirects.txt file stores all the redirects for the published docs
+# If you change a filename, move or delete a file, you need a redirect here.
+# - Comment lines start with a hash (#) and are ignored
+# - Each redirect should appear on its own line
+
+# We are using the dirhtml builder, so files are treated as directories:
+# - A file is built like `filename/index.html`, not `filename.html`
+# - *Do* include a trailing slash at the end of the path
+# - *Do not* include a file extension or you'll get errors
+# - Paths don't need a slash in front of them
+
+# Example:
+# redirect/from/file/ redirect/to/file/
+
+# Tutorial
+
+t-set-up/ tutorial/
+t-deploy/ tutorial/
+t-scale/ tutorial/
+t-manage-passwords/ tutorial/
+t-integrate/ tutorial/
+t-enable-tls/ tutorial/
+t-clean-up/ tutorial/
+
+# How-to guides
+
+h-deploy-sunbeam/ how-to/deploy/sunbeam
+h-deploy-lxd/ how-to/deploy/lxd
+h-deploy-maas/ how-to/deploy/maas
+h-deploy-ec2/ how-to/deploy/aws-ec2
+h-deploy-gce/ how-to/deploy/gce
+h-deploy-azure/ how-to/deploy/azure
+h-deploy-multi-az/ how-to/deploy/multi-az
+h-deploy-terraform/ how-to/deploy/terraform
+h-deploy-airgapped/ how-to/deploy/air-gapped
+h-deploy-spaces/ how-to/deploy/juju-spaces
+
+h-integrate/ how-to/integrate-with-another-application
+h-external-access/ how-to/external-network-access
+h-scale/ how-to/scale-replicas
+h-enable-tls/ how-to/enable-tls
+
+h-configure-s3-aws/ how-to/back-up-and-restore/configure-s3-aws
+h-configure-s3-radosgw/ how-to/back-up-and-restore/configure-s3-radosgw
+h-create-backup/ how-to/back-up-and-restore/create-a-backup
+h-restore-backup/ how-to/back-up-and-restore/restore-a-backup
+h-migrate-cluster/ how-to/back-up-and-restore/migrate-a-cluster
+
+h-enable-monitoring/ how-to/monitoring-cos/enable-monitoring
+h-enable-alert-rules/ how-to/monitoring-cos/enable-alert-rules
+h-enable-tracing/ how-to/monitoring-cos/enable-tracing
+
+h-upgrade/ how-to/upgrade/
+h-upgrade-juju/ how-to/upgrade/upgrade-juju
+h-upgrade-minor/ how-to/upgrade/perform-a-minor-upgrade
+h-rollback-minor/ how-to/upgrade/perform-a-minor-rollback
+
+h-async/ how-to/cross-regional-async-replication/
+h-async-deployment/ how-to/cross-regional-async-replication/deploy
+h-async-clients/ how-to/cross-regional-async-replication/clients
+h-async-failover/ how-to/cross-regional-async-replication/switchover-failover
+h-async-recovery/ how-to/cross-regional-async-replication/recovery
+h-async-removal/ how-to/cross-regional-async-replication/removal
+
+h-development-integrate/ how-to/development/integrate-with-your-charm
+h-migrate-mysqldump/ how-to/development/migrate-data-via-mysqldump
+h-migrate-mydumper/ how-to/development/migrate-data-via-mydumper
+h-migrate-backup-restore/ how-to/development/migrate-data-via-backup-restore
+
+h-troubleshooting/ reference/troubleshooting/
+h-contribute/ how-to/contribute
+
+# Reference
+
+r-releases/ reference/releases
+r-system-requirements/ reference/system-requirements
+r-testing/ reference/software-testing
+r-profiles/ reference/profiles
+r-plugins-extensions/ reference/plugins-extensions
+r-alert-rules/ reference/alert-rules
+r-statuses/ reference/charm-statuses
+r-contacts/ reference/contacts
+r-sos-report/ reference/troubleshooting/sos-report
+
+# Explanation
+
+e-architecture/ explanation/architecture
+e-interfaces-endpoints/ explanation/interfaces-and-endpoints
+e-juju/ explanation/juju
+e-legacy-charm/ explanation/legacy-charm
+e-users/ explanation/users
+
+e-logs/ explanation/logs/
+e-audit-logs/ explanation/logs/audit-logs
+
+e-security/ explanation/security/
+e-cryptography/ explanation/security/cryptography

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ packaging
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinxext-rediraffe


### PR DESCRIPTION
## Issue

The slugs/paths to each page are different from the slugs used in the Charmhub/Discourse documentation. This means that when the web team enables wildcard redirects from `charmhub.io/mysql-k8s/docs/*` to `canonical-charmed-mysql-k8s.readthedocs-hosted.com/*`, there will be a mismatch in most slugs and the redirects will fail.

## Solution

Enabled the rediraffe Sphinx extension and added a `redirects.txt` file that specifies the mapping between each Charmhub slug and its new RTD slug. 

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
