### PR TITLE
[MISC] Data-replication Jubilant tests

### DIFF
--- a/tests/integration/high_availability/high_availability_helpers_new.py
+++ b/tests/integration/high_availability/high_availability_helpers_new.py
@@ -9,16 +9,44 @@ from collections.abc import Callable
 import jubilant_backports
 from jubilant_backports import Juju
 from jubilant_backports.statustypes import Status, UnitStatus
-from tenacity import Retrying, stop_after_delay, wait_fixed
+from tenacity import (
+    Retrying,
+    stop_after_delay,
+    wait_fixed,
+)
 
 from constants import SERVER_CONFIG_USERNAME
 
 from ..helpers import execute_queries_on_unit
 
 MINUTE_SECS = 60
+TEST_DATABASE_NAME = "testing"
 
 JujuModelStatusFn = Callable[[Status], bool]
 JujuAppsStatusFn = Callable[[Status, str], bool]
+
+
+def check_mysql_instances_online(juju: Juju, app_name: str) -> bool:
+    """Checks whether all MySQL cluster instances are online.
+
+    Args:
+        juju: The Juju instance
+        app_name: The name of the application
+    """
+    mysql_app_leader = get_app_leader(juju, app_name)
+    mysql_app_units = get_app_units(juju, app_name)
+
+    for attempt in Retrying(stop=stop_after_delay(10 * MINUTE_SECS), wait=wait_fixed(10)):
+        with attempt:
+            mysql_cluster_status = get_mysql_cluster_status(juju, mysql_app_leader)
+            mysql_cluster_topology = mysql_cluster_status["defaultreplicaset"]["topology"]
+            assert len(mysql_cluster_topology) == len(mysql_app_units)
+
+            for member in mysql_cluster_topology.values():
+                if member["status"] != "online":
+                    return False
+
+    return True
 
 
 async def check_mysql_units_writes_increment(
@@ -77,6 +105,33 @@ def get_app_units(juju: Juju, app_name: str) -> dict[str, UnitStatus]:
     return app_status.units
 
 
+def scale_app_units(juju: Juju, app_name: str, num_units: int) -> None:
+    """Scale a given application to a number of units."""
+    app_units = get_app_units(juju, app_name)
+    app_units_diff = len(app_units) - num_units
+
+    scale_func = None
+    if app_units_diff > 0:
+        scale_func = juju.remove_unit
+    if app_units_diff < 0:
+        scale_func = juju.add_unit
+    if app_units_diff == 0:
+        return
+
+    for _ in range(abs(app_units_diff)):
+        scale_func(app_name, num_units=1)
+
+    juju.wait(
+        ready=lambda status: len(status.apps[app_name].units) == num_units,
+        timeout=20 * MINUTE_SECS,
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, app_name),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
 def get_unit_by_number(juju: Juju, app_name: str, unit_number: int) -> str:
     """Get unit by number."""
     model_status = juju.status()
@@ -107,6 +162,17 @@ def get_unit_info(juju: Juju, unit_name: str) -> dict:
     )
 
     return json.loads(output)
+
+
+def get_unit_process_id(juju: Juju, unit_name: str, process_name: str) -> int | None:
+    """Return the pid of a process running in a given unit."""
+    try:
+        task = juju.exec(f"pgrep -x {process_name}", unit=unit_name)
+        task.raise_on_failure()
+
+        return int(task.stdout.strip())
+    except Exception:
+        return None
 
 
 def get_unit_status_log(juju: Juju, unit_name: str, log_lines: int = 0) -> list[dict]:
@@ -242,6 +308,111 @@ async def get_mysql_variable_value(
         [f"SELECT @@{variable_name};"],
     )
     return output[0]
