### PR TITLE
[MISC] Bump Jubilant-backports to v1.4.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -974,34 +974,19 @@ files = [
 referencing = ">=0.28.0"
 
 [[package]]
-name = "jubilant"
+name = "jubilant-backports"
 version = "1.4.0"
 description = "Juju CLI wrapper for charm integration testing"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "jubilant-1.4.0-py3-none-any.whl", hash = "sha256:1df7eaf125fad8d0d3d35e6d83eca43bfbb7884debcd6c7f4b0822600e2a485c"},
-    {file = "jubilant-1.4.0.tar.gz", hash = "sha256:aa377699a8811fea29bfe0febb6b552d4593c02e666f5ba8c3fba24258700199"},
+    {file = "jubilant_backports-1.4.0-py3-none-any.whl", hash = "sha256:b5c2d9aca29b39543bbe45b3205e97dd22b60fca9f8e0e66885b71201f8127d5"},
+    {file = "jubilant_backports-1.4.0.tar.gz", hash = "sha256:0961645e67a08e85b3371d6c386795d254527d0c107a355ca24bdbca3872b671"},
 ]
 
 [package.dependencies]
 PyYAML = "==6.*"
-
-[[package]]
-name = "jubilant-backports"
-version = "1.0.0a1"
-description = "Extends Jubilant to include support for Juju 2.9"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "jubilant_backports-1.0.0a1-py3-none-any.whl", hash = "sha256:ff8d73e17afaae4418c588496978ac42ee9eb9d6d4e77ce103102772038796cc"},
-    {file = "jubilant_backports-1.0.0a1.tar.gz", hash = "sha256:03f0788a2301e1a71ebab56bc59515361c37e5686e40a985caba5b2907514e3f"},
-]
-
-[package.dependencies]
-jubilant = ">=1.2,<2.0"
 
 [[package]]
 name = "juju"
@@ -2537,4 +2522,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "8b0ec063b95e882f19e59ea53a211b1b432d249528d0c88bcd0aac9acbc87937"
+content-hash = "5b72d9ac2be134de1f8cf10d5dc56033a814d97baa4c315c9a901093abc2a09d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ pyyaml = "^6.0"
 urllib3 = "^2.0.0"
 allure-pytest = "^2.13.2"
 allure-pytest-default-results = "^0.1.2"
-jubilant-backports = "^1.0.0a1"
+jubilant-backports = "^1.4.0"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
This PR bumps the `jubilant-backports` package version to `1.4.0`, standardizing the API with its sibling package.

This PR is proposed manually, in order to have the `TaskError` wrapping flaw described in [this comment](https://github.com/canonical/mysql-k8s-operator/pull/661#issuecomment-3355968920) fixed, before porting any other high-availability tests to Jubilant.
