### PR TITLE
[MISC] Replace charmcraft-test by spread

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -23,19 +23,22 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up environment
         run: |
-          sudo snap install charmcraft --classic
-          pipx install tox poetry
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
+          pipx install tox
+          pipx install poetry
       - name: Collect spread jobs
         id: collect-jobs
         shell: python
         run: |
           import json
           import os
+          import pathlib
           import subprocess
 
           spread_jobs = (
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci:tests/spread/integration/"],
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci:tests/spread/integration/"],
                   capture_output=True,
                   check=True,
                   text=True,
@@ -107,10 +110,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up environment
         timeout-minutes: 5
-        run: sudo snap install charmcraft --classic
-      # TODO: remove when https://github.com/canonical/charmcraft/issues/2105 and
-      # https://github.com/canonical/charmcraft/issues/2130 fixed
-      - run: |
+        run: |
+          sudo snap install charmcraft --classic
           sudo snap install go --classic
           go install github.com/snapcore/spread/cmd/spread@latest
       - name: Download packed charm(s)
@@ -122,9 +123,6 @@ jobs:
       - name: Run spread job
         timeout-minutes: 180
         id: spread
-        # TODO: replace with `charmcraft test` when
-        # https://github.com/canonical/charmcraft/issues/2105 and
-        # https://github.com/canonical/charmcraft/issues/2130 fixed
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}

--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -23,19 +23,22 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up environment
         run: |
-          sudo snap install charmcraft --classic
-          pipx install tox poetry
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
+          pipx install tox
+          pipx install poetry
       - name: Collect spread jobs
         id: collect-jobs
         shell: python
         run: |
           import json
           import os
+          import pathlib
           import subprocess
 
           spread_jobs = (
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci:tests/spread/release/"],
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci:tests/spread/release/"],
                   capture_output=True,
                   check=True,
                   text=True,
@@ -107,10 +110,8 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up environment
         timeout-minutes: 5
-        run: sudo snap install charmcraft --classic
-      # TODO: remove when https://github.com/canonical/charmcraft/issues/2105 and
-      # https://github.com/canonical/charmcraft/issues/2130 fixed
-      - run: |
+        run: |
+          sudo snap install charmcraft --classic
           sudo snap install go --classic
           go install github.com/snapcore/spread/cmd/spread@latest
       - name: Download packed charm(s)
@@ -122,9 +123,6 @@ jobs:
       - name: Run spread job
         timeout-minutes: 180
         id: spread
-        # TODO: replace with `charmcraft test` when
-        # https://github.com/canonical/charmcraft/issues/2105 and
-        # https://github.com/canonical/charmcraft/issues/2130 fixed
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}


### PR DESCRIPTION
This PR replaces `charmcraft test` by `spread` when it comes to collecting the tests on CI.

This fixes compatibility with `charmcraft` 4.0.1+