+
+
+async def insert_mysql_test_data(juju: Juju, app_name: str, table_name: str, value: str) -> None:
+    """Insert data into the MySQL database.
+
+    Args:
+        juju: The Juju model.
+        app_name: The application name.
+        table_name: The database table name.
+        value: The value to insert.
+    """
+    mysql_leader = get_app_leader(juju, app_name)
+    mysql_primary = get_mysql_primary_unit(juju, app_name)
+
+    credentials_task = juju.run(
+        unit=mysql_leader,
+        action="get-password",
+        params={"username": SERVER_CONFIG_USERNAME},
+    )
+    credentials_task.raise_on_failure()
+
+    insert_queries = [
+        f"CREATE DATABASE IF NOT EXISTS `{TEST_DATABASE_NAME}`",
+        f"CREATE TABLE IF NOT EXISTS `{TEST_DATABASE_NAME}`.`{table_name}` (id VARCHAR(255), PRIMARY KEY (id))",
+        f"INSERT INTO `{TEST_DATABASE_NAME}`.`{table_name}` (id) VALUES ('{value}')",
+    ]
+
+    await execute_queries_on_unit(
+        get_unit_ip(juju, app_name, mysql_primary),
+        credentials_task.results["username"],
+        credentials_task.results["password"],
+        insert_queries,
+        commit=True,
+    )
+
+
+async def remove_mysql_test_data(juju: Juju, app_name: str, table_name: str) -> None:
+    """Remove data into the MySQL database.
+
+    Args:
+        juju: The Juju model.
+        app_name: The application name.
+        table_name: The database table name.
+    """
+    mysql_leader = get_app_leader(juju, app_name)
+    mysql_primary = get_mysql_primary_unit(juju, app_name)
+
+    credentials_task = juju.run(
+        unit=mysql_leader,
+        action="get-password",
+        params={"username": SERVER_CONFIG_USERNAME},
+    )
+    credentials_task.raise_on_failure()
+
+    remove_queries = [
+        f"DROP TABLE IF EXISTS `{TEST_DATABASE_NAME}`.`{table_name}`",
+        f"DROP DATABASE IF EXISTS `{TEST_DATABASE_NAME}`",
+    ]
+
+    await execute_queries_on_unit(
+        get_unit_ip(juju, app_name, mysql_primary),
+        credentials_task.results["username"],
+        credentials_task.results["password"],
+        remove_queries,
+        commit=True,
+    )
+
+
+async def verify_mysql_test_data(juju: Juju, app_name: str, table_name: str, value: str) -> None:
+    """Verifies data into the MySQL database.
+
+    Args:
+        juju: The Juju model.
+        app_name: The application name.
+        table_name: The database table name.
+        value: The value to check against.
+    """
+    mysql_app_leader = get_app_leader(juju, app_name)
+    mysql_app_units = get_app_units(juju, app_name)
+
+    credentials_task = juju.run(
+        unit=mysql_app_leader,
+        action="get-password",
+        params={"username": SERVER_CONFIG_USERNAME},
+    )
+    credentials_task.raise_on_failure()
+
+    select_queries = [
+        f"SELECT id FROM `{TEST_DATABASE_NAME}`.`{table_name}` WHERE id = '{value}'",
+    ]
+
+    for unit_name in mysql_app_units:
+        for attempt in Retrying(
+            reraise=True,
+            stop=stop_after_delay(5 * MINUTE_SECS),
+            wait=wait_fixed(10),
+        ):
+            with attempt:
+                output = await execute_queries_on_unit(
+                    get_unit_ip(juju, app_name, unit_name),
+                    credentials_task.results["username"],
+                    credentials_task.results["password"],
+                    select_queries,
+                )
+                assert output[0] == value
 
 
 def wait_for_apps_status(jubilant_status_func: JujuAppsStatusFn, *apps: str) -> JujuModelStatusFn:

