### PR TITLE
[DPE-7796] Tweak Terraform modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,22 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.2.1
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Install terraform
+        run: |
+          sudo snap install terraform --classic
+      - name: Install tox & poetry
+        run: |
+          pipx install tox
+          pipx install poetry
+      - name: Run linters
+        run: |
+          tox run -e lint
+          tox run -e lint-terraform
 
   unit-test:
     name: Unit test charm

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.py[cod]
 .coverage
 coverage.xml
+.terraform
+.terraform.lock.hcl
 .tox/
 .idea/
 .vscode/

--- a/docs/how-to/deploy/terraform.md
+++ b/docs/how-to/deploy/terraform.md
@@ -1,33 +1,30 @@
 
 # How to deploy using Terraform
 
-[Terraform](https://www.terraform.io/) is an infrastructure automation tool to provision and manage resources in clouds or data centers. To deploy Charmed MySQL using Terraform and Juju, you can use the [Juju Terraform Provider](https://registry.terraform.io/providers/juju/juju/latest). 
-
-The easiest way is to start from [these examples of terraform modules](https://github.com/canonical/terraform-modules) prepared by Canonical. This page will guide you through a deployment using an example module for MySQL on machines.
+[Terraform](https://www.terraform.io/) is an infrastructure automation tool to provision and manage resources in clouds or data centers.
+To deploy Charmed MySQL using Terraform and Juju, you can use the [Juju Terraform Provider](https://registry.terraform.io/providers/juju/juju/latest). 
 
 For an in-depth introduction to the Juju Terraform Provider, read [this Discourse post](https://discourse.charmhub.io/t/6939).
 
-```{note}
-Storage support was added in [Juju Terraform Provider version 0.13+](https://github.com/juju/terraform-provider-juju/releases/tag/v0.13.0).
-```
-
 ## Install Terraform tooling
 
-This guide assumes Juju is installed and you have an LXD controller already bootstrapped. For more information, check the [Charmed MySQL tutorial](/tutorial/index).
+This guide assumes Juju is installed, and you have an LXD controller already bootstrapped. For more information, check the [Charmed MySQL tutorial](/tutorial/index).
 
 Let's install Terraform Provider and example modules:
 ```shell
 sudo snap install terraform --classic
 ```
+
 Switch to the LXD provider and create a new model:
 ```shell
 juju switch lxd
 juju add-model my-model
 ```
-Clone examples and navigate to the MySQL machine module:
+
+Clone the MySQL operator repository and navigate to the terraform module:
 ```shell
-git clone https://github.com/canonical/terraform-modules.git
-cd terraform-modules/modules/machine/mysql
+git clone https://github.com/canonical/mysql-operator.git
+cd terraform
 ```
 
 Initialise the Juju Terraform Provider:
@@ -37,27 +34,10 @@ terraform init
 
 ## Verify the deployment
 
-Open the `main.tf` file to see the brief contents of the Terraform module:
-
-```tf
-resource "juju_application" "machine_mysql" {
-  name  = var.mysql_application_name
-  model = var.juju_model_name
-  trust = true
-
-  charm {
-    name    = "mysql"
-    channel = var.mysql_charm_channel
-  }
-
-  units = 1
-}
-```
-
-Run `terraform plan` to get a preview of the changes that will be made:
+Open the `main.tf` file to see the brief contents of the Terraform module, and run `terraform plan` to get a preview of the changes that will be made:
 
 ```shell
-terraform plan -var "juju_model_name=my-model"
+terraform plan -var "model_name=my-model"
 ```
 
 ## Apply the deployment
@@ -65,7 +45,7 @@ terraform plan -var "juju_model_name=my-model"
 If everything looks correct, deploy the resources (skip the approval):
 
 ```shell
-terraform apply -auto-approve -var "juju_model_name=my-model"
+terraform apply -auto-approve -var "model_name=my-model"
 ```
 
 ## Check deployment status
@@ -83,7 +63,7 @@ Model     Controller      Cloud/Region         Version  SLA          Timestamp
 my-model  lxd-controller  localhost/localhost  3.5.3    unsupported  12:49:34Z     
 
 App    Version          Status  Scale  Charm  Channel     Rev  Exposed  Message                                
-mysql  8.0.36-0ubun...  active      1  mysql  8.0/stable  240  no                                   
+mysql  8.0.41-0ubun...  active      1  mysql  8.0/stable  366  no                                   
 
 Unit      Workload  Agent  Machine  Public address  Ports           Message    
 mysql/0*  active    idle   0        10.101.248.225  3306,33060/tcp  Primary                           
@@ -96,22 +76,22 @@ Continue to operate the charm as usual from here or apply further Terraform chan
 
 ## Clean up
 
-To keep the house clean, remove the newly deployed Charmed MySQL by running
+To keep the house clean, remove the newly deployed MySQL charm by running
 ```shell
-terraform destroy -var "juju_model_name=my-model"
+terraform destroy -var "model_name=my-model"
 ```
 
 Sample output:
 ```shell
-juju_application.machine_mysql: Refreshing state... [id=my-model:mysql]
+juju_application.mysql_server: Refreshing state... [id=my-model:mysql]
 
 Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
   - destroy
 
 Terraform will perform the following actions:
 
-  # juju_application.machine_mysql will be destroyed
-  - resource "juju_application" "machine_mysql" {
+  # juju_application.mysql_server will be destroyed
+  - resource "juju_application" "mysql_server" {
       - constraints = "arch=amd64" -> null
       - id          = "my-model:mysql" -> null
       - model       = "my-model" -> null
@@ -122,7 +102,7 @@ Terraform will perform the following actions:
               - count = 1 -> null
               - label = "database" -> null
               - pool  = "rootfs" -> null
-              - size  = "99G" -> null
+              - size  = "10G" -> null
             },
         ] -> null
       - trust       = true -> null
@@ -132,7 +112,7 @@ Terraform will perform the following actions:
           - base     = "ubuntu@22.04" -> null
           - channel  = "8.0/stable" -> null
           - name     = "mysql" -> null
-          - revision = 240 -> null
+          - revision = 366 -> null
           - series   = "jammy" -> null
         }
     }
@@ -148,15 +128,12 @@ Do you really want to destroy all resources?
 
   Enter a value: yes
 
-juju_application.machine_mysql: Destroying... [id=my-model:mysql]
-juju_application.machine_mysql: Destruction complete after 0s
+juju_application.mysql_server: Destroying... [id=my-model:mysql]
+juju_application.mysql_server: Destruction complete after 0s
 
 Destroy complete! Resources: 1 destroyed.
 ```
+
 ---
-```{note}
-For more examples of Terraform modules for VM, see the other directories in the [`terraform-modules` repository](https://github.com/canonical/terraform-modules/tree/main/modules/machine).
-```
 
-Feel free to [contact us](/reference/contacts) if you have any question and [collaborate with us on GitHub](https://github.com/canonical/terraform-modules)!
-
+Feel free to [contact us](/reference/contacts) if you have any question and collaborate with us on GitHub!

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,19 +1,20 @@
-resource "juju_application" "machine_mysql" {
+resource "juju_application" "mysql_server" {
   name  = var.app_name
-  model = var.juju_model_name
+  model = var.model_name
 
   charm {
     name     = "mysql"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
-    base     = var.base
   }
 
   storage_directives = {
     database = var.storage_size
   }
 
-  units       = var.units
-  constraints = var.constraints
-  config      = var.config
+  config            = var.config
+  constraints       = var.constraints
+  endpoint_bindings = var.endpoint_bindings
+  units             = var.units
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,8 +1,10 @@
-output "application_name" {
-  value = juju_application.machine_mysql.name
+output "app_name" {
+  description = "Name of the MySQL Server VM application"
+  value       = juju_application.mysql_server.name
 }
 
 output "provides" {
+  description = "Map of all the provided endpoints"
   value = {
     database  = "database",
     cos_agent = "cos-agent",
@@ -10,8 +12,10 @@ output "provides" {
 }
 
 output "requires" {
+  description = "Map of all the required endpoints"
   value = {
     certificates  = "certificates"
     s3_parameters = "s3-parameters"
+    tracing       = "tracing"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,24 +1,12 @@
-variable "juju_model_name" {
-  description = "Juju model name"
+variable "model_name" {
+  description = "Juju model to deploy to"
   type        = string
 }
 
 variable "app_name" {
-  description = "Name of the application in the Juju model."
+  description = "Name of the juju application"
   type        = string
   default     = "mysql"
-}
-
-variable "channel" {
-  description = "Charm channel to use when deploying"
-  type        = string
-  default     = "8.0/stable"
-}
-
-variable "revision" {
-  description = "Revision number to deploy charm"
-  type        = number
-  default     = null
 }
 
 variable "base" {
@@ -27,16 +15,34 @@ variable "base" {
   default     = "ubuntu@22.04"
 }
 
-variable "units" {
-  description = "Number of units to deploy"
-  type        = number
-  default     = 1
+variable "config" {
+  description = "Application configuration. Details at https://charmhub.io/mysql/configurations"
+  type        = map(string)
+  default     = {}
 }
 
 variable "constraints" {
-  description = "Juju constraints to apply for this application."
+  description = "Juju constraints for the application"
   type        = string
   default     = "arch=amd64"
+}
+
+variable "channel" {
+  description = "Charm channel to deploy from"
+  type        = string
+  default     = "8.0/stable"
+}
+
+variable "revision" {
+  description = "Charm revision to deploy"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 3
 }
 
 variable "storage_size" {
@@ -45,8 +51,10 @@ variable "storage_size" {
   default     = "10G"
 }
 
-variable "config" {
-  description = "Application configuration. Details at https://charmhub.io/mysql/configurations"
-  type        = map(string)
-  default     = {}
+variable "endpoint_bindings" {
+  description = "Map of endpoint bindings"
+  type        = set(map(string))
+  default     = []
 }
+
+

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,9 +1,10 @@
 terraform {
   required_version = ">= 1.6.6"
+
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.20.0, < 1.0.0"
     }
   }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ env_list = lint, unit
 src_path = "{tox_root}/src"
 tests_path = "{tox_root}/tests"
 lib_path = "{tox_root}/lib/charms/mysql"
+terraform_path = "{tox_root}/terraform"
 all_path = {[vars]src_path} {[vars]tests_path} {[vars]lib_path}
 
 [testenv]
@@ -42,6 +43,16 @@ commands =
     poetry run ruff check {[vars]all_path}
     poetry run ruff format --check --diff {[vars]all_path}
     find {[vars]all_path} -type f \( -name "*.sh" -o -name "*.bash" \) -exec poetry run shellcheck --color=always \{\} +
+
+[testenv:lint-terraform]
+description = Check code against Terraform style standards
+allowlist_externals =
+    {[testenv]allowlist_externals}
+    terraform
+commands =
+    terraform fmt -check -diff -recursive {[vars]terraform_path}
+    terraform -chdir={[vars]terraform_path} init -backend=false
+    terraform -chdir={[vars]terraform_path} validate
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
This PR tweaks the Terraform modules of the MySQL Server VM substrate, following the[ CC006 specification](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit?tab=t.0), which outlines how to organize Terrraform variables and outputs at the _charm_ level.

From the list of optional input variables:
- [x] base
- [ ] expose
- [ ] resources
- [ ] machines
- [x] endpoint_bindings 
- [x] storage 
