### PR TITLE
Add optional flags to provides endpoints

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -32,8 +32,10 @@ peers:
 provides:
   database:
     interface: mysql_client
+    optional: false
   mysql:
     interface: mysql
+    optional: false
   db-router:
     interface: mysql-router
     optional: true

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,14 +36,18 @@ provides:
     interface: mysql
   db-router:
     interface: mysql-router
+    optional: true
   shared-db:
     interface: mysql-shared
+    optional: true
   cos-agent:
     interface: cos_agent
     limit: 1
+    optional: true
   replication-offer:
     interface: mysql_async
     limit: 1
+    optional: true
 
 requires:
   certificates:


### PR DESCRIPTION
Filed by @canonical/solutions-qa 

## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoint to indicate correct optionality.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