--- a/tests/integration/high_availability/test_replication_data_consistency_new.py
+++ b/tests/integration/high_availability/test_replication_data_consistency_new.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant_backports
+import pytest
+from jubilant_backports import Juju
+
+from ..helpers import generate_random_string
+from .high_availability_helpers_new import (
+    check_mysql_units_writes_increment,
+    insert_mysql_test_data,
+    remove_mysql_test_data,
+    verify_mysql_test_data,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_consistent_data_replication_across_cluster(juju: Juju) -> None:
+    """Confirm that data is replicated from the primary node to all the replicas."""
+    table_name = "data"
+    table_value = generate_random_string(255)
+
+    await insert_mysql_test_data(juju, MYSQL_APP_NAME, table_name, table_value)
+    await verify_mysql_test_data(juju, MYSQL_APP_NAME, table_name, table_value)
+    await remove_mysql_test_data(juju, MYSQL_APP_NAME, table_name)
+
+    await check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)

--- a/tests/integration/high_availability/test_replication_data_isolation_new.py
+++ b/tests/integration/high_availability/test_replication_data_isolation_new.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant_backports
+import pytest
+from jubilant_backports import Juju
+
+from .high_availability_helpers_new import (
+    insert_mysql_test_data,
+    remove_mysql_test_data,
+    verify_mysql_test_data,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+async def test_cluster_data_isolation(juju: Juju, charm: str) -> None:
+    """Test for cluster data isolation.
+
+    This test creates a new cluster, create a new table on both cluster, write a single record with
+    the application name for each cluster, retrieve and compare these records, asserting they are
+    not the same.
+    """
+    mysql_main_app_name = f"{MYSQL_APP_NAME}"
+    mysql_other_app_name = f"{MYSQL_APP_NAME}-other"
+
+    juju.deploy(
+        charm=charm,
+        app=mysql_other_app_name,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=1,
+    )
+
+    logging.info("Wait for application to become active")
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, mysql_other_app_name),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+    table_name = "cluster_isolation_table"
+
+    for app_name in (mysql_main_app_name, mysql_other_app_name):
+        await insert_mysql_test_data(juju, app_name, table_name, f"{app_name}-value")
+    for app_name in (mysql_main_app_name, mysql_other_app_name):
+        await verify_mysql_test_data(juju, app_name, table_name, f"{app_name}-value")
+    for app_name in (mysql_main_app_name, mysql_other_app_name):
+        await remove_mysql_test_data(juju, app_name, table_name)
+
+    juju.remove_application(mysql_other_app_name, destroy_storage=True, force=True)

