### PR TITLE
[DPE-7322] Tweak database DBA role naming

### DIFF
--- a/docs/explanation/roles.md
+++ b/docs/explanation/roles.md
@@ -53,12 +53,14 @@ Charmed MySQL also introduces database level roles, with permissions tied to eac
 Example for a database named `test`:
 
 ```text
-mysql> SELECT host, user FROM mysql.user WHERE user LIKE '%_test';
-+-----------+------------------+
-| host      | user             |
-+-----------+------------------+
-| %         | charmed_dba_test |
-+-----------+------------------+
+mysql> SELECT host, user FROM mysql.user WHERE user LIKE '%_test_%';
++-----------+---------------------+
+| host      | user                |
++-----------+---------------------+
+| %         | charmed_dba_test_00 |
++-----------+---------------------+
 ```
 
-The `charmed_dba_<database>` role contains every data and schema related permission, scoped to the database it references.
+The `charmed_dba_<database>_<num>` role contains every data and schema related permission, scoped to the database it references.
+The numeric part is introduced in order to differentiate across DBA roles whose first set of characters is the same,
+given that database names will be pruned in order to fit into the MySQL role length limit (32 characters).

--- a/tests/integration/roles/test_database_dba_role.py
+++ b/tests/integration/roles/test_database_dba_role.py
@@ -74,7 +74,7 @@ async def test_charmed_dba_role(ops_test: OpsTest):
 
     await ops_test.model.applications[f"{INTEGRATOR_APP_NAME}2"].set_config({
         "database-name": "throwaway",
-        "extra-user-roles": "charmed_dba_preserved",
+        "extra-user-roles": "charmed_dba_preserved_00",
     })
     await ops_test.model.add_relation(f"{INTEGRATOR_APP_NAME}2", DATABASE_APP_NAME)
     await ops_test.model.wait_for_idle(
@@ -143,4 +143,4 @@ async def test_charmed_dba_role(ops_test: OpsTest):
     assert sorted(rows) == sorted([
         "test_data_1",
         "test_data_2",
-    ]), "Unexpected data in preserved with charmed_dba_preserved role"
+    ]), "Unexpected data in preserved with charmed_dba_preserved_00 role"


### PR DESCRIPTION
This PR updates the database-level DBA role naming in order to lift the restriction of having database names limited to 20 characters (down from the 32 character limit that MySQL supports). The agreed approach is to append a two-digit number at the end of the DBA role name, in order to distinguish it from other DBA role whose first set of characters is the same. 

### Proposed approach

Paulo and I think that using the Juju relation ID is a bad idea. It will heavily trim the space dedicated to the, potentially pruned database name (as relation IDs are several digits long), and introduced consistency issues when relations get broken, and new relations targeting the same database are created.

Instead, we propose the simple approach of incrementing an implicit counter, dictated by the number of roles which the naming schema would collide with.