### PR TITLE
[MISC] Cleanup integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 import os
 import uuid
 
@@ -8,6 +9,8 @@ import jubilant_backports
 import pytest
 
 from . import architecture
+
+logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/helpers_ha.py
+++ b/tests/integration/helpers_ha.py
@@ -185,8 +185,6 @@ def get_unit_process_id(juju: Juju, unit_name: str, process_name: str) -> int | 
     """Return the pid of a process running in a given unit."""
     try:
         task = juju.exec(f"pgrep -x {process_name}", unit=unit_name)
-        task.raise_on_failure()
-
         return int(task.stdout.strip())
     except Exception:
         return None
@@ -254,7 +252,6 @@ def get_mysql_cluster_status(juju: Juju, unit: str, cluster_set: bool = False) -
         params={"cluster-set": cluster_set},
         wait=5 * MINUTE_SECS,
     )
-    task.raise_on_failure()
 
     return task.results["status"]
 
@@ -302,7 +299,6 @@ def get_mysql_server_credentials(
         action="get-password",
         params={"username": username},
     )
-    credentials_task.raise_on_failure()
 
     return credentials_task.results
 
@@ -325,12 +321,11 @@ def rotate_mysql_server_credentials(
     if password is not None:
         params["password"] = password
 
-    rotate_task = juju.run(
+    juju.run(
         unit=unit_name,
         action="set-password",
         params=params,
     )
-    rotate_task.raise_on_failure()
 
 
 def get_legacy_mysql_credentials(
@@ -351,7 +346,6 @@ def get_legacy_mysql_credentials(
         action="get-legacy-mysql-credentials",
         params={"username": username},
     )
-    credentials_task.raise_on_failure()
 
     return credentials_task.results
 

--- a/tests/integration/integration/helpers_backups.py
+++ b/tests/integration/integration/helpers_backups.py
@@ -87,13 +87,11 @@ def build_and_deploy_operations(
     )
 
     logger.info("Rotating mysql credentials")
-    primary_unit_name = get_mysql_primary_unit(juju, MYSQL_APPLICATION_NAME)
-    credentials_task = juju.run(
-        unit=primary_unit_name,
+    juju.run(
+        unit=get_mysql_primary_unit(juju, MYSQL_APPLICATION_NAME),
         action="set-password",
         params={"username": SERVER_CONFIG_USERNAME, "password": SERVER_CONFIG_PASSWORD},
     )
-    credentials_task.raise_on_failure()
 
     logger.info("Configuring s3 integrator and integrating it with mysql")
     juju.wait(

--- a/tests/integration/integration/high_availability/conftest.py
+++ b/tests/integration/integration/high_availability/conftest.py
@@ -6,20 +6,10 @@ from collections.abc import Generator
 
 import pytest
 from jubilant_backports import Juju
-from pytest_operator.plugin import OpsTest
 
-from ...helpers_ha import (
-    get_app_leader,
-)
-from .high_availability_helpers import (
-    deploy_and_scale_application,
-    deploy_and_scale_mysql,
-    relate_mysql_and_application,
-)
+from ...helpers_ha import get_app_leader
 
 MYSQL_TEST_APP_NAME = "mysql-test-app"
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.fixture()
@@ -36,22 +26,3 @@ def continuous_writes(juju: Juju) -> Generator:
 
     logging.info("Clearing continuous writes")
     juju.run(test_app_leader, "clear-continuous-writes")
-
-
-@pytest.fixture()
-async def highly_available_cluster(ops_test: OpsTest, charm) -> None:
-    """Run the set up for high availability tests.
-
-    Args:
-        ops_test: The ops test framework
-    """
-    logger.info("Deploying mysql and scaling to 3 units")
-    mysql_application_name = await deploy_and_scale_mysql(ops_test, charm)
-
-    logger.info("Deploying mysql-test-app")
-    application_name = await deploy_and_scale_application(ops_test)
-
-    logger.info("Relating mysql with mysql-test-app")
-    await relate_mysql_and_application(ops_test, mysql_application_name, application_name)
-
-    yield

--- a/tests/integration/integration/high_availability/test_async_replication.py
+++ b/tests/integration/integration/high_availability/test_async_replication.py
@@ -183,12 +183,11 @@ def test_create_replication(first_model: str, second_model: str) -> None:
     model_2 = Juju(model=second_model)
 
     logging.info("Running create replication action")
-    task = model_1.run(
+    model_1.run(
         unit=get_app_leader(model_1, MYSQL_APP_1),
         action="create-replication",
         wait=5 * MINUTE_SECS,
     )
-    task.raise_on_failure()
 
     logging.info("Waiting for the applications to settle")
     model_1.wait(
@@ -221,12 +220,11 @@ async def test_standby_promotion(first_model: str, second_model: str, continuous
     model_2_mysql_leader = get_app_leader(model_2, MYSQL_APP_2)
 
     logging.info("Promoting standby cluster to primary")
-    promotion_task = model_2.run(
+    model_2.run(
         unit=model_2_mysql_leader,
         action="promote-to-primary",
         params={"scope": "cluster"},
     )
-    promotion_task.raise_on_failure()
 
     results = await get_mysql_max_written_values(first_model, second_model)
     assert len(results) == 6
@@ -260,13 +258,12 @@ def test_failover(first_model: str, second_model: str) -> None:
     model_1 = Juju(model=first_model)
     model_1_mysql_leader = get_app_leader(model_1, MYSQL_APP_1)
 
-    promotion_task = model_1.run(
+    model_1.run(
         unit=model_1_mysql_leader,
         action="promote-to-primary",
         params={"scope": "cluster", "force": True},
         wait=5 * MINUTE_SECS,
     )
-    promotion_task.raise_on_failure()
 
     # Restore mysqld process
     logging.info("Unfreezing mysqld on primary cluster units")
@@ -295,15 +292,12 @@ async def test_rejoin_invalidated_cluster(
 ) -> None:
     """Test rejoin invalidated cluster with."""
     model_1 = Juju(model=first_model)
-    model_1_mysql_leader = get_app_leader(model_1, MYSQL_APP_1)
-
-    task = model_1.run(
-        unit=model_1_mysql_leader,
+    model_1.run(
+        unit=get_app_leader(model_1, MYSQL_APP_1),
         action="rejoin-cluster",
         params={"cluster-name": "cuzco"},
         wait=5 * MINUTE_SECS,
     )
-    task.raise_on_failure()
 
     results = await get_mysql_max_written_values(first_model, second_model)
     assert len(results) == 6
@@ -345,12 +339,11 @@ async def test_unrelate_and_relate(first_model: str, second_model: str, continuo
     )
 
     logging.info("Running create replication action")
-    task = model_1.run(
+    model_1.run(
         unit=get_app_leader(model_1, MYSQL_APP_1),
         action="create-replication",
         wait=5 * MINUTE_SECS,
     )
-    task.raise_on_failure()
 
     logging.info("Waiting for the applications to settle")
     model_1.wait(
@@ -374,12 +367,11 @@ async def get_mysql_max_written_values(first_model: str, second_model: str) -> l
     model_2 = Juju(model=second_model)
 
     logging.info("Stopping continuous writes")
-    stopping_task = model_1.run(
+    model_1.run(
         unit=get_app_leader(model_1, MYSQL_TEST_APP_NAME),
         action="stop-continuous-writes",
         params={},
     )
-    stopping_task.raise_on_failure()
 
     time.sleep(5)
     results = []

--- a/tests/integration/integration/high_availability/test_async_replication.py
+++ b/tests/integration/integration/high_availability/test_async_replication.py
@@ -27,8 +27,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.fixture(scope="module")
 def first_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:

--- a/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -171,12 +171,11 @@ def test_create_replication(first_model: str, second_model: str) -> None:
     model_2 = Juju(model=second_model)
 
     logging.info("Running create replication action")
-    task = model_1.run(
+    model_1.run(
         unit=get_app_leader(model_1, MYSQL_APP_1),
         action="create-replication",
         wait=5 * MINUTE_SECS,
     )
-    task.raise_on_failure()
 
     logging.info("Waiting for the applications to settle")
     model_1.wait(
@@ -223,12 +222,11 @@ async def get_mysql_max_written_values(first_model: str, second_model: str) -> l
     model_2 = Juju(model=second_model)
 
     logging.info("Stopping continuous writes")
-    stopping_task = model_1.run(
+    model_1.run(
         unit=get_app_leader(model_1, MYSQL_TEST_APP_NAME),
         action="stop-continuous-writes",
         params={},
     )
-    stopping_task.raise_on_failure()
 
     time.sleep(5)
     results = []
@@ -252,8 +250,7 @@ async def run_pre_upgrade_checks(juju: Juju, app_name: str) -> None:
     app_units = get_app_units(juju, app_name)
 
     logging.info("Run pre-upgrade-check action")
-    task = juju.run(unit=app_leader, action="pre-upgrade-check")
-    task.raise_on_failure()
+    juju.run(unit=app_leader, action="pre-upgrade-check")
 
     logging.info("Assert slow shutdown is enabled")
     for unit_name in app_units:

--- a/tests/integration/integration/high_availability/test_async_replication_upgrade.py
+++ b/tests/integration/integration/high_availability/test_async_replication_upgrade.py
@@ -28,8 +28,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.fixture(scope="module")
 def first_model(juju: Juju, request: pytest.FixtureRequest) -> Generator:

--- a/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -2,22 +2,65 @@
 # See LICENSE file for licensing details.
 
 import logging
-from subprocess import run
+import subprocess
 
+import jubilant_backports
 import pytest
-from jubilant_backports import Juju, all_active
+from jubilant_backports import Juju
 
 from ...helpers_ha import (
     get_app_name,
     get_app_units,
     get_mysql_primary_unit,
+    update_interval,
+    wait_for_apps_status,
     wait_for_unit_message,
     wait_for_unit_status,
 )
 
+MYSQL_APP_NAME = "mysql"
+MYSQL_TEST_APP_NAME = "mysql-test-app"
+
+MINUTE_SECS = 60
+
 
 @pytest.mark.abort_on_fail
-def test_cluster_switchover(juju: Juju, highly_available_cluster) -> None:
+def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:
+    """Simple test to ensure that the MySQL and application charms get deployed."""
+    logging.info("Deploying MySQL cluster")
+    juju.deploy(
+        charm=charm,
+        app=MYSQL_APP_NAME,
+        base="ubuntu@22.04",
+        config={"profile": "testing"},
+        num_units=3,
+    )
+    juju.deploy(
+        charm=MYSQL_TEST_APP_NAME,
+        app=MYSQL_TEST_APP_NAME,
+        base="ubuntu@22.04",
+        channel="latest/edge",
+        config={"sleep_interval": 500},
+        num_units=1,
+    )
+
+    juju.integrate(
+        f"{MYSQL_APP_NAME}:database",
+        f"{MYSQL_TEST_APP_NAME}:database",
+    )
+
+    logging.info("Wait for applications to become active")
+    juju.wait(
+        ready=wait_for_apps_status(
+            jubilant_backports.all_active, MYSQL_APP_NAME, MYSQL_TEST_APP_NAME
+        ),
+        error=jubilant_backports.any_blocked,
+        timeout=20 * MINUTE_SECS,
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_cluster_switchover(juju: Juju) -> None:
     """Test that the primary node can be switched over."""
     logging.info("Testing cluster switchover...")
     app_name = get_app_name(juju, "mysql")
@@ -45,7 +88,7 @@ def test_cluster_switchover(juju: Juju, highly_available_cluster) -> None:
 
 
 @pytest.mark.abort_on_fail
-def test_cluster_failover_after_majority_loss(juju: Juju, highly_available_cluster) -> None:
+def test_cluster_failover_after_majority_loss(juju: Juju) -> None:
     """Test the promote-to-primary command after losing the majority of nodes, with force flag."""
     app_name = get_app_name(juju, "mysql")
     assert app_name, "MySQL application not found in the cluster"
@@ -69,19 +112,19 @@ def test_cluster_failover_after_majority_loss(juju: Juju, highly_available_clust
     for unit in units_to_kill:
         machine_name.append(get_unit_machine(juju, app_name, unit))
 
-    run(["lxc", "restart", "--force", machine_name[0], machine_name[1]], check=True)
+    subprocess.run(["lxc", "restart", "--force", machine_name[0], machine_name[1]], check=True)
 
-    juju.model_config({"update-status-hook-interval": "45s"})
-    logging.info("Waiting to settle in error state")
-    juju.wait(
-        ready=lambda status: all((
-            wait_for_unit_status(app_name, unit_to_promote, "active")(status),
-            wait_for_unit_message(app_name, units_to_kill[0], "offline")(status),
-            wait_for_unit_message(app_name, units_to_kill[1], "offline")(status),
-        )),
-        timeout=60 * 15,
-        delay=15,
-    )
+    with update_interval(juju, "45s"):
+        logging.info("Waiting to settle in error state")
+        juju.wait(
+            ready=lambda status: all((
+                wait_for_unit_status(app_name, unit_to_promote, "active")(status),
+                wait_for_unit_message(app_name, units_to_kill[0], "offline")(status),
+                wait_for_unit_message(app_name, units_to_kill[1], "offline")(status),
+            )),
+            timeout=15 * MINUTE_SECS,
+            delay=15,
+        )
 
     juju.run(
         unit=unit_to_promote,
@@ -90,9 +133,13 @@ def test_cluster_failover_after_majority_loss(juju: Juju, highly_available_clust
         wait=600,
     )
 
-    juju.model_config({"update-status-hook-interval": "15s"})
-    logging.info("Waiting for all units to become active after switchover...")
-    juju.wait(all_active, timeout=60 * 10, delay=5)
+    with update_interval(juju, "15s"):
+        logging.info("Waiting for all units to become active after switchover...")
+        juju.wait(
+            ready=jubilant_backports.all_active,
+            timeout=10 * MINUTE_SECS,
+            delay=5,
+        )
 
     assert get_mysql_primary_unit(juju, app_name) == unit_to_promote, "Failover failed"
 

--- a/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -15,8 +15,6 @@ from ...helpers_ha import (
     wait_for_unit_status,
 )
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_cluster_switchover(juju: Juju, highly_available_cluster) -> None:

--- a/tests/integration/integration/high_availability/test_primary_switchover.py
+++ b/tests/integration/integration/high_availability/test_primary_switchover.py
@@ -37,8 +37,11 @@ def test_cluster_switchover(juju: Juju, highly_available_cluster) -> None:
     new_primary_unit = app_units.pop()
     logging.info(f"New primary unit selected: {new_primary_unit}")
 
-    switchover_task = juju.run(new_primary_unit, "promote-to-primary", {"scope": "unit"})
-    assert switchover_task.status == "completed", "Switchover failed"
+    juju.run(
+        unit=new_primary_unit,
+        action="promote-to-primary",
+        params={"scope": "unit"},
+    )
 
     assert get_mysql_primary_unit(juju, app_name) == new_primary_unit, "Switchover failed"
 
@@ -82,16 +85,14 @@ def test_cluster_failover_after_majority_loss(juju: Juju, highly_available_clust
         delay=15,
     )
 
-    failover_task = juju.run(
-        unit_to_promote,
-        "promote-to-primary",
-        {"scope": "unit", "force": True},
+    juju.run(
+        unit=unit_to_promote,
+        action="promote-to-primary",
+        params={"scope": "unit", "force": True},
         wait=600,
     )
 
     juju.model_config({"update-status-hook-interval": "15s"})
-
-    assert failover_task.status == "completed", "Switchover failed"
     logging.info("Waiting for all units to become active after switchover...")
     juju.wait(all_active, timeout=60 * 10, delay=5)
 

--- a/tests/integration/integration/high_availability/test_replication_data_consistency.py
+++ b/tests/integration/integration/high_availability/test_replication_data_consistency.py
@@ -21,8 +21,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_replication_data_isolation.py
+++ b/tests/integration/integration/high_availability/test_replication_data_isolation.py
@@ -20,8 +20,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -27,8 +27,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_replication_logs_rotation.py
+++ b/tests/integration/integration/high_availability/test_replication_logs_rotation.py
@@ -146,8 +146,7 @@ def delete_unit_file(juju: Juju, unit_name: str, file_path: str) -> None:
     if file_path.strip() in ["/", "."]:
         return
 
-    task = juju.exec(f"sudo find {file_path} -maxdepth 1 -delete", unit=unit_name)
-    task.raise_on_failure()
+    juju.exec(f"sudo find {file_path} -maxdepth 1 -delete", unit=unit_name)
 
 
 def list_unit_files(juju: Juju, unit_name: str, file_path: str) -> list[str]:
@@ -159,8 +158,6 @@ def list_unit_files(juju: Juju, unit_name: str, file_path: str) -> list[str]:
         file_path: The path at which to list the files
     """
     task = juju.exec(f"sudo ls -la {file_path}", unit=unit_name)
-    task.raise_on_failure()
-
     output = task.stdout.split("\n")[1:]
 
     return [

--- a/tests/integration/integration/high_availability/test_replication_reelection.py
+++ b/tests/integration/integration/high_availability/test_replication_reelection.py
@@ -23,8 +23,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_replication_scaling.py
+++ b/tests/integration/integration/high_availability/test_replication_scaling.py
@@ -22,8 +22,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -32,8 +32,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
+++ b/tests/integration/integration/high_availability/test_replication_unit_endpoints.py
@@ -78,7 +78,6 @@ def test_exporter_endpoints(juju: Juju) -> None:
 
     for unit_name in get_app_units(juju, MYSQL_APP_NAME):
         task = juju.exec(f"sudo snap services {service_name}", unit=unit_name)
-        task.raise_on_failure()
 
         assert task.stdout.split("\n")[1].split()[2] == "inactive"
 
@@ -87,7 +86,6 @@ def test_exporter_endpoints(juju: Juju) -> None:
             action="get-password",
             params={"username": MONITORING_USERNAME},
         )
-        credentials_task.raise_on_failure()
 
         username = credentials_task.results["username"]
         password = credentials_task.results["password"]
@@ -99,7 +97,6 @@ def test_exporter_endpoints(juju: Juju) -> None:
         for attempt in Retrying(stop=stop_after_attempt(45), wait=wait_fixed(2)):
             with attempt:
                 task = juju.exec(f"sudo snap services {service_name}", unit=unit_name)
-                task.raise_on_failure()
 
         assert task.stdout.split("\n")[1].split()[2] == "active"
 

--- a/tests/integration/integration/high_availability/test_replication_variables.py
+++ b/tests/integration/integration/high_availability/test_replication_variables.py
@@ -18,8 +18,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -95,7 +95,6 @@ async def test_network_cut(juju: Juju, continuous_writes) -> None:
         action="get-password",
         params={"username": CLUSTER_ADMIN_USERNAME},
     )
-    credentials_task.raise_on_failure()
 
     config = {
         "username": credentials_task.results["username"],
@@ -198,9 +197,9 @@ def get_controller_hostname(juju: Juju) -> str:
 def get_unit_hostname(juju: Juju, app_name: str, unit_name: str) -> str:
     """Get hostname for a unit."""
     task = juju.exec("hostname", unit=unit_name)
-    task.raise_on_failure()
+    output = task.stdout.strip()
 
-    return task.stdout.strip()
+    return output
 
 
 @retry(stop=stop_after_attempt(20), wait=wait_fixed(15))
@@ -213,8 +212,8 @@ def wait_for_unit_network(juju: Juju, app_name: str, unit_name: str) -> None:
         unit_name: The name of the unit
     """
     task = juju.exec("ip address", unit=unit_name)
-    task.raise_on_failure()
+    output = task.stdout.strip()
 
     unit_ip = get_unit_ip(juju, app_name, unit_name)
-    if unit_ip in task.stdout:
+    if unit_ip in output:
         raise Exception()

--- a/tests/integration/integration/high_availability/test_self_healing_network_cut.py
+++ b/tests/integration/integration/high_availability/test_self_healing_network_cut.py
@@ -38,8 +38,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -31,8 +31,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
+++ b/tests/integration/integration/high_availability/test_self_healing_process_frozen.py
@@ -88,7 +88,6 @@ async def test_freeze_db_process(juju: Juju, continuous_writes) -> None:
         action="get-password",
         params={"username": CLUSTER_ADMIN_USERNAME},
     )
-    credentials_task.raise_on_failure()
 
     config = {
         "username": credentials_task.results["username"],

--- a/tests/integration/integration/high_availability/test_self_healing_process_killed.py
+++ b/tests/integration/integration/high_availability/test_self_healing_process_killed.py
@@ -25,8 +25,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
+++ b/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
@@ -142,7 +142,6 @@ async def purge_mysql_binary_logs(juju: Juju, app_name: str, unit_name: str) -> 
         action="get-password",
         params={"username": SERVER_CONFIG_USERNAME},
     )
-    credentials_task.raise_on_failure()
 
     await execute_queries_on_unit(
         unit_address=get_unit_ip(juju, app_name, unit_name),

--- a/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
+++ b/tests/integration/integration/high_availability/test_self_healing_restart_forceful.py
@@ -32,8 +32,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -81,7 +81,6 @@ async def test_cluster_manual_rejoin(juju: Juju, continuous_writes) -> None:
         action="get-password",
         params={"username": SERVER_CONFIG_USERNAME},
     )
-    credentials_task.raise_on_failure()
 
     config = {
         "username": credentials_task.results["username"],

--- a/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
+++ b/tests/integration/integration/high_availability/test_self_healing_restart_graceful.py
@@ -26,8 +26,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_stop_all.py
+++ b/tests/integration/integration/high_availability/test_self_healing_stop_all.py
@@ -32,8 +32,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -34,8 +34,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_highly_available_cluster(juju: Juju, charm: str) -> None:

--- a/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
+++ b/tests/integration/integration/high_availability/test_self_healing_stop_primary.py
@@ -87,7 +87,6 @@ async def test_replicate_data_on_restart(juju: Juju, continuous_writes) -> None:
         action="get-password",
         params={"username": CLUSTER_ADMIN_USERNAME},
     )
-    credentials_task.raise_on_failure()
 
     config = {
         "username": credentials_task.results["username"],
@@ -151,7 +150,6 @@ async def insert_mysql_test_data(
         action="get-password",
         params={"username": SERVER_CONFIG_USERNAME},
     )
-    credentials_task.raise_on_failure()
 
     insert_queries = [
         f"CREATE DATABASE IF NOT EXISTS `{TEST_DATABASE_NAME}`",

--- a/tests/integration/integration/high_availability/test_upgrade.py
+++ b/tests/integration/integration/high_availability/test_upgrade.py
@@ -26,8 +26,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_latest(juju: Juju) -> None:

--- a/tests/integration/integration/high_availability/test_upgrade.py
+++ b/tests/integration/integration/high_availability/test_upgrade.py
@@ -71,8 +71,7 @@ async def test_pre_upgrade_check(juju: Juju) -> None:
     mysql_units = get_app_units(juju, MYSQL_APP_NAME)
 
     logging.info("Run pre-upgrade-check action")
-    task = juju.run(unit=mysql_leader, action="pre-upgrade-check")
-    task.raise_on_failure()
+    juju.run(unit=mysql_leader, action="pre-upgrade-check")
 
     logging.info("Assert slow shutdown is enabled")
     for unit_name in mysql_units:
@@ -118,8 +117,7 @@ async def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> N
     mysql_app_units = get_app_units(juju, MYSQL_APP_NAME)
 
     logging.info("Run pre-upgrade-check action")
-    task = juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
-    task.raise_on_failure()
+    juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
 
     tmp_folder = Path("tmp")
     tmp_folder.mkdir(exist_ok=True)
@@ -143,8 +141,7 @@ async def test_fail_and_rollback(juju: Juju, charm: str, continuous_writes) -> N
     await check_mysql_units_writes_increment(juju, MYSQL_APP_NAME, mysql_app_units)
 
     logging.info("Re-run pre-upgrade-check action")
-    task = juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
-    task.raise_on_failure()
+    juju.run(unit=mysql_app_leader, action="pre-upgrade-check")
 
     logging.info("Re-refresh the charm")
     juju.refresh(app=MYSQL_APP_NAME, path=charm)

--- a/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -29,8 +29,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
 # (details: https://github.com/canonical/mysql-operator/pull/472#discussion_r1659300069)

--- a/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
+++ b/tests/integration/integration/high_availability/test_upgrade_rollback_incompat.py
@@ -94,8 +94,7 @@ async def test_pre_upgrade_check(juju: Juju) -> None:
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
 
     logging.info("Run pre-upgrade-check action")
-    task = juju.run(unit=mysql_leader, action="pre-upgrade-check")
-    task.raise_on_failure()
+    juju.run(unit=mysql_leader, action="pre-upgrade-check")
 
 
 # TODO: remove AMD64 marker after next incompatible MySQL server version is released in our snap
@@ -162,8 +161,7 @@ async def test_rollback(juju: Juju, charm: str, continuous_writes) -> None:
     time.sleep(10)
 
     logging.info("Run pre-upgrade-check action")
-    task = juju.run(unit=mysql_leader, action="pre-upgrade-check")
-    task.raise_on_failure()
+    juju.run(unit=mysql_leader, action="pre-upgrade-check")
 
     time.sleep(20)
 

--- a/tests/integration/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
+++ b/tests/integration/integration/high_availability/test_upgrade_skip_pre_upgrade_check.py
@@ -19,8 +19,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 def test_deploy_stable(juju: Juju) -> None:

--- a/tests/integration/integration/relations/test_database.py
+++ b/tests/integration/integration/relations/test_database.py
@@ -269,9 +269,8 @@ def rotate_mysql_server_credentials(
     if password is not None:
         params["password"] = password
 
-    rotate_task = juju.run(
+    juju.run(
         unit=unit_name,
         action="set-password",
         params=params,
     )
-    rotate_task.raise_on_failure()

--- a/tests/integration/integration/relations/test_database.py
+++ b/tests/integration/integration/relations/test_database.py
@@ -37,8 +37,6 @@ APPS = [DATABASE_APP_NAME, APPLICATION_APP_NAME]
 ENDPOINT = "database"
 TIMEOUT = 15 * MINUTE_SECS
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/integration/integration/relations/test_db_router.py
+++ b/tests/integration/integration/relations/test_db_router.py
@@ -31,8 +31,6 @@ ANOTHER_KEYSTONE_MYSQLROUTER_APP_NAME = "another-keystone-mysql-router"
 SLOW_WAIT_TIMEOUT = 45 * 60
 FAST_WAIT_TIMEOUT = 30 * 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 async def test_keystone_bundle_db_router(juju: Juju, charm) -> None:

--- a/tests/integration/integration/relations/test_relation_mysql_legacy.py
+++ b/tests/integration/integration/relations/test_relation_mysql_legacy.py
@@ -30,8 +30,6 @@ TEST_USER = "testuser"
 TEST_DATABASE = "continuous_writes"
 TIMEOUT = 15 * 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/integration/integration/relations/test_shared_db.py
+++ b/tests/integration/integration/relations/test_shared_db.py
@@ -31,8 +31,6 @@ ANOTHER_KEYSTONE_APP_NAME = "another-keystone"
 SLOW_WAIT_TIMEOUT = 25 * 60
 FAST_WAIT_TIMEOUT = 15 * 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 async def test_keystone_bundle_shared_db(juju: Juju, charm) -> None:

--- a/tests/integration/integration/roles/test_database_dba_role.py
+++ b/tests/integration/integration/roles/test_database_dba_role.py
@@ -25,8 +25,6 @@ INTEGRATOR_APP_NAME = "data-integrator"
 
 TIMEOUT = 15 * MINUTE_SECS
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/integration/integration/roles/test_database_dba_role.py
+++ b/tests/integration/integration/roles/test_database_dba_role.py
@@ -94,15 +94,13 @@ async def test_charmed_dba_role(juju: Juju):
 
     data_integrator_2_unit = get_app_units(juju, f"{INTEGRATOR_APP_NAME}2")[0]
     task = juju.run(unit=data_integrator_2_unit, action="get-credentials")
-    task.raise_on_failure()
-    results = task.results
 
     logger.info("Checking that the database-level DBA role cannot create new databases")
     with pytest.raises(ProgrammingError):
         await execute_queries_on_unit(
             primary_unit_address,
-            results["mysql"]["username"],
-            results["mysql"]["password"],
+            task.results["mysql"]["username"],
+            task.results["mysql"]["password"],
             ["CREATE DATABASE IF NOT EXISTS test"],
             commit=True,
         )
@@ -110,8 +108,8 @@ async def test_charmed_dba_role(juju: Juju):
     logger.info("Checking that the database-level DBA role can see all databases")
     await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         ["SHOW DATABASES"],
         commit=True,
     )
@@ -119,8 +117,8 @@ async def test_charmed_dba_role(juju: Juju):
     logger.info("Checking that the database-level DBA role can create a new table")
     await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         [
             "CREATE TABLE preserved.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
         ],
@@ -130,8 +128,8 @@ async def test_charmed_dba_role(juju: Juju):
     logger.info("Checking that the database-level DBA role can write into an existing table")
     await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         [
             "INSERT INTO preserved.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
         ],
@@ -141,8 +139,8 @@ async def test_charmed_dba_role(juju: Juju):
     logger.info("Checking that the database-level DBA role can read from an existing table")
     rows = await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         [
             "SELECT `data` FROM preserved.test_table",
         ],

--- a/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/tests/integration/integration/roles/test_instance_dba_role.py
@@ -76,28 +76,24 @@ async def test_charmed_dba_role(juju: Juju):
 
     data_integrator_unit = get_app_units(juju, INTEGRATOR_APP_NAME)[0]
     task = juju.run(unit=data_integrator_unit, action="get-credentials")
-    task.raise_on_failure()
-    results = task.results
 
     logger.info("Checking that the instance-level DBA role can create new databases")
     await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         ["CREATE DATABASE IF NOT EXISTS test"],
         commit=True,
     )
 
     data_integrator_unit = get_app_units(juju, INTEGRATOR_APP_NAME)[0]
     task = juju.run(unit=data_integrator_unit, action="get-credentials")
-    task.raise_on_failure()
-    results = task.results
 
     logger.info("Checking that the instance-level DBA role can see all databases")
     rows = await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         ["SHOW DATABASES"],
         commit=True,
     )

--- a/tests/integration/integration/roles/test_instance_dba_role.py
+++ b/tests/integration/integration/roles/test_instance_dba_role.py
@@ -24,8 +24,6 @@ INTEGRATOR_APP_NAME = "data-integrator"
 
 TIMEOUT = 15 * MINUTE_SECS
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/integration/integration/roles/test_instance_roles.py
+++ b/tests/integration/integration/roles/test_instance_roles.py
@@ -99,14 +99,12 @@ async def test_charmed_read_role(juju: Juju):
 
     data_integrator_unit = get_app_units(juju, f"{INTEGRATOR_APP_NAME}1")[0]
     task = juju.run(unit=data_integrator_unit, action="get-credentials")
-    task.raise_on_failure()
-    results = task.results
 
     logger.info("Checking that the charmed_read role can read from an existing table")
     rows = await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         [
             "SELECT `data` FROM charmed_read_db.test_table",
         ],
@@ -120,8 +118,8 @@ async def test_charmed_read_role(juju: Juju):
     with pytest.raises(ProgrammingError):
         await execute_queries_on_unit(
             primary_unit_address,
-            results["mysql"]["username"],
-            results["mysql"]["password"],
+            task.results["mysql"]["username"],
+            task.results["mysql"]["password"],
             [
                 "INSERT INTO charmed_read_db.test_table (`data`) VALUES ('test_data_3')",
             ],
@@ -132,8 +130,8 @@ async def test_charmed_read_role(juju: Juju):
     with pytest.raises(ProgrammingError):
         await execute_queries_on_unit(
             primary_unit_address,
-            results["mysql"]["username"],
-            results["mysql"]["password"],
+            task.results["mysql"]["username"],
+            task.results["mysql"]["password"],
             [
                 "CREATE TABLE charmed_read_db.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
             ],
@@ -179,14 +177,12 @@ async def test_charmed_dml_role(juju: Juju):
 
     data_integrator_1_unit = get_app_units(juju, f"{INTEGRATOR_APP_NAME}1")[0]
     task = juju.run(unit=data_integrator_1_unit, action="get-credentials")
-    task.raise_on_failure()
-    results = task.results
 
     logger.info("Checking that when no role is specified the created user can do everything")
     rows = await execute_queries_on_unit(
         primary_unit_address,
-        results["mysql"]["username"],
-        results["mysql"]["password"],
+        task.results["mysql"]["username"],
+        task.results["mysql"]["password"],
         [
             "CREATE TABLE charmed_dml_db.test_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
             "INSERT INTO charmed_dml_db.test_table (`data`) VALUES ('test_data_1'), ('test_data_2')",
@@ -199,15 +195,13 @@ async def test_charmed_dml_role(juju: Juju):
     )
 
     data_integrator_2_unit = get_app_units(juju, f"{INTEGRATOR_APP_NAME}2")[0]
-    task = juju.run(unit=data_integrator_2_unit, action="get-credentials")
-    task.raise_on_failure()
-    results2 = task.results
+    task2 = juju.run(unit=data_integrator_2_unit, action="get-credentials")
 
     logger.info("Checking that the charmed_dml role can read from an existing table")
     rows = await execute_queries_on_unit(
         primary_unit_address,
-        results2["mysql"]["username"],
-        results2["mysql"]["password"],
+        task2.results["mysql"]["username"],
+        task2.results["mysql"]["password"],
         [
             "SELECT `data` FROM charmed_dml_db.test_table",
         ],
@@ -220,8 +214,8 @@ async def test_charmed_dml_role(juju: Juju):
     logger.info("Checking that the charmed_dml role can write into an existing table")
     await execute_queries_on_unit(
         primary_unit_address,
-        results2["mysql"]["username"],
-        results2["mysql"]["password"],
+        task2.results["mysql"]["username"],
+        task2.results["mysql"]["password"],
         [
             "INSERT INTO charmed_dml_db.test_table (`data`) VALUES ('test_data_3')",
         ],
@@ -232,8 +226,8 @@ async def test_charmed_dml_role(juju: Juju):
     with pytest.raises(ProgrammingError):
         await execute_queries_on_unit(
             primary_unit_address,
-            results2["mysql"]["username"],
-            results2["mysql"]["password"],
+            task2.results["mysql"]["username"],
+            task2.results["mysql"]["password"],
             [
                 "CREATE TABLE charmed_dml_db.new_table (`id` SERIAL PRIMARY KEY, `data` TEXT)",
             ],

--- a/tests/integration/integration/roles/test_instance_roles.py
+++ b/tests/integration/integration/roles/test_instance_roles.py
@@ -26,8 +26,6 @@ INTEGRATOR_APP_NAME = "data-integrator"
 
 TIMEOUT = 15 * MINUTE_SECS
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed

--- a/tests/integration/integration/test_backup_aws.py
+++ b/tests/integration/integration/test_backup_aws.py
@@ -47,8 +47,6 @@ MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR = (
     "Move restored cluster to another S3 repository"
 )
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 backup_id, value_before_backup, value_after_backup = "", None, None
 
 

--- a/tests/integration/integration/test_backup_ceph.py
+++ b/tests/integration/integration/test_backup_ceph.py
@@ -57,8 +57,6 @@ MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR = (
 )
 MICROCEPH_BUCKET = "testbucket"
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 backup_id, value_before_backup, value_after_backup = "", None, None
 
 

--- a/tests/integration/integration/test_backup_gcp.py
+++ b/tests/integration/integration/test_backup_gcp.py
@@ -47,8 +47,6 @@ MOVE_RESTORED_CLUSTER_TO_ANOTHER_S3_REPOSITORY_ERROR = (
     "Move restored cluster to another S3 repository"
 )
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 backup_id, value_before_backup, value_after_backup = "", None, None
 
 

--- a/tests/integration/integration/test_backup_pitr_aws.py
+++ b/tests/integration/integration/test_backup_pitr_aws.py
@@ -1,14 +1,10 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import logging
-
 import pytest
 from jubilant_backports import Juju
 
 from .helpers_backups import build_and_deploy_operations, pitr_operations
-
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/integration/test_backup_pitr_gcp.py
+++ b/tests/integration/integration/test_backup_pitr_gcp.py
@@ -1,14 +1,10 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import logging
-
 import pytest
 from jubilant_backports import Juju
 
 from .helpers_backups import build_and_deploy_operations, pitr_operations
-
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -113,8 +113,7 @@ async def run_upgrade_check(juju: Juju) -> None:
     mysql_leader = get_app_leader(juju, MYSQL_APP_NAME)
 
     logging.info("Run pre-upgrade-check action")
-    task = juju.run(unit=mysql_leader, action="pre-upgrade-check")
-    task.raise_on_failure()
+    juju.run(unit=mysql_leader, action="pre-upgrade-check")
 
     logging.info("Assert primary is set to leader")
     mysql_primary = get_mysql_primary_unit(juju, MYSQL_APP_NAME)

--- a/tests/integration/release/high_availability/test_upgrade_from_stable.py
+++ b/tests/integration/release/high_availability/test_upgrade_from_stable.py
@@ -23,8 +23,6 @@ MYSQL_TEST_APP_NAME = "mysql-test-app"
 
 MINUTE_SECS = 60
 
-logging.getLogger("jubilant.wait").setLevel(logging.WARNING)
-
 
 @contextmanager
 def continuous_writes(juju: Juju) -> Generator:


### PR DESCRIPTION
This PR cleans up the integration tests, by:

- Removing unnecessary `raise_on_failure()` calls (performed internally within the Jubilant methods).
- Moving all the Jubilant logging to the global `conftest.py` module.
- Removing legacy fixture within high-availability `conftest.py` module.

---

Follow up to https://github.com/canonical/mysql-operator/pull/734.