--- a/tests/integration/high_availability/test_replication_logs_rotation_new.py
+++ b/tests/integration/high_availability/test_replication_logs_rotation_new.py
@@ -1,0 +1,231 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import tempfile
+
+import jubilant
+import jubilant_backports
+import pytest
+from jubilant_backports import Juju
+from tenacity import (
+    Retrying,
+    stop_after_attempt,
+    wait_fixed,
+)
+
+from constants import CHARMED_MYSQL_COMMON_DIRECTORY
+
+from .high_availability_helpers_new import (
+    get_app_leader,
+    get_unit_process_id,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_log_rotation(juju: Juju) -> None:
+    """Test the log rotation of text files."""
+    log_types = ["error", "audit"]
+    log_files = ["error.log", "audit.log"]
+    archive_dirs = ["archive_error", "archive_audit"]
+
+    mysql_app_leader = get_app_leader(juju, MYSQL_APP_NAME)
+    mysql_logs_path = f"{CHARMED_MYSQL_COMMON_DIRECTORY}/var/log/mysql"
+
+    logging.info("Removing the cron file")
+    delete_unit_file(juju, mysql_app_leader, "/etc/cron.d/flush_mysql_logs")
+
+    logging.info("Stopping any running logrotate jobs")
+    stop_unit_flush_logs_job(juju, mysql_app_leader)
+
+    for log_type in log_types:
+        logging.info("Removing existing archive directories")
+        delete_unit_file(juju, mysql_app_leader, f"{mysql_logs_path}/archive_{log_type}")
+        logging.info("Writing some data to the text log files")
+        write_unit_file(juju, mysql_app_leader, f"{mysql_logs_path}/{log_type}.log", "content\n")
+
+    logging.info("Ensuring only log files exist")
+    log_files_listed = list_unit_files(juju, mysql_app_leader, mysql_logs_path)
+    log_dirs_listed = [line.split()[-1] for line in log_files_listed]
+
+    assert len(log_files_listed) == len(log_files)
+    assert sorted(log_dirs_listed) == sorted(log_files)
+
+    logging.info("Executing logrotate")
+    start_unit_flush_logs_job(juju, mysql_app_leader)
+
+    logging.info("Ensuring log files and archive directories exist")
+    log_files_listed = list_unit_files(juju, mysql_app_leader, mysql_logs_path)
+    log_dirs_listed = [line.split()[-1] for line in log_files_listed]
+
+    assert len(log_files_listed) == len(log_files + archive_dirs)
+    assert sorted(log_dirs_listed) == sorted(log_files + archive_dirs)
+
+    logging.info("Ensuring log files were rotated")
+    for log_type in log_types:
+        active_log_file_data = read_unit_file(
+            juju, mysql_app_leader, f"{mysql_logs_path}/{log_type}.log"
+        )
+        assert "content" not in active_log_file_data
+
+        archive_log_files_listed = list_unit_files(
+            juju, mysql_app_leader, f"{mysql_logs_path}/archive_{log_type}"
+        )
+        assert len(archive_log_files_listed) == 1
+
+        archive_log_file_name = archive_log_files_listed[0].split()[-1]
+        archive_log_file_data = read_unit_file(
+            juju, mysql_app_leader, f"{mysql_logs_path}/archive_{log_type}/{archive_log_file_name}"
+        )
+        assert "content" in archive_log_file_data
+
+
+def delete_unit_file(juju: Juju, unit: str, path: str) -> bool:
+    """Delete a path in the provided unit.
+
+    Args:
+        juju: The Juju instance
+        unit: The unit on which to delete the file
+        path: The path or file to delete
+    """
+    if path.strip() in ["/", "."]:
+        return False
+
+    try:
+        juju.exec(f"sudo find {path} -maxdepth 1 -delete", unit=unit)
+        return True
+    except (jubilant.TaskError, jubilant_backports.TaskError):
+        return False
+
+
+def list_unit_files(juju: Juju, unit: str, path: str) -> list[str]:
+    """Returns the list of files in the given path.
+
+    Args:
+        juju: The Juju instance
+        unit: The unit in which to list the files
+        path: The path at which to list the files
+    """
+    task = juju.exec(f"sudo ls -la {path}", unit=unit)
+    task.raise_on_failure()
+
+    output = task.stdout.split("\n")[1:]
+
+    return [
+        line.strip("\r")
+        for line in output
+        if len(line.strip()) > 0 and line.split()[-1] not in [".", ".."]
+    ]
+
+
+def read_unit_file(juju: Juju, unit: str, path: str) -> str:
+    """Read contents from file in the provided unit.
+
+    Args:
+        juju: The Juju instance
+        unit: The unit in which to read the file from
+        path: The path from which to read the data from
+    """
+    temp_path = "/tmp/file"
+
+    juju.exec(f"sudo cp {path} {temp_path}", unit=unit)
+    juju.exec(f"sudo chown ubuntu:ubuntu {temp_path}", unit=unit)
+
+    with tempfile.NamedTemporaryFile(mode="r+") as temp_file:
+        juju.scp(
+            f"{unit}:{temp_path}",
+            f"{unit}:{temp_file.name}",
+        )
+        contents = temp_file.read()
+
+    juju.exec(f"sudo rm {temp_path}", unit=unit)
+    return contents
+
+
+def write_unit_file(juju: Juju, unit: str, path: str, data: str) -> None:
+    """Write content to the file in the provided unit.
+
+    Args:
+        juju: The Juju instance
+        unit: The unit in which to write to file in
+        path: The path at which to write the data into
+        data: The data to write to the file.
+    """
+    temp_path = "/tmp/file"
+
+    with tempfile.NamedTemporaryFile(mode="w") as temp_file:
+        temp_file.write(data)
+        temp_file.flush()
+
+        juju.scp(
+            f"{unit}:{temp_file.name}",
+            f"{unit}:{temp_path}",
+        )
+
+    juju.exec(f"sudo mv {temp_path} {path}", unit=unit)
+    juju.exec(f"sudo chown snap_daemon:root {path}", unit=unit)
+
+
+def start_unit_flush_logs_job(juju: Juju, unit: str) -> None:
+    """Start running the logrotate job."""
+    juju.exec(
+        command="sudo logrotate -f /etc/logrotate.d/flush_mysql_logs",
+        unit=unit,
+    )
+
+
+def stop_unit_flush_logs_job(juju: Juju, unit: str) -> None:
+    """Stop running any logrotate jobs that may have been triggered by cron."""
+    juju.exec(
+        command="sudo pkill --signal SIGTERM -f logrotate -f /etc/logrotate.d/flush_mysql_logs",
+        unit=unit,
+    )
+
+    # Hold execution until process is stopped
+    for attempt in Retrying(stop=stop_after_attempt(45), wait=wait_fixed(2)):
+        with attempt:
+            if get_unit_process_id(juju, unit, "logrotate") is not None:
+                raise Exception("Failed to stop the flush_mysql_logs logrotate process")

--- a/tests/integration/high_availability/test_replication_reelection_new.py
+++ b/tests/integration/high_availability/test_replication_reelection_new.py
@@ -1,0 +1,100 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant_backports
+import pytest
+from jubilant_backports import Juju
+
+from ..helpers import generate_random_string
+from .high_availability_helpers_new import (
+    check_mysql_instances_online,
+    check_mysql_units_writes_increment,
+    get_mysql_primary_unit,
+    insert_mysql_test_data,
+    remove_mysql_test_data,
+    scale_app_units,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_kill_primary_check_reelection(juju: Juju) -> None:
+    """Confirm that a new primary is elected when the current primary is tear down."""
+    await check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+
+    mysql_old_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
+
+    # Destroy the primary unit to ensure that the juju status changed from active
+    logging.info("Killing the primary unit")
+    juju.remove_unit(mysql_old_primary)
+
+    juju.wait(
+        ready=lambda status: len(status.apps[MYSQL_APP_NAME].units) == 2,
+        timeout=20 * MINUTE_SECS,
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+    # Confirm that the new primary unit is different
+    mysql_new_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)
+    assert mysql_new_primary != mysql_old_primary, "Primary has not changed"
+
+    # Add the unit back and wait until it is active
+    logging.info("Scaling back to 3 units")
+    scale_app_units(juju, MYSQL_APP_NAME, 3)
+
+    # Retry until the killed pod is back online in the mysql cluster
+    assert check_mysql_instances_online(juju, MYSQL_APP_NAME)
+
+    table_name = "data"
+    table_value = generate_random_string(255)
+    await check_mysql_units_writes_increment(juju, MYSQL_APP_NAME)
+    await insert_mysql_test_data(juju, MYSQL_APP_NAME, table_name, table_value)
+    await remove_mysql_test_data(juju, MYSQL_APP_NAME, table_name)

--- a/tests/integration/high_availability/test_replication_scaling_new.py
+++ b/tests/integration/high_availability/test_replication_scaling_new.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant_backports
+import pytest
+from jubilant_backports import Juju
+
+from ..helpers import generate_random_string
+from .high_availability_helpers_new import (
+    get_app_units,
+    insert_mysql_test_data,
+    remove_mysql_test_data,
+    scale_app_units,
+    verify_mysql_test_data,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_scaling_without_data_loss(juju: Juju) -> None:
+    """Test that data is preserved during scale up and scale down."""
+    table_name = "instance_state_replication"
+    table_value = generate_random_string(255)
+
+    await insert_mysql_test_data(juju, MYSQL_APP_NAME, table_name, table_value)
+
+    mysql_app_old_units = set(get_app_units(juju, MYSQL_APP_NAME))
+    scale_app_units(juju, MYSQL_APP_NAME, 4)
+    mysql_app_new_units = set(get_app_units(juju, MYSQL_APP_NAME))
+
+    # Ensure that all units have the above inserted data
+    await verify_mysql_test_data(juju, MYSQL_APP_NAME, table_name, table_value)
+
+    mysql_app_added_unit = (mysql_app_new_units - mysql_app_old_units).pop()
+    juju.remove_unit(mysql_app_added_unit)
+    juju.wait(
+        ready=lambda status: len(status.apps[MYSQL_APP_NAME].units) == 3,
+        timeout=20 * MINUTE_SECS,
+    )
+    juju.wait(
+        ready=wait_for_apps_status(jubilant_backports.all_active, MYSQL_APP_NAME),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+    # Ensure that the data still exists in all the units
+    await verify_mysql_test_data(juju, MYSQL_APP_NAME, table_name, table_value)
+    await remove_mysql_test_data(juju, MYSQL_APP_NAME, table_name)

--- a/tests/integration/high_availability/test_replication_unit_endpoints_new.py
+++ b/tests/integration/high_availability/test_replication_unit_endpoints_new.py
@@ -1,0 +1,105 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import time
+
+import jubilant_backports
+import pytest
+import urllib3
+from jubilant_backports import Juju
+from tenacity import (
+    Retrying,
+    stop_after_attempt,
+    wait_fixed,
+)
+
+from constants import MONITORING_USERNAME, MYSQL_EXPORTER_PORT
+
+from .high_availability_helpers_new import (
+    get_app_units,
+    get_unit_ip,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_exporter_endpoints(juju: Juju) -> None:
+    """Test that endpoints are running."""
+    http = urllib3.PoolManager()
+
+    for unit in get_app_units(juju, MYSQL_APP_NAME):
+        task = juju.exec("sudo snap services charmed-mysql.mysqld-exporter", unit=unit)
+        task.raise_on_failure()
+
+        assert task.stdout.split("\n")[1].split()[2] == "inactive"
+
+        credentials_task = juju.run(
+            unit=unit,
+            action="get-password",
+            params={"username": MONITORING_USERNAME},
+        )
+        credentials_task.raise_on_failure()
+
+        username = credentials_task.results["username"]
+        password = credentials_task.results["password"]
+
+        juju.exec(f"sudo snap set charmed-mysql exporter.user={username}", unit=unit)
+        juju.exec(f"sudo snap set charmed-mysql exporter.password={password}", unit=unit)
+
+        for attempt in Retrying(stop=stop_after_attempt(45), wait=wait_fixed(2)):
+            with attempt:
+                task = juju.exec("sudo snap services charmed-mysql.mysqld-exporter", unit=unit)
+                task.raise_on_failure()
+
+        assert task.stdout.split("\n")[1].split()[2] == "active"
+
+        time.sleep(30)
+
+        mysql_unit_address = get_unit_ip(juju, MYSQL_APP_NAME, unit)
+        mysql_unit_exporter_url = f"http://{mysql_unit_address}:{MYSQL_EXPORTER_PORT}/metrics"
+        mysql_unit_response = http.request("GET", mysql_unit_exporter_url)
+
+        assert mysql_unit_response.status == 200

--- a/tests/integration/high_availability/test_replication_variables_new.py
+++ b/tests/integration/high_availability/test_replication_variables_new.py
@@ -1,0 +1,67 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import jubilant_backports
+import pytest
+from jubilant_backports import Juju
+
+from .high_availability_helpers_new import (
+    get_app_units,
+    get_mysql_variable_value,
+    wait_for_apps_status,
+)
+
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
+
+
+@pytest.mark.abort_on_fail
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_custom_variables(juju: Juju) -> None:
+    """Query database for custom variables."""
+    for unit in get_app_units(juju, MYSQL_APP_NAME):
+        custom_vars = {"max_connections": 100}
+
+        for k, v in custom_vars.items():
+            logging.info(f"Checking that {k} is set to {v} on {unit}")
+            assert await get_mysql_variable_value(juju, MYSQL_APP_NAME, unit, k) == v

--- a/tests/spread/test_replication_data_consistency_new.py/task.yaml
+++ b/tests/spread/test_replication_data_consistency_new.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_replication_data_consistency_new.py
+environment:
+  TEST_MODULE: high_availability/test_replication_data_consistency_new.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_replication_data_isolation_new.py/task.yaml
+++ b/tests/spread/test_replication_data_isolation_new.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_replication_data_isolation_new.py
+environment:
+  TEST_MODULE: high_availability/test_replication_data_isolation_new.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_replication_logs_rotation_new.py/task.yaml
+++ b/tests/spread/test_replication_logs_rotation_new.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_replication_logs_rotation_new.py
+environment:
+  TEST_MODULE: high_availability/test_replication_logs_rotation_new.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_replication_reelection_new.py/task.yaml
+++ b/tests/spread/test_replication_reelection_new.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_replication_reelection_new.py
+environment:
+  TEST_MODULE: high_availability/test_replication_reelection_new.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_replication_scaling_new.py/task.yaml
+++ b/tests/spread/test_replication_scaling_new.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_replication_scaling_new.py
+environment:
+  TEST_MODULE: high_availability/test_replication_scaling_new.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_replication_unit_endpoints_new.py/task.yaml
+++ b/tests/spread/test_replication_unit_endpoints_new.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_replication_unit_endpoints_new.py
+environment:
+  TEST_MODULE: high_availability/test_replication_unit_endpoints_new.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/test_replication_variables_new.py/task.yaml
+++ b/tests/spread/test_replication_variables_new.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_replication_variables_new.py
+environment:
+  TEST_MODULE: high_availability/test_replication_variables_new.py
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results


### PR DESCRIPTION
This PR refactors the _data-replication_ set of tests to Jubilant (JuJu 3 exclusive):

- _Data consistency_ tests, porting existing ones from [this file](https://github.com/canonical/mysql-operator/blob/main/tests/integration/high_availability/test_replication_data_consistency.py).
- _Data isolation_ tests, porting existing ones from [this file](https://github.com/canonical/mysql-operator/blob/main/tests/integration/high_availability/test_replication_data_isolation.py).
- _Logs rotation_ tests, porting existing ones from [this file](https://github.com/canonical/mysql-operator/blob/main/tests/integration/high_availability/test_replication_logs_rotation.py).
- _Re-election_ tests, porting existing ones from [this file](https://github.com/canonical/mysql-operator/blob/main/tests/integration/high_availability/test_replication_reelection.py).
- _Scaling_ tests, porting existing ones from [this file](https://github.com/canonical/mysql-operator/blob/main/tests/integration/high_availability/test_replication_scaling.py).
- _Unit endpoints_ tests, porting existing ones from [this file](https://github.com/canonical/mysql-operator/blob/main/tests/integration/high_availability/test_replication_unit_endpoints.py).
- _Variables_ tests, porting existing ones from [this file](https://github.com/canonical/mysql-operator/blob/main/tests/integration/high_availability/test_replication_variables.py).

---

The `new` suffix added to the file name containing the ported integration tests has been added to improve diff visibility on GitHub. Will be removed right before merging